### PR TITLE
Include stdlib

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@
 # }
 class nginx {
 
-  class { 'stdlib': }
+  include stdlib
 
   class { 'nginx::package':
     notify => Class['nginx::service'],


### PR DESCRIPTION
I'm a newcomer to puppet so excuse me if this isn't the correct way to use stdlib, but I was getting a conflict with another module which uses stdlib:

`Error 400 on SERVER: Duplicate declaration: Class[Stdlib] is already declared; cannot redeclare`

This fixed it for me.
