### PR TITLE
Comparison operations in nginx.conf.erb template look misplaced.

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -6,7 +6,7 @@ pid        <%= scope.lookupvar('nginx::params::nx_pid')%>;
 
 events {
   worker_connections <%= scope.lookupvar('nginx::params::nx_worker_connections') %>;
-  <% if scope.lookupvar('nginx::params::nx_multi_accept' == 'on') %>multi_accept on;<% end %>
+  <% if scope.lookupvar('nginx::params::nx_multi_accept') == 'on' %>multi_accept on;<% end %>
 }
 
 http {
@@ -17,14 +17,14 @@ http {
 
   sendfile    <%= scope.lookupvar('nginx::params::nx_sendfile')%>;
 
-  <% if scope.lookupvar('nginx::params::nx_tcp_nopush' == 'on') %>
+  <% if scope.lookupvar('nginx::params::nx_tcp_nopush') == 'on' %>
   tcp_nopush  on;
   <% end %>
 
   keepalive_timeout  <%= scope.lookupvar('nginx::params::nx_keepalive_timeout')%>;
   tcp_nodelay        <%= scope.lookupvar('nginx::params::nx_tcp_nodelay')%>;
 
-  <% if scope.lookupvar('nginx::params::nx_gzip' == 'on') %> 
+  <% if scope.lookupvar('nginx::params::nx_gzip') == 'on' %> 
   gzip         on;
   gzip_disable "MSIE [1-6]\.(?!.*SV1)";
   <% end %>


### PR DESCRIPTION
It looked to me that a number of comparison operations that were being performed in the nginx.conf.erb template were misplaced?  Comparisons were being performed against that parameter of the call to scope.lookupvar instead of against the result of the call.
