### PR TITLE
Fixed error from cat when trying nginx.d/* on nodes without vhosts defined

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,6 +17,7 @@ class nginx::service {
   exec { 'rebuild-nginx-vhosts':
     command     => "/bin/cat ${nginx::params::nx_temp_dir}/nginx.d/* > ${nginx::params::nx_conf_dir}/conf.d/vhost_autogen.conf",
     refreshonly => true,
+    unless	=> "/usr/bin/test ! -f ${nginx::params::nx_temp_dir}/nginx.d/*",
     subscribe   => File["${nginx::params::nx_temp_dir}/nginx.d"],
   }
   service { "nginx":


### PR DESCRIPTION
Affects jfryman/puppet-nginx#20

When running first time from scratch, if class was included without any setup at all
and with sane defaults, in debian squeeze generates an error when trying to collect
non existant vhosts, because cat complains that can not expand \* because there are no
files.

Changed:
Added unless to check that at least there is a file in nginx.d by testing it can expand.
