### PR TITLE
Add scientific linux support

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -18,7 +18,7 @@ class nginx::package {
   anchor { 'nginx::package::end': }
 
   case $::operatingsystem {
-    centos,fedora,rhel,redhat: {
+    centos,fedora,rhel,redhat,scientific: {
       class { 'nginx::package::redhat':
         require => Anchor['nginx::package::begin'],
         before  => Anchor['nginx::package::end'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,8 +51,8 @@ class nginx::params {
   }
 
   $nx_daemon_user = $::operatingsystem ? {
-    /(?i-mx:debian|ubuntu)/                           => 'www-data',
-    /(?i-mx:fedora|rhel|redhat|centos|suse|opensuse)/ => 'nginx',
+    /(?i-mx:debian|ubuntu)/                                      => 'www-data',
+    /(?i-mx:fedora|rhel|redhat|centos|scientific|suse|opensuse)/ => 'nginx',
   }
 
   # Service restart after Nginx 0.7.53 could also be just "/path/to/nginx/bin -s HUP"


### PR DESCRIPTION
This commit simply adds scientific to the `$::operatingsystem`
selectors. It is an `$::osfamily` of RedHat.
