### PR TITLE
Add support for upstream_cfg_prepend

### DIFF
--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -3,8 +3,9 @@
 # This definition creates a new upstream proxy entry for NGINX
 #
 # Parameters:
-#   [*ensure*]      - Enables or disables the specified location (present|absent)
-#   [*members*]     - Array of member URIs for NGINX to connect to. Must follow valid NGINX syntax.
+#   [*members*]               - Array of member URIs for NGINX to connect to. Must follow valid NGINX syntax.
+#   [*ensure*]                - Enables or disables the specified location (present|absent)
+#   [*upstream_cfg_prepend*] - It expects a hash with custom directives to put before anything else inside upstream
 #
 # Actions:
 #
@@ -19,7 +20,27 @@
 #      'localhost:3002',
 #    ],
 #  }
-define nginx::resource::upstream ($ensure = 'present', $members) {
+#
+#  Custom config example to use ip_hash, and 20 keepalive connections
+#  create a hash with any extra custom config you want.
+#  $my_config = {
+#    'ip_hash'   => '',
+#    'keepalive' => '20',
+#  }
+#  nginx::resource::upstream { 'proxypass':
+#    ensure              => present,
+#    members => [
+#      'localhost:3000',
+#      'localhost:3001',
+#      'localhost:3002',
+#    ],
+#    upstream_cfg_prepend => $my_config,
+#  }
+define nginx::resource::upstream (
+  $members,
+  $ensure = 'present',
+  $upstream_cfg_prepend = undef,
+) {
   File {
     owner => 'root',
     group => 'root',

--- a/templates/conf.d/upstream.erb
+++ b/templates/conf.d/upstream.erb
@@ -1,4 +1,7 @@
 upstream <%= name %> {
+<% if @upstream_cfg_prepend -%><% upstream_cfg_prepend.each do |key,value| -%>
+  <%= key %> <%= value %>;
+<% end -%><% end -%>
   <% members.each do |i| %>
   server <%= i %>;
   <% end %>


### PR DESCRIPTION
Makes things possible like specifying ip_hash and/or keepalive.
