### PR TITLE
Pull request #53 contains broken vhost.pp

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -67,6 +67,7 @@ define nginx::resource::vhost (
   $rewrite_to_https 	  = undef,
   $location_cfg_prepend   = undef,
   $location_cfg_append    = undef,
+  $include_files		  = undef,
   $try_files              = undef) {
   File {
     ensure => $ensure ? {
@@ -78,7 +79,6 @@ define nginx::resource::vhost (
     group  => 'root',
     mode   => '0644',
   }
-  $include_files		  = undef,
 
   # Add IPv6 Logic Check - Nginx service will not start if ipv6 is enabled
   # and support does not exist for it in the kernel.


### PR DESCRIPTION
It looks like there's a bug in the code brought in via pull #53.

Specifically, in 921d7f7 -- the $include_files definition should be a couple lines up, inside the parameter list.

I've already created a commit that remedies this defect: LeeXGreen@d4c5db2
