### PR TITLE
Add server_names_hash_bucket_size param

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class nginx::params {
   $nx_worker_connections      = 1024
   $nx_types_hash_max_size     = 1024
   $nx_types_hash_bucket_size  = 512
+  $nx_names_hash_bucket_size  = 64
   $nx_multi_accept            = off
   $nx_events_use         = false # One of [kqueue|rtsig|epoll|/dev/poll|select|poll|eventport] or false to use OS default
   $nx_sendfile                = on

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -24,6 +24,8 @@ http {
   types_hash_max_size <%= scope.lookupvar('nginx::params::nx_types_hash_max_size')%>;
   types_hash_bucket_size <%= scope.lookupvar('nginx::params::nx_types_hash_bucket_size')%>;
 
+  server_names_hash_bucket_size <%= scope.lookupvar('nginx::params::nx_names_hash_bucket_size')%>;
+
   keepalive_timeout  <%= scope.lookupvar('nginx::params::nx_keepalive_timeout')%>;
   tcp_nodelay        <%= scope.lookupvar('nginx::params::nx_tcp_nodelay')%>;
 


### PR DESCRIPTION
I got bit by not having this param set, so thought it should be
configurable (while providing a sane default).
