### PR TITLE
Add support for fully custom location configurations.

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -18,7 +18,7 @@
 #   [*ssl_only*]             - Required if the SSL and normal vHost have the same port.
 #   [*location_alias*]       - Path to be used as basis for serving requests for this location
 #   [*stub_status*]          - If true it will point configure module stub_status to provide nginx stats on location
-#   [*custom_cfg*]           - Expects a hash with custom directives, cannot be used with other location types (proxy, fastcgi, root, or stub_status)
+#   [*location_custom_cfg*]  - Expects a hash with custom directives, cannot be used with other location types (proxy, fastcgi, root, or stub_status)
 #   [*location_cfg_prepend*] - Expects a hash with extra directives to put before anything else inside location (used with all other types except custom_cfg)
 #   [*location_cfg_append*]  - Expects a hash with extra directives to put after everything else inside location (used with all other types except custom_cfg)
 #   [*try_files*]            - An array of file locations to try
@@ -78,7 +78,7 @@ define nginx::resource::location (
   $location_alias       = undef,
   $option               = undef,
   $stub_status          = undef,
-  $custom_cfg           = undef,
+  $location_custom_cfg  = undef,
   $location_cfg_prepend = undef,
   $location_cfg_append  = undef,
   $try_files            = undef,
@@ -100,14 +100,12 @@ define nginx::resource::location (
     default  => file,
   }
 
-  notice "custom_cfg ${custom_cfg}"
-
   ## Check for various error conditions
   if ($vhost == undef) {
     fail('Cannot create a location reference without attaching to a virtual host')
   }
-  if (($www_root == undef) and ($proxy == undef) and ($location_alias == undef) and ($stub_status == undef) and ($fastcgi == undef) and ($custom_cfg == undef)) {
-    fail('Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, stub_status, or custom_cfg defined')
+  if (($www_root == undef) and ($proxy == undef) and ($location_alias == undef) and ($stub_status == undef) and ($fastcgi == undef) and ($location_custom_cfg == undef)) {
+    fail('Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, stub_status, or location_custom_cfg defined')
   }
   if (($www_root != undef) and ($proxy != undef)) {
     fail('Cannot define both directory and proxy in a virtual host')

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -91,6 +91,7 @@ define nginx::resource::vhost (
   $www_root               = undef,
   $rewrite_www_to_non_www = false,
   $rewrite_to_https       = undef,
+  $location_custom_cfg    = undef,
   $location_cfg_prepend   = undef,
   $location_cfg_append    = undef,
   $try_files              = undef,
@@ -157,6 +158,7 @@ define nginx::resource::vhost (
     fastcgi_script       => $fastcgi_script,
     try_files            => $try_files,
     www_root             => $www_root,
+    location_custom_cfg  => $location_custom_cfg,
     notify               => Class['nginx::service'],
   }
 

--- a/templates/vhost/vhost_location_empty.erb
+++ b/templates/vhost/vhost_location_empty.erb
@@ -1,5 +1,5 @@
   location <%= location %> {
-<% custom_cfg.each do |key,value| -%>
+<% location_custom_cfg.each do |key,value| -%>
     <%= key %> <%= value %>;
 <% end -%>
   }


### PR DESCRIPTION
This adds a new location type that simply accepts a location_custom_cfg hash to supply directives.

I also moved the variable checks in location.pp above the template calls, this fixes user template errors that would have been caught by the config checks.

This fixes #82
