### PR TITLE
Sort location_custom_cfg hash to prevent random ordering

### DIFF
--- a/templates/vhost/vhost_location_empty.erb
+++ b/templates/vhost/vhost_location_empty.erb
@@ -1,5 +1,5 @@
   location <%= location %> {
-<% location_custom_cfg.each do |key,value| -%>
+<% location_custom_cfg.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %> <%= value %>;
 <% end -%>
   }


### PR DESCRIPTION
This is a fix for a bug in my previous pull request... sorry about that!

The location_custom_cfg hash was not being sorted and so the nginx config was being refreshed each time to due the random ordering of the hash's entries.
