### PR TITLE
Add index_files to location for vhost

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -158,6 +158,7 @@ define nginx::resource::vhost (
     fastcgi_script       => $fastcgi_script,
     try_files            => $try_files,
     www_root             => $www_root,
+    index_files          => $index_files,
     location_custom_cfg  => $location_custom_cfg,
     notify               => Class['nginx::service'],
   }


### PR DESCRIPTION
This patch passes the index_files parameter
down from the vhost resource to its
associated location, where previsouly
it was ignored.
