### PR TITLE
Fix deprecated variable names

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -14,7 +14,7 @@
 #
 # This class file is not called directly
 class nginx::package::debian {
-  $operatingsystem_lowercase = inline_template('<%= operatingsystem.downcase %>')
+  $operatingsystem_lowercase = inline_template('<%= @operatingsystem.downcase %>')
 
   package { 'nginx':
     ensure  => present,

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -1,11 +1,11 @@
 user <%= scope.lookupvar('nginx::config::nx_daemon_user') %>;
-worker_processes <%= worker_processes %>;
+worker_processes <%= @worker_processes %>;
 
 error_log  <%= scope.lookupvar('nginx::params::nx_logdir')%>/error.log;
 pid        <%= scope.lookupvar('nginx::params::nx_pid')%>;
 
 events {
-  worker_connections <%= worker_connections -%>;
+  worker_connections <%= @worker_connections -%>;
 <% if scope.lookupvar('nginx::params::nx_multi_accept') == 'on' %>multi_accept on;<% end -%>
 <% if scope.lookupvar('nginx::params::nx_events_use') %>use <%= scope.lookupvar('nginx::params::nx_events_use')%>;<% end -%>
 }
@@ -18,7 +18,7 @@ http {
 
   sendfile    <%= scope.lookupvar('nginx::params::nx_sendfile')%>;
 
-  server_tokens <%= server_tokens %>;
+  server_tokens <%= @server_tokens %>;
   <% if scope.lookupvar('nginx::params::nx_tcp_nopush') == 'on' %>tcp_nopush on;<% end %>
 
   types_hash_max_size <%= scope.lookupvar('nginx::params::nx_types_hash_max_size')%>;
@@ -29,13 +29,13 @@ http {
   keepalive_timeout  <%= scope.lookupvar('nginx::params::nx_keepalive_timeout')%>;
   tcp_nodelay        <%= scope.lookupvar('nginx::params::nx_tcp_nodelay')%>;
 
-  <% if scope.lookupvar('nginx::params::nx_gzip') == 'on' %> 
+  <% if scope.lookupvar('nginx::params::nx_gzip') == 'on' %>
   gzip         on;
   gzip_disable "MSIE [1-6]\.(?!.*SV1)";
   <% end -%>
 
-<% if proxy_cache_path -%>
-  proxy_cache_path    <%= proxy_cache_path %> levels=<%= proxy_cache_levels %> keys_zone=<%= proxy_cache_keys_zone %> max_size=<%= proxy_cache_max_size %> inactive=<%= proxy_cache_inactive %>;
+<% if @proxy_cache_path -%>
+  proxy_cache_path    <%= @proxy_cache_path %> levels=<%= @proxy_cache_levels %> keys_zone=<%= @proxy_cache_keys_zone %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive %>;
 <% end -%>
 
   include /etc/nginx/conf.d/*.conf;

--- a/templates/conf.d/proxy.conf.erb
+++ b/templates/conf.d/proxy.conf.erb
@@ -6,5 +6,5 @@ proxy_send_timeout      <%= scope.lookupvar('nginx::params::nx_proxy_send_timeou
 proxy_read_timeout      <%= scope.lookupvar('nginx::params::nx_proxy_read_timeout') %>;
 proxy_buffers           <%= scope.lookupvar('nginx::params::nx_proxy_buffers') %>;
 proxy_http_version      <%= @proxy_http_version %>;
-<% proxy_set_header.each do |header| %>
+<% @proxy_set_header.each do |header| %>
 proxy_set_header        <%= header %>;<% end %>

--- a/templates/conf.d/upstream.erb
+++ b/templates/conf.d/upstream.erb
@@ -1,6 +1,6 @@
-upstream <%= name %> {
+upstream <%= @name %> {
 <% if @upstream_cfg_prepend -%><% upstream_cfg_prepend.sort_by{|k,v| k}.each do |key,value| -%>
   <%= key %> <%= value %>;<% end -%><% end -%>
-  <% members.each do |i| %>
+  <% @members.each do |i| %>
   server     <%= i %>;<% end %>
 }

--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -6,10 +6,10 @@ include <%= file %>;
 <% end -%>
 <% end -%>
 }
-<% if rewrite_www_to_non_www -%>
+<% if @rewrite_www_to_non_www -%>
 server {
-  listen                <%= listen_ip %>;
-  server_name           www.<%= name.gsub(/^www\./, '') %>;
-  rewrite               ^ http://<%= name.gsub(/^www\./, '') %>$uri permanent;
+  listen                <%= @listen_ip %>;
+  server_name           www.<%= @name.gsub(/^www\./, '') %>;
+  rewrite               ^ http://<%= @name.gsub(/^www\./, '') %>$uri permanent;
 }
 <% end %>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -1,19 +1,19 @@
 server {
-  listen                <%= listen_ip %>:<%= listen_port %><% if @listen_options %> <%= listen_options %><% end %>;
+  listen                <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
 <% # check to see if ipv6 support exists in the kernel before applying %>
-<% if ipv6_enable == 'true' && (defined? ipaddress6) %>
-  listen [<%= ipv6_listen_ip %>]:<%= ipv6_listen_port %> <% if @ipv6_listen_options %><%= ipv6_listen_options %><% end %> ipv6only=on;
+<% if @ipv6_enable == 'true' && (defined? ipaddress6) %>
+  listen [<%= ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %> ipv6only=on;
 <% end %>
-  server_name           <%= rewrite_www_to_non_www ? name.gsub(/^www\./, '') : server_name.join(" ") %>;
-  access_log            <%= scope.lookupvar('nginx::params::nx_logdir')%>/<%= name %>.access.log;
+  server_name           <%= @rewrite_www_to_non_www ? @name.gsub(/^www\./, '') : @server_name.join(" ") %>;
+  access_log            <%= scope.lookupvar('nginx::params::nx_logdir')%>/<%= @name %>.access.log;
 <% if defined? auth_basic -%>
-  auth_basic           "<%= auth_basic %>";
+  auth_basic           "<%= @auth_basic %>";
 <% end -%>
 <% if defined? auth_basic_user_file -%>
-  auth_basic_user_file <%= auth_basic_user_file %>;
+  auth_basic_user_file <%= @auth_basic_user_file %>;
 <% end -%>
 
-<% proxy_set_header.each do |header| -%>
+<% @proxy_set_header.each do |header| -%>
   proxy_set_header        <%= header %>;
 <% end -%>
 <% if @rewrite_to_https -%>

--- a/templates/vhost/vhost_location_alias.erb
+++ b/templates/vhost/vhost_location_alias.erb
@@ -1,7 +1,7 @@
-  location <%= location %> {
-<% if @location_cfg_prepend -%><% location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
+  location <%= @location %> {
+<% if @location_cfg_prepend -%><% @location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %> <%= value %>;<% end -%><% end -%>
-    alias      <%= location_alias %>;
-<% if @location_cfg_append -%><% location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
+    alias      <%= @location_alias %>;
+<% if @location_cfg_append -%><% @location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %> <%= value %>;<% end -%><% end -%>
   }

--- a/templates/vhost/vhost_location_directory.erb
+++ b/templates/vhost/vhost_location_directory.erb
@@ -1,22 +1,21 @@
-  location <%= location %> {
-<% if @location_cfg_prepend -%><% location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
+  location <%= @location %> {
+<% if @location_cfg_prepend -%><% @location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %> <%= value %>;
 <% end -%><% end -%>
-    root  <%= www_root %>;
+    root  <%= @www_root %>;
 <% if @try_files -%>
-    try_files <% try_files.each do |try| -%> <%= try %> <% end -%>;
+    try_files <% @try_files.each do |try| -%> <%= try %> <% end -%>;
 <% end -%>
-<% if index_files -%>
-    index <% index_files.each do |i| %> <%= i %><% end %>; 
+<% if @index_files -%>
+    index <% @index_files.each do |i| %> <%= i %><% end %>;
 <% end -%>
 <% if defined? auth_basic -%>
-    auth_basic           "<%= auth_basic %>";
+    auth_basic           "<%= @auth_basic %>";
 <% end -%>
 <% if defined? auth_basic_user_file -%>
-    auth_basic_user_file <%= auth_basic_user_file %>;
+    auth_basic_user_file <%= @auth_basic_user_file %>;
 <% end -%>
-<% if @location_cfg_append -%><% location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
+<% if @location_cfg_append -%><% @location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %> <%= value %>;
 <% end -%><% end -%>
   }
-

--- a/templates/vhost/vhost_location_empty.erb
+++ b/templates/vhost/vhost_location_empty.erb
@@ -1,5 +1,5 @@
-  location <%= location %> {
-<% location_custom_cfg.sort_by {|k,v| k}.each do |key,value| -%>
+  location <%= @location %> {
+<% @location_custom_cfg.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %> <%= value %>;
 <% end -%>
   }

--- a/templates/vhost/vhost_location_fastcgi.erb
+++ b/templates/vhost/vhost_location_fastcgi.erb
@@ -1,9 +1,8 @@
-  location <%= location %> {
-    root  <%= www_root %>;
-    include <%= fastcgi_params %>;
-    fastcgi_pass <%= fastcgi %>;
-<% unless fastcgi_script == :undef %>
-    fastcgi_param SCRIPT_FILENAME <%= fastcgi_script %>;
+  location <%= @location %> {
+    root  <%= @www_root %>;
+    include <%= @fastcgi_params %>;
+    fastcgi_pass <%= @fastcgi %>;
+<% unless @fastcgi_script == :undef %>
+    fastcgi_param SCRIPT_FILENAME <%= @fastcgi_script %>;
 <% end -%>
   }
-

--- a/templates/vhost/vhost_location_proxy.erb
+++ b/templates/vhost/vhost_location_proxy.erb
@@ -1,14 +1,14 @@
-  location <%= location %> {
-<% if @location_cfg_prepend -%><% location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
+  location <%= @location %> {
+<% if @location_cfg_prepend -%><% @location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %>         <%= value %>;
 <% end -%><% end -%>
-<% if proxy_cache -%>
-    proxy_cache         <%= proxy_cache %>;
-    proxy_cache_valid   <%= proxy_cache_valid %>;
+<% if @proxy_cache -%>
+    proxy_cache         <%= @proxy_cache %>;
+    proxy_cache_valid   <%= @proxy_cache_valid %>;
 <% end -%>
-    proxy_pass          <%= proxy %>;
-    proxy_read_timeout  <%= proxy_read_timeout %>;
-<% if @location_cfg_append -%><% location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
+    proxy_pass          <%= @proxy %>;
+    proxy_read_timeout  <%= @proxy_read_timeout %>;
+<% if @location_cfg_append -%><% @location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %> <%= value %>;
 <% end -%><% end -%>
   }

--- a/templates/vhost/vhost_location_stub_status.erb
+++ b/templates/vhost/vhost_location_stub_status.erb
@@ -1,7 +1,7 @@
-  location <%= location %> {
-<% if @location_cfg_prepend -%><% location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
+  location <%= @location %> {
+<% if @location_cfg_prepend -%><% @location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %>  <%= value %>;<% end -%><% end -%>
     stub_status on;
-<% if @location_cfg_append -%><% location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
+<% if @location_cfg_append -%><% @location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %>  <%= value %>;<% end -%><% end -%>
   }

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -1,26 +1,25 @@
 server {
-  listen       <%= listen_ip %>:<%= ssl_port %> ssl<% if spdy == 'on' %> spdy<% end %><% if @listen_options %><%= listen_options %><% end %>;
-  <% if ipv6_enable == 'true' && (defined? ipaddress6) %>
-  listen [<%= ipv6_listen_ip %>]:<%= ipv6_listen_port %> <% if @ipv6_listen_options %><%= ipv6_listen_options %><% end %> ipv6only=on;
+  listen       <%= @listen_ip %>:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @listen_options %><%= @listen_options %><% end %>;
+  <% if @ipv6_enable == 'true' && (defined? ipaddress6) %>
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %> ipv6only=on;
   <% end %>
-  server_name  <%= rewrite_www_to_non_www ? name.gsub(/^www\./, '') : server_name.join(" ") %>;
+  server_name  <%= @rewrite_www_to_non_www ? @name.gsub(/^www\./, '') : @server_name.join(" ") %>;
 
   ssl on;
 
-  ssl_certificate           <%= scope.lookupvar('nginx::params::nx_conf_dir') %>/<%= name.gsub(' ', '_') %>.crt;
-  ssl_certificate_key       <%= scope.lookupvar('nginx::params::nx_conf_dir') %>/<%= name.gsub(' ', '_') %>.key;
+  ssl_certificate           <%= scope.lookupvar('nginx::params::nx_conf_dir') %>/<%= @name.gsub(' ', '_') %>.crt;
+  ssl_certificate_key       <%= scope.lookupvar('nginx::params::nx_conf_dir') %>/<%= @name.gsub(' ', '_') %>.key;
   ssl_session_cache         shared:SSL:10m;
   ssl_session_timeout       5m;
-  ssl_protocols             <%= ssl_protocols %>;
-  ssl_ciphers               <%= ssl_ciphers %>;
+  ssl_protocols             <%= @ssl_protocols %>;
+  ssl_ciphers               <%= @ssl_ciphers %>;
   ssl_prefer_server_ciphers on;
-<% if auth_basic != :undef -%>
-  auth_basic                "<%= auth_basic %>";
+<% if @auth_basic != :undef -%>
+  auth_basic                "<%= @auth_basic %>";
 <% end -%>
-<% if auth_basic_user_file != :undef -%>
-  auth_basic_user_file      <%= auth_basic_user_file %>;
+<% if @auth_basic_user_file != :undef -%>
+  auth_basic_user_file      <%= @auth_basic_user_file %>;
 <% end -%>
 
-  access_log            <%= scope.lookupvar('nginx::params::nx_logdir')%>/ssl-<%= name.gsub(' ', '_') %>.access.log;
-  error_log             <%= scope.lookupvar('nginx::params::nx_logdir')%>/ssl-<%= name.gsub(' ', '_') %>.error.log;
-
+  access_log            <%= scope.lookupvar('nginx::params::nx_logdir')%>/ssl-<%= @name.gsub(' ', '_') %>.access.log;
+  error_log             <%= scope.lookupvar('nginx::params::nx_logdir')%>/ssl-<%= @name.gsub(' ', '_') %>.error.log;


### PR DESCRIPTION
I had some annoying warnings with puppet 3.0+.
So I changed the variable names accordingly.
