### PR TITLE
Fix undefined method `sort_by' error from vhost_location_empty.erb

### DIFF
--- a/templates/vhost/vhost_location_empty.erb
+++ b/templates/vhost/vhost_location_empty.erb
@@ -1,5 +1,5 @@
   location <%= @location %> {
-<% @location_custom_cfg.sort_by {|k,v| k}.each do |key,value| -%>
+<% if @location_custom_cfg -%><% @location_custom_cfg.sort_by {|k,v| k}.each do |key,value| -%>
     <%= key %> <%= value %>;
-<% end -%>
+<% end -%><% end -%>
   }


### PR DESCRIPTION
I got the following error:

```
Filepath: /etc/puppet/modules/common/nginx/templates/vhost/vhost_location_empty.erb
Line: 2
Detail: undefined method `sort_by' for nil:NilClass
at /etc/puppet/modules/common/nginx/manifests/resource/location.pp:133 on node xxxxxx
```

In the template, we should check if the variable is defined before use it.
