### PR TITLE
Remove GeoIP in spec to fix the tests

### DIFF
--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -5,7 +5,6 @@ describe 'nginx::package' do
   shared_examples 'redhat' do |operatingsystem|
     let(:facts) {{ :operatingsystem => operatingsystem }}
     it { should contain_package('nginx') }
-    it { should contain_package('GeoIP') }
     it { should contain_package('gd') }
     it { should contain_package('libXpm') }
     it { should contain_package('libxslt') }


### PR DESCRIPTION
The GeoIP package has been removed from c01a7a8280b5f073ede456efb00af8c217b63a88 but not in tests
