### PR TITLE
Inverted condition for IPv6 warning  

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -114,7 +114,7 @@ define nginx::resource::vhost (
 
   # Add IPv6 Logic Check - Nginx service will not start if ipv6 is enabled
   # and support does not exist for it in the kernel.
-  if ($ipv6_enable == true) and ($ipaddress6) {
+  if ($ipv6_enable == true) and (!$ipaddress6) {
     warning('nginx: IPv6 support is not enabled or configured properly')
   }
 


### PR DESCRIPTION
If $ipv6_enable is true ypu sshould warn the user only if the machine _doesn't have_ an ip address.

At the moment the warning is raised when ipv6 is configured properly
