### PR TITLE
un-quoted auth_basic_user_file, nginx fails to restart

### DIFF
--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -18,7 +18,7 @@ server {
   auth_basic                "<%= @auth_basic %>";
 <% end -%>
 <% if @auth_basic_user_file != :undef -%>
-  auth_basic_user_file      <%= @auth_basic_user_file %>;
+  auth_basic_user_file      "<%= @auth_basic_user_file %>";
 <% end -%>
 
   access_log            <%= scope.lookupvar('nginx::params::nx_logdir')%>/ssl-<%= @name.gsub(' ', '_') %>.access.log;


### PR DESCRIPTION
when there is no value for auth_basic_user_file, nginx fails to restart with invalid number of arguments 

added quotes around auth_basic_user_file to fix this
