### PR TITLE
auth_basic lines appearing in SSL vhost header when they shouldn't

### DIFF
--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -14,10 +14,10 @@ server {
   ssl_protocols             <%= @ssl_protocols %>;
   ssl_ciphers               <%= @ssl_ciphers %>;
   ssl_prefer_server_ciphers on;
-<% if @auth_basic != :undef -%>
+<% if defined? @auth_basic -%>
   auth_basic                "<%= @auth_basic %>";
 <% end -%>
-<% if @auth_basic_user_file != :undef -%>
+<% if defined? @auth_basic_user_file -%>
   auth_basic_user_file      <%= @auth_basic_user_file %>;
 <% end -%>
 


### PR DESCRIPTION
I had nginx crashing on startup because there were some malformed lines about `auth_basic` in the configuration for a vhost using SSL, even though I hadn't specified anything to do with basic auth in Puppet.

Turns out that [`vhost_header.erb`](https://github.com/jfryman/puppet-nginx/blob/master/templates/vhost/vhost_header.erb#L9-L14) and `vhost_ssl_header.erb` use a different syntax to test if `@auth_basic` is set, so I changed the latter to match the former, and it worked.

Possibly related to #100.
