### PR TITLE
check for undefined variables with `nil?` instead of `== :undef` in temp...

### DIFF
--- a/templates/vhost/vhost_location_fastcgi.erb
+++ b/templates/vhost/vhost_location_fastcgi.erb
@@ -2,7 +2,7 @@
     root  <%= @www_root %>;
     include <%= @fastcgi_params %>;
     fastcgi_pass <%= @fastcgi %>;
-<% unless @fastcgi_script == :undef %>
+<% unless @fastcgi_script.nil? %>
     fastcgi_param SCRIPT_FILENAME <%= @fastcgi_script %>;
 <% end -%>
   }

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -14,10 +14,10 @@ server {
   ssl_protocols             <%= @ssl_protocols %>;
   ssl_ciphers               <%= @ssl_ciphers %>;
   ssl_prefer_server_ciphers on;
-<% if @auth_basic != :undef -%>
+<% unless @auth_basic.nil? -%>
   auth_basic                "<%= @auth_basic %>";
 <% end -%>
-<% if @auth_basic_user_file != :undef -%>
+<% unless @auth_basic_user_file.nil? -%>
   auth_basic_user_file      <%= @auth_basic_user_file %>;
 <% end -%>
 


### PR DESCRIPTION
...lates

It appears that at some point puppet started using `nil` inplace of `:undef` in
undefined variables.
