### PR TITLE
Fix the error 'You cannot specify more than one of content, source, target'

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -213,12 +213,10 @@ define nginx::resource::vhost (
     # Check if the file has been defined before creating the file to
     # avoid the error when using wildcard cert on the multiple vhosts
     ensure_resource('file', "${nginx::params::nx_conf_dir}/${cert}.crt", {
-      ensure => $ensure,
       mode   => '0644',
       source => $ssl_cert,
     })
     ensure_resource('file', "${nginx::params::nx_conf_dir}/${cert}.key", {
-      ensure => $ensure,
       mode   => '0644',
       source => $ssl_key,
     })


### PR DESCRIPTION
I get the above error message. It is easily fixed by removing the `ensure` inside `ensure_resource`, since `ensure_resource` should already be setting `$ensure` to `file`.
