### PR TITLE
Fix syntax "each" for ruby1.9 => each_line

### DIFF
--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -1,4 +1,4 @@
-<% if @include_files %><% @include_files.each do |file| -%>
+<% if @include_files %><% @include_files.each_line do |file| -%>
 include <%= file %>;
 <% end -%><% end -%>
 <% if @vhost_cfg_append -%><% vhost_cfg_append.each do |key,value| -%>


### PR DESCRIPTION
String#each`is no longer available in Ruby 1.9, use`String#each_line` instead.

Debug:
Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template nginx/vhost/vhost_footer.erb:
  Filepath: /etc/puppet/modules/nginx/templates/vhost/vhost_footer.erb
  Line: 1
  Detail: undefined method `each' for "global/security.conf":String
