### PR TITLE
Fix SSL cert and key permissions

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -219,7 +219,7 @@ define nginx::resource::vhost (
     })
     ensure_resource('file', "${nginx::params::nx_conf_dir}/${cert}.key", {
       owner  => $nginx::params::nx_daemon_user,
-      mode   => '0400',
+      mode   => '0440',
       source => $ssl_key,
     })
   }


### PR DESCRIPTION
It is bad practice to use 644 on a private key so we
have migrated the key mode to 0400. The cert is already
avaliable publicly through nginx so we have allowed it
0444.

Nothing should need to write either the cert of the key
after puppet has run, so we have denied any writing.
