### PR TITLE
* Bug fix, remove each_line method

### DIFF
--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -1,7 +1,7 @@
-<% if @include_files %><% @include_files.each_line do |file| -%>
+<% if @include_files %><% @include_files.each do |file| -%>
 include <%= file %>;
 <% end -%><% end -%>
-<% if @vhost_cfg_append -%><% vhost_cfg_append.each_line do |key,value| -%>
+<% if @vhost_cfg_append -%><% vhost_cfg_append.each do |key,value| -%>
   <%= key %> <%= value %>;
 <% end -%>
 <% end -%>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -11,7 +11,7 @@ server {
 <% if defined? auth_basic_user_file -%>
   auth_basic_user_file <%= @auth_basic_user_file %>;
 <% end -%>
-<% @proxy_set_header.each_line do |header| -%>
+<% @proxy_set_header.each do |header| -%>
   proxy_set_header        <%= header %>;
 <% end -%>
 <% if @rewrite_to_https -%>

--- a/templates/vhost/vhost_location_directory.erb
+++ b/templates/vhost/vhost_location_directory.erb
@@ -6,10 +6,10 @@
     root  <%= @www_root %>;
 <% end -%>
 <% if @try_files -%>
-    try_files <% @try_files.each_line do |try| -%> <%= try %> <% end -%>;
+    try_files <% @try_files.each do |try| -%> <%= try %> <% end -%>;
 <% end -%>
 <% if @index_files -%>
-    index <% @index_files.each_line do |i| %> <%= i %><% end %>;
+    index <% @index_files.each do |i| %> <%= i %><% end %>;
 <% end -%>
 <% if defined? auth_basic -%>
     auth_basic           "<%= @auth_basic %>";

--- a/templates/vhost/vhost_location_fastcgi.erb
+++ b/templates/vhost/vhost_location_fastcgi.erb
@@ -9,7 +9,7 @@
     fastcgi_split_path_info <%= @fastcgi_split_path %>;
 <% end -%>
 <% if @try_files -%>
-    try_files <% @try_files.each_line do |try| -%> <%= try %> <% end -%>;
+    try_files <% @try_files.each do |try| -%> <%= try %> <% end -%>;
 <% end -%>
     include <%= @fastcgi_params %>;
     fastcgi_pass <%= @fastcgi %>;


### PR DESCRIPTION
Class Array don't have method each_line on ruby 1.8.x, 1.9.x, 2.0.x

proxy_set_header - array
try_files - array
index_files -array
include_files - array
vhost_cfg_append - array

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template nginx/vhost/vhost_location_directory.erb:
Filepath: /usr/lib/ruby/vendor_ruby/rgen/array_extensions.rb
Line: 25
Detail: undefined method `each_line' for ["index.php", "index.html", "index.htm"]:Array
at /etc/puppet/modules/nginx/manifests/resource/location.pp:148 on node xxx
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
