### PR TITLE
sort $vhost_cfg_append hash in vhost_footer.erb template

### DIFF
--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -1,7 +1,10 @@
 <% if @include_files %><% @include_files.each do |file| -%>
 include <%= file %>;
 <% end -%><% end -%>
-<% if @vhost_cfg_append -%><% vhost_cfg_append.each do |key,value| -%>
+<%# make sure that allow comes before deny by forcing the allow key (if it -%>
+<%# exists) to be first in the output order.  The hash keys also need to be -%>
+<%# sorted so that the ordering is stable. -%>
+<% if @vhost_cfg_append -%><% vhost_cfg_append.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
   <%= key %> <%= value %>;
 <% end -%>
 <% end -%>


### PR DESCRIPTION
This is so the paremter ordering in the configuration is stable. It also
force the :allow key (if it exists) to be first in the sort ordering.
It would probably be better to change `$vhost_cfg_append` into an array
of one key hashes but would require a public API change.
