### PR TITLE
#66: This commit allows you to set package_ensure in nginx and have that

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@
 class nginx (
   $worker_processes       = $nginx::params::nx_worker_processes,
   $worker_connections     = $nginx::params::nx_worker_connections,
+  $package_ensure         = $nginx::params::package_ensure,
   $proxy_set_header       = $nginx::params::nx_proxy_set_header,
   $proxy_http_version     = $nginx::params::nx_proxy_http_version,
   $confd_purge            = $nginx::params::nx_confd_purge,

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -17,7 +17,7 @@ class nginx::package::debian {
   $operatingsystem_lowercase = inline_template('<%= @operatingsystem.downcase %>')
 
   package { 'nginx':
-    ensure  => present,
+    ensure  => $nginx::package_ensure,
     require => Anchor['nginx::apt_repo'],
   }
 

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -62,7 +62,7 @@ class nginx::package::redhat {
   }
 
   package { $redhat_packages:
-    ensure  => present,
+    ensure  => $nginx::package_ensure,
   }
 
 }

--- a/manifests/package/suse.pp
+++ b/manifests/package/suse.pp
@@ -24,6 +24,6 @@ class nginx::package::suse {
   ]
 
   package { $suse_packages:
-    ensure => present,
+    ensure => $nginx::package_ensure,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,4 +84,6 @@ class nginx::params {
 
   $nx_http_cfg_append = false
 
+  $package_ensure = 'present'
+
 }

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -22,4 +22,15 @@ describe 'nginx' do
     it_behaves_like 'linux', 'debian', 'www-data'
   end
 
+  describe 'installs the requested package version' do
+    let(:facts) {{ :kernel => 'linux', :operatingsystem => 'redhat', :osfamily => 'redhat' }}
+    let(:params) {{ :package_ensure => '3.0.0' }}
+
+    it 'installs 3.0.0 exactly' do
+      should contain_package('nginx').with({
+        'ensure' => '3.0.0'
+      })
+    end
+  end
+
 end


### PR DESCRIPTION
trickle through to the package classes.  I've avoided making them
into paramaterized classes and we just refer directly back to the main
nginx namespace to get the variable.  Makes for a cleaner looking
module!

Fixes #66.
