### PR TITLE
Fix deprecated variable access warning in vhost footer template

### DIFF
--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -4,7 +4,7 @@ include <%= file %>;
 <%# make sure that allow comes before deny by forcing the allow key (if it -%>
 <%# exists) to be first in the output order.  The hash keys also need to be -%>
 <%# sorted so that the ordering is stable. -%>
-<% if @vhost_cfg_append -%><% vhost_cfg_append.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+<% if @vhost_cfg_append -%><% @vhost_cfg_append.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
   <%= key %> <%= value %>;
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Removed this warning:
`Warning: Variable access via 'vhost_cfg_append' is deprecated. Use '@vhost_cfg_append' instead. template[/etc/puppet/modules/nginx/templates/vhost/vhost_footer.erb]:4`
