### PR TITLE
Fix stub_status location so it has line breaks.

### DIFF
--- a/templates/vhost/vhost_location_stub_status.erb
+++ b/templates/vhost/vhost_location_stub_status.erb
@@ -1,8 +1,10 @@
   location <%= @location %> {
 <% if @location_cfg_prepend -%><% @location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
-    <%= key %>  <%= value %>;<% end -%><% end -%>
+    <%= key %>  <%= value %>;
+<% end -%><% end -%>
     stub_status on;
 <% if @location_cfg_append -%><% @location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
-    <%= key %>  <%= value %>;<% end -%><% end -%>
+    <%= key %>  <%= value %>;
+<% end -%><% end -%>
   }
 


### PR DESCRIPTION
Currently because the end calls are on the same line as the key-value lines and because they end in `-%>` it got rid of the line break in the template. This moves those end calls to next line which is how the other templates do it.

An example of what gets changed after this change is applied (HOST and EXAMPLE are replacement values for actual hostname):

```
--- /tmp/nginx.d/HOST.EXAMPLE.com-500-HOST-stub_status    2013-09-14 10:18:28.000000000 +0200
+++ /tmp/puppet-file20130914-4235-1go88yp-0     2013-09-14 10:22:01.000000000 +0200
@@ -1,4 +1,7 @@
   location /nginx_status {
-    access_log  off;    allow  127.0.0.1;    deny  all;    stub_status on;
+    access_log  off;
+    allow  127.0.0.1;
+    deny  all;
+    stub_status on;
   }
```
