### PR TITLE
Adds root directive to vhost_header and vhost_ssl_header templates.

### DIFF
--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -40,8 +40,7 @@ server {
 <% if @index_files.count > 0 -%>
     index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
 <% end -%>
-
-<% if defined? @www_root -%>
+<% if @www_root -%>
   root <%= @www_root %>;
 <% end -%>
 

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -44,8 +44,7 @@ server {
 <% if @index_files.count > 0 -%>
     index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
 <% end -%>
-
-<% if defined? @www_root -%>
+<% if @www_root -%>
   root <%= @www_root %>;
 <% end -%>
 


### PR DESCRIPTION
This change will result in there being a 'root' directive in both the
server block, and the location sub-block. This is a perfectly valid
configuration and avoids the possible issue of having a location
with no 'root' if it isn't explicitly set.

---

From #142, I thought this was the most concise way to solve the 'no root' issue, another possibility would be to remove the root directive from the default '/' location, but having the duplicate has no ill-effects and keeps the '/' location consistent with any others added to the vhost.

I don't like schkovich's solution (d22a25908460fae1d31f3047369db110a72a824b) as it removes the ability to define locations blocks with different document roots.
