### PR TITLE
Add support for disabling repository management

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class nginx (
   $worker_processes       = $nginx::params::nx_worker_processes,
   $worker_connections     = $nginx::params::nx_worker_connections,
   $package_ensure         = $nginx::params::package_ensure,
+  $manage_repos           = $nginx::params::manage_repos,
   $proxy_set_header       = $nginx::params::nx_proxy_set_header,
   $proxy_http_version     = $nginx::params::nx_proxy_http_version,
   $confd_purge            = $nginx::params::nx_confd_purge,

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -14,7 +14,6 @@
 #
 # This class file is not called directly
 class nginx::package::debian {
-  $distro = downcase($::operatingsystem)
 
   package { 'nginx':
     ensure  => $nginx::package_ensure,
@@ -23,21 +22,25 @@ class nginx::package::debian {
 
   anchor { 'nginx::apt_repo' : }
 
-  include '::apt'
+  if $nginx::manage_repos {
+    $distro = downcase($::operatingsystem)
 
-  apt::source { 'nginx':
-    location   => "http://nginx.org/packages/${distro}",
-    repos      => 'nginx',
-    key        => '7BD9BF62',
-    key_source => 'http://nginx.org/keys/nginx_signing.key',
-  }
+    include '::apt'
 
-  exec { 'apt_get_update_for_nginx':
-    command     => '/usr/bin/apt-get update',
-    timeout     => 240,
-    returns     => [ 0, 100 ],
-    refreshonly => true,
-    subscribe   => Apt::Source['nginx'],
-    before      => Anchor['nginx::apt_repo'],
+    apt::source { 'nginx':
+      location   => "http://nginx.org/packages/${distro}",
+      repos      => 'nginx',
+      key        => '7BD9BF62',
+      key_source => 'http://nginx.org/keys/nginx_signing.key',
+    }
+
+    exec { 'apt_get_update_for_nginx':
+      command     => '/usr/bin/apt-get update',
+      timeout     => 240,
+      returns     => [ 0, 100 ],
+      refreshonly => true,
+      subscribe   => Apt::Source['nginx'],
+      before      => Anchor['nginx::apt_repo'],
+    }
   }
 }

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -38,27 +38,31 @@ class nginx::package::redhat {
         }
       }
 
-      # as of 2013-07-28
-      # http://nginx.org/packages/centos appears to be identical to
-      # http://nginx.org/packages/rhel
-      # no other dedicated dirs exist for platforms under $::osfamily == redhat
-      yumrepo { 'nginx-release':
-        baseurl  => "http://nginx.org/packages/rhel/${os_rel}/\$basearch/",
-        descr    => 'nginx repo',
-        enabled  => '1',
-        gpgcheck => '1',
-        priority => '1',
-        gpgkey   => 'http://nginx.org/keys/nginx_signing.key',
-      }
+      if $nginx::manage_repos {
+        # as of 2013-07-28
+        # http://nginx.org/packages/centos appears to be identical to
+        # http://nginx.org/packages/rhel
+        # no other dedicated dirs exist for platforms under $::osfamily == redhat
+        yumrepo { 'nginx-release':
+          baseurl  => "http://nginx.org/packages/rhel/${os_rel}/\$basearch/",
+          descr    => 'nginx repo',
+          enabled  => '1',
+          gpgcheck => '1',
+          priority => '1',
+          gpgkey   => 'http://nginx.org/keys/nginx_signing.key',
+        }
 
-      Yumrepo['nginx-release'] -> Package[$redhat_packages]
+        Yumrepo['nginx-release'] -> Package[$redhat_packages]
+      }
     }
   }
 
-  #Define file for nginx-repo so puppet doesn't delete it
-  file { '/etc/yum.repos.d/nginx-release.repo':
-    ensure  => present,
-    require => Yumrepo['nginx-release'],
+  if $manage_repos {
+    # Define file for nginx-repo so puppet doesn't delete it
+    file { '/etc/yum.repos.d/nginx-release.repo':
+      ensure  => present,
+      require => Yumrepo['nginx-release'],
+    }
   }
 
   package { $redhat_packages:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -89,4 +89,5 @@ class nginx::params {
   $nx_http_access_log = "${nx_logdir}/access.log"
 
   $package_ensure = 'present'
+  $manage_repos   = true
 }


### PR DESCRIPTION
As the repo handling at least for the Debian-based case is not ideal and causes problems in our setup, there should be a parameter to disable the management of repositories. This pull request adds this feature without breaking the default behaviour.
