### PR TITLE
Allow the service name to be configured

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,7 @@ class nginx (
   $proxy_cache_max_size   = $nginx::params::nx_proxy_cache_max_size,
   $proxy_cache_inactive   = $nginx::params::nx_proxy_cache_inactive,
   $configtest_enable      = $nginx::params::nx_configtest_enable,
+  $service_name           = $nginx::params::nx_service_name,
   $service_restart        = $nginx::params::nx_service_restart,
   $mail                   = $nginx::params::nx_mail,
   $server_tokens          = $nginx::params::nx_server_tokens,
@@ -82,6 +83,7 @@ class nginx (
   class { 'nginx::service':
     configtest_enable => $configtest_enable,
     service_restart   => $service_restart,
+    service_name      => $service_name,
   }
 
   validate_hash($nginx_upstreams)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,7 +79,8 @@ class nginx::params {
   # $nx_service_restart value, forcing configtest.
 
   $nx_configtest_enable = false
-  $nx_service_restart = '/etc/init.d/nginx configtest && /etc/init.d/nginx restart'
+  $nx_service_name = 'nginx'
+  $nx_service_restart = "/etc/init.d/${nx_service_name} configtest && /etc/init.d/${nx_service_name} restart"
 
   $nx_mail = false
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,7 +15,8 @@
 # This class file is not called directly
 class nginx::service(
   $configtest_enable = $nginx::params::nx_configtest_enable,
-  $service_restart   = $nginx::params::nx_service_restart
+  $service_restart   = $nginx::params::nx_service_restart,
+  $service_name      = $nginx::params::nx_service_name,
 ) {
   exec { 'rebuild-nginx-vhosts':
     command     => "/bin/cat ${nginx::params::nx_temp_dir}/nginx.d/* > ${nginx::params::nx_conf_dir}/conf.d/vhost_autogen.conf",
@@ -30,6 +31,7 @@ class nginx::service(
     subscribe   => File["${nginx::params::nx_temp_dir}/nginx.mail.d"],
   }
   service { 'nginx':
+    name       => $service_name,
     ensure     => running,
     enable     => true,
     hasstatus  => true,


### PR DESCRIPTION
Some nginx packages (particularly the openresty bundle) use a different service name. This patch allows the service name to be overridden in the `nginx` class without breaking any dependencies on `Service['nginx']`.
