### PR TITLE
Allow the package name to be specified on RedHat-based systems

### DIFF
--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -14,9 +14,12 @@
 #
 # This class file is not called directly
 class nginx::package::redhat (
-  $manage_repo = true
+  $manage_repo = true,
+  $package_name   = 'nginx',
+  $package_source = 'nginx',
+  $package_ensure = 'present'
 ) {
-  $redhat_packages = ['nginx', 'gd', 'libXpm', 'libxslt']
+  $redhat_packages = [$package_name, 'gd', 'libXpm', 'libxslt']
 
   case $::operatingsystem {
     'fedora': {
@@ -67,7 +70,7 @@ class nginx::package::redhat (
   }
 
   package { $redhat_packages:
-    ensure  => $nginx::package_ensure,
+    ensure  => $package_ensure,
   }
 
 }


### PR DESCRIPTION
This fixes an error relating to passing parameters to the `nginx::package::redhat` class whilst adding the capability to  configure the package name for such systems.
