### PR TITLE
Fix RHEL installation support

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -26,9 +26,8 @@ class nginx::package(
     'redhat': {
       class { 'nginx::package::redhat':
         manage_repo    => $manage_repo,
-        package_name   => $package_name,
-        package_source => $package_source,
         package_ensure => $package_ensure,
+        package_name   => $package_name,
         require        => Anchor['nginx::package::begin'],
         before         => Anchor['nginx::package::end'],
       }

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -14,9 +14,10 @@
 #
 # This class file is not called directly
 class nginx::package::redhat (
-  $manage_repo = true
+  $manage_repo    = true,
+  $package_ensure = 'present',
+  $package_name   = 'nginx',
 ) {
-  $redhat_packages = ['nginx', 'gd', 'libXpm', 'libxslt']
 
   case $::operatingsystem {
     'fedora': {
@@ -52,7 +53,7 @@ class nginx::package::redhat (
           gpgcheck => '1',
           priority => '1',
           gpgkey   => 'http://nginx.org/keys/nginx_signing.key',
-          before   => Package[$redhat_packages],
+          before   => Package[$package_name],
         }
       }
     }
@@ -66,8 +67,8 @@ class nginx::package::redhat (
     }
   }
 
-  package { $redhat_packages:
-    ensure  => $nginx::package_ensure,
+  package { $package_name:
+    ensure  => $package_ensure,
   }
 
 }


### PR DESCRIPTION
The commit 7ea6b570c3ff550f145ef98af66169bfb6500e78 broke RHEL support by introducing the parameters `package_name` and `package_source` in `package.pp` but those parameters are not supported in `package/redhat.pp`.

This pull request fixes the problem and also consolidates redhat.pp to match the style of debian.pp.  This includes replacing the `$redhat_packages` parameter (a list of packages) with simply `$package_name`.  Checking the latest nginx in EPEL for RHEL6 all related packages with the exception of libXpm are already specified as dependencies in the `nginx` RPM.  I haven't found out why `libXpm` was listed in `$redhat_packages` in the first place.
