### PR TITLE
Add Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+---
+branches:
+  only:
+  - master
+language: ruby
+script: "bundle exec rake --rakefile $PWD/.travis/Rakefile spec SPEC_OPTS='--format documentation'"
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+gemfile: .travis/Gemfile
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 2.7.0"
+    - PUPPET_GEM_VERSION="~> 3.0"
+matrix:
+  exclude:
+    - rvm: 1.9.3
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
+      gemfile: .travis/Gemfile
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 2.7.0"
+      gemfile: .travis/Gemfile
+notifications:
+  email: false

--- a/.travis/Gemfile
+++ b/.travis/Gemfile
@@ -1,0 +1,12 @@
+source 'https://rubygems.org'
+
+group :rake do
+  gem 'puppetlabs_spec_helper'
+  gem 'librarian-puppet-maestrodev'
+end
+
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
+end

--- a/.travis/Rakefile
+++ b/.travis/Rakefile
@@ -1,0 +1,8 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+
+# use librarian-puppet to manage fixtures instead of .fixtures.yml
+# offers more possibilities like explicit version management, forge downloads,...
+task :librarian_spec_prep do
+  sh "librarian-puppet install --path=$PWD/spec/fixtures/modules/"
+end
+task :spec_prep => :librarian_spec_prep


### PR DESCRIPTION
Add a specific Travis config that tests across Ruby versions on latest Puppet release from 2.7.x and 3.x series.
