### PR TITLE
Fix upstream_cfg_prepend loop to put every element on a dedicated line

### DIFF
--- a/templates/conf.d/upstream.erb
+++ b/templates/conf.d/upstream.erb
@@ -1,5 +1,5 @@
 upstream <%= @name %> {
-<% if @upstream_cfg_prepend -%><% upstream_cfg_prepend.sort_by{|k,v| k}.each do |key,value| -%>
+<% if @upstream_cfg_prepend -%><% upstream_cfg_prepend.sort_by{|k,v| k}.each do |key,value| %>
   <%= key %> <%= value %>;<% end -%><% end -%>
   <% @members.each do |i| %>
   server     <%= i %>;<% end %>


### PR DESCRIPTION
Hi James,

this tiny change will fix the upstream template. Turns this

```
check interval=3000 rise=2 fall=5 timeout=1000 type=http;  check_http_expect_alive http_2xx;  check_http_send "GET /_version HTTP/1.0\r\n\r\n";
```

into

```
check interval=3000 rise=2 fall=5 timeout=1000 type=http;
check_http_expect_alive http_2xx;
check_http_send "GET /_version HTTP/1.0\r\n\r\n";
```

Thanks a lot for your work on this module.

Cheers!
Daniel
