### PR TITLE
[rspec fixes] fedora package spec needs lsbmajdistrelease fact

### DIFF
--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -49,7 +49,7 @@ describe 'nginx::package' do
   context 'fedora' do
     # fedora is identical to the rest of osfamily RedHat except for not
     # including nginx-release
-    let(:facts) {{ :operatingsystem => 'Fedora', :osfamily => 'RedHat' }}
+    let(:facts) {{ :operatingsystem => 'Fedora', :osfamily => 'RedHat', :lsbmajdistrelease => 5 }}
     it { should contain_package('nginx') }
     it { should_not contain_yumrepo('nginx-release') }
   end


### PR DESCRIPTION
When I ran tests for #165 on my machine I had ruby 1.9.3, which didn't show up a failure that Travis did on 1.8.7.

What's worse is I'd already hit this during my testing and forgot to fix it :(

Anyway, NOW all the tests will pass!
