### PR TITLE
Adding upstream fail_timeout.

### DIFF
--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -5,7 +5,8 @@
 # Parameters:
 #   [*members*]               - Array of member URIs for NGINX to connect to. Must follow valid NGINX syntax.
 #   [*ensure*]                - Enables or disables the specified location (present|absent)
-#   [*upstream_cfg_prepend*] - It expects a hash with custom directives to put before anything else inside upstream
+#   [*upstream_cfg_prepend*]  - It expects a hash with custom directives to put before anything else inside upstream
+#   [*upstream_fail_timeout*] - Set the fail_timeout for the upstream. Default is 10 seconds - As that is what Nginx does normally.
 #
 # Actions:
 #
@@ -40,6 +41,7 @@ define nginx::resource::upstream (
   $members,
   $ensure = 'present',
   $upstream_cfg_prepend = undef,
+  $upstream_fail_timeout = '10s',
 ) {
   File {
     owner => 'root',

--- a/templates/conf.d/upstream.erb
+++ b/templates/conf.d/upstream.erb
@@ -2,5 +2,5 @@ upstream <%= @name %> {
 <% if @upstream_cfg_prepend -%><% upstream_cfg_prepend.sort_by{|k,v| k}.each do |key,value| %>
   <%= key %> <%= value %>;<% end -%><% end -%>
   <% @members.each do |i| %>
-  server     <%= i %>;<% end %>
+  server     <%= i %>  fail_timeout=<%= @upstream_fail_timeout %>;<% end %>
 }


### PR DESCRIPTION
I needed to be able to change the fail_timeout on my upstream. This does the trick.
