### PR TITLE
Adds OracleLinux value to operating system matching in params

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,7 +70,7 @@ class nginx::params {
 
   $nx_daemon_user = $::operatingsystem ? {
     /(?i-mx:debian|ubuntu)/                                                    => 'www-data',
-    /(?i-mx:fedora|rhel|redhat|centos|scientific|suse|opensuse|amazon|gentoo)/ => 'nginx',
+    /(?i-mx:fedora|rhel|redhat|centos|scientific|suse|opensuse|amazon|gentoo|oraclelinux)/ => 'nginx',
   }
 
   # Service restart after Nginx 0.7.53 could also be just


### PR DESCRIPTION
Fix #176 "Add OracleLinux value to operating system matching in params".
