### PR TITLE
Added proxy_set_header and vhost_cfg_prepend to the ssl vhost template.

### DIFF
--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -21,9 +21,19 @@ server {
   auth_basic_user_file      "<%= @auth_basic_user_file %>";
 <% end -%>
 
+<% @proxy_set_header.each do |header| -%>
+  proxy_set_header        <%= header %>;
+<% end -%>
+
   access_log            <%= @ssl_access_log %>;
   error_log             <%= @ssl_error_log %>;
 
+<%# make sure that allow comes before deny by forcing the allow key (if it -%>
+<%# exists) to be first in the output order.  The hash keys also need to be -%>
+<%# sorted so that the ordering is stable. -%>
+<% if @vhost_cfg_prepend -%><% vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+  <%= key %> <%= value %>;
+<% end -%><% end -%>
 <% if @root -%>
   root <%= @root %>;
 <% end -%>


### PR DESCRIPTION
proxy_set_header and vhost_cfg_prepend was missing from ssl vhost template.

proxy_set_header is important in cases where nginx is used as a SSL proxy and the backend application need
to have custom headers appended to.

For instance Wordpress need headers like 'X-Forwarded-Proto https' to work properly with SSL proxying.
