### PR TITLE
Remove sorting since it breaks rewrite rules.

### DIFF
--- a/templates/vhost/vhost_location_empty.erb
+++ b/templates/vhost/vhost_location_empty.erb
@@ -1,5 +1,5 @@
   location <%= @location %> {
-<% if @location_custom_cfg -%><% @location_custom_cfg.sort_by {|k,v| k}.each do |key,value| -%>
+<% if @location_custom_cfg -%><% @location_custom_cfg.each do |key,value| -%>
     <%= key %> <%= value %>;
 <% end -%><% end -%>
   }


### PR DESCRIPTION
Hi,

when using following hiera config:

``` yaml
        location_custom_cfg:
            - rewrite ^/api/(.*) /index_rest.php/$1 last
            - rewrite ^/robots.txt /index_cnseo.php last
            - rewrite ^/sitemaps/sitemap.*.xml$ /index_cnseo.php last
            - rewrite ^/interstitial/.* /interstitial.php last
            - rewrite ^([^/]+/)?content/treemenu.*$ /index_treemenu.php$1 last
            - rewrite ^(.*)$ /index.php$1 last
```

it produces location code like:

```
        location /xy {
            rewrite ^(.*)$ /index.php$1 last;
            rewrite ^([^/]+/)?content/treemenu.*$ /index_treemenu.php$1 last;
            ...;
        }
```

Due to sorting the index rule will be set on first position and therefore no other rewrite will ever match.

Regards,
Martin
