### PR TITLE
Feature: Added HSTS header support into ssl vhost.

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -66,6 +66,8 @@
 #      password with HTTP Basic Authentication.
 #   [*auth_basic_user_file*]    - This directive sets the htpasswd filename for
 #     the authentication realm.
+#   [*header_hsts*]             - Adds the Strict-Transport-Security header with
+#     a value as defiend within.
 #   [*vhost_cfg_append*]        - It expects a hash with custom directives to
 #     put after everything else inside vhost
 #   [*vhost_cfg_prepend*]       - It expects a hash with custom directives to
@@ -77,7 +79,7 @@
 #      options like log format to the end.
 #   [*error_log*]               - Where to write error log. May add additional
 #      options like error level to the end.
-#   [*passenger_cgi_param*]     - Allows one to define additional CGI environment 
+#   [*passenger_cgi_param*]     - Allows one to define additional CGI environment
 #      variables to pass to the backend application
 # Actions:
 #
@@ -134,6 +136,7 @@ define nginx::resource::vhost (
   $try_files              = undef,
   $auth_basic             = undef,
   $auth_basic_user_file   = undef,
+  $header_hsts            = undef,
   $vhost_cfg_prepend      = undef,
   $vhost_cfg_append       = undef,
   $include_files          = undef,
@@ -205,7 +208,7 @@ define nginx::resource::vhost (
   if ($ssl == true) and ($ssl_port == $listen_port) {
     $ssl_only = true
   }
-  
+
   if $use_default_location == true {
     # Create the default location reference for the vHost
     nginx::resource::location {"${name}-default":

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -20,6 +20,9 @@ server {
 <% if defined? @auth_basic_user_file -%>
   auth_basic_user_file      "<%= @auth_basic_user_file %>";
 <% end -%>
+<% if defined? @header_hsts -%>
+  add_header Strict-Transport-Security "<%= @header_hsts %>";
+<% end -%>
 
   access_log            <%= @ssl_access_log %>;
   error_log             <%= @ssl_error_log %>;


### PR DESCRIPTION
In nginx::vhost I have added $header_hsts. This option, when defined
will set "add_header Strict-Transport-Security "${header_hsts}";".

There is also some trailing whitespace that I have cleaned up.

Comments and suggestions welcome.
