### PR TITLE
Add nginx autoindex to resource nginx::location and style up the nginx::vhost directory template

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -13,6 +13,8 @@
 #   [*location_deny*]        - Array: Locations to deny connections from.
 #   [*www_root*]             - Specifies the location on disk for files to be
 #     read from. Cannot be set in conjunction with $proxy
+#   [*autoindex*]            - Set it on 'on' to activate autoindex directory
+#     listing. Undef by default.
 #   [*index_files*]          - Default index files for NGINX to read when
 #     traversing a directory
 #   [*proxy*]                - Proxy server(s) for a location to connect to.
@@ -91,6 +93,7 @@ define nginx::resource::location (
   $location             = $name,
   $vhost                = undef,
   $www_root             = undef,
+  $autoindex            = undef,
   $index_files          = [
     'index.html',
     'index.htm',
@@ -126,7 +129,7 @@ define nginx::resource::location (
     mode   => '0644',
     notify => Class['nginx::service'],
   }
-  
+
   validate_array($index_files)
 
   # # Shared Variables

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -26,7 +26,7 @@
 #   [*index_files*]         - Default index files for NGINX to read when
 #     traversing a directory
 #   [*autoindex*]           - Set it on 'on' to activate autoindex directory
-#     listing. Undef by default.)
+#     listing. Undef by default.
 #   [*proxy*]               - Proxy server(s) for the root location to connect
 #     to.  Accepts a single value, can be used in conjunction with
 #     nginx::resource::upstream

--- a/templates/vhost/vhost_location_directory.erb
+++ b/templates/vhost/vhost_location_directory.erb
@@ -14,7 +14,9 @@
 <% if @try_files -%>
     try_files<% @try_files.each do |try| -%> <%= try %><% end -%>;
 <% end -%>
-<% if @autoindex == 'on' -%>autoindex on;<% end -%>
+<% if @autoindex == 'on' -%>
+    autoindex on;
+<% end -%>
 <% if @index_files -%>
     index <% @index_files.each do |i| %> <%= i %><% end %>;
 <% end -%>


### PR DESCRIPTION
I extend and style up the code from my last pull request [#194](https://github.com/jfryman/puppet-nginx/pull/194).
Now, you can use in the location definition the autoindex option, too.

Regards,
Markus "bionix"
