### PR TITLE
Fix for order statements. Concat requires strings

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -180,7 +180,7 @@ define nginx::resource::location (
     concat::fragment { "${vhost}-${priority}-${location_sanitized}":
       target  => $config_file,
       content => $content_real,
-      order   => $priority,
+      order   => "${priority}",
     }
   }
 
@@ -190,7 +190,7 @@ define nginx::resource::location (
     concat::fragment {"${vhost}-${ssl_priority}-${location_sanitized}-ssl":
       target  => $config_file,
       content => $content_real,
-      order   => $ssl_priority,
+      order   => "${ssl_priority}",
     }
   }
 


### PR DESCRIPTION
concat module would complain about these locations.  Error: 800 is not a string.  It looks to be a Fixnum 

Wrapping them in quotes forces them to be strings.  
