### PR TITLE
Add vhost_cfg_prepend in vhost_ssl_header

### DIFF
--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -27,6 +27,9 @@ server {
   access_log            <%= @ssl_access_log %>;
   error_log             <%= @ssl_error_log %>;
 
+<% if @vhost_cfg_prepend -%><% @vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+  <%= key %> <%= value %>;
+<% end -%><% end -%>
 <% if @root -%>
   root <%= @root %>;
 <% end -%>


### PR DESCRIPTION
vhost_cfg_prepend is missing from vhost_ssl_header. When using vhost_cfg_prepend with ssl = true, the config is missing from ssl vhost section.
