### PR TITLE
Fix Travis build errors on Rubygems 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ branches:
   only:
   - master
 language: ruby
+before_install:
+  - gem update --system 2.1.11
+  - gem --version
 script: "bundle exec rake --rakefile $PWD/.travis/Rakefile spec SPEC_OPTS='--format documentation'"
 rvm:
   - 1.8.7


### PR DESCRIPTION
Force last known good Rubygems version - revert once https://github.com/rubygems/rubygems/pull/763 has been released.
