### PR TITLE
Add validation for location $priority

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -57,7 +57,7 @@
 #   [*auth_basic_user_file*]  - This directive sets the htpasswd filename for
 #     the authentication realm.
 #   [*priority*]              - Location priority. Default: 500. User priority
-#     400-499, 501-599. If the priority is higher than the default priority,
+#     401-499, 501-599. If the priority is higher than the default priority,
 #     the location will be defined after root, or before root.
 #
 #
@@ -131,6 +131,12 @@ define nginx::resource::location (
   }
 
   validate_array($index_files)
+  if !is_integer($priority) {
+    fail("$priority must be an integer.")
+  }
+  if ($priority < 401) or ($priority > 599) {
+    fail("$priority must be in the range 401-599. It was set to ${priority}.")
+  }
 
   # # Shared Variables
   $ensure_real = $ensure ? {


### PR DESCRIPTION
Valid range changed to 401-599:

vhost SSL header has priority 700. If $priority is set to 400 (which resolves to 400+300=700 for SSL locations), then it would conflict with the priority of the header. It must be 401 or higher to avoid this.

Top end of range is limited to 599 to reflect documentation however it could be increased to 698 and still provide expected behavior.

Current default priorities:
- 001 HTTP header
- 500 nginx::resource::location default (included when `$ssl_only != true`, which is default)
- 699 HTTP footer
- 700 SSL header
- 800 nginx::resource::location default (included when `$ssl == true`). Is `$priority + 300`.
- 999 SSL footer

Non-conflicting HTTP location fragment priorities: 002-698. Means `$priority` valid range is 002-698.
Non-conflicting SSL location fragment priorities:  701-998. Means `$priority` valid range is 401-698.

Documentation says valid range is 400-499 and 501-599. This is correct for HTTP but is incorrect for SSL (the range should be 401-499).
