### PR TITLE
Fix index_files ivar warning

### DIFF
--- a/templates/vhost/vhost_location_directory.erb
+++ b/templates/vhost/vhost_location_directory.erb
@@ -18,7 +18,7 @@
     autoindex on;
 <% end -%>
 <% if @index_files.count > 0 -%>
-    index <% Array(index_files).each do |i| %> <%= i %><% end %>;
+    index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
 <% end -%>
 <% if defined? @auth_basic -%>
     auth_basic           "<%= @auth_basic %>";


### PR DESCRIPTION
Fix the index_files instance variable deprecation warning:

```
Warning: Variable access via 'index_files' is deprecated. Use '@index_files' instead.
```
