### PR TITLE
Fix multi-line comment indentation

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,8 +25,8 @@ class nginx::params {
   $nx_types_hash_bucket_size  = 512
   $nx_names_hash_bucket_size  = 64
   $nx_multi_accept            = off
-# One of [kqueue|rtsig|epoll|/dev/poll|select|poll|eventport]
-# or false to use OS default
+  # One of [kqueue|rtsig|epoll|/dev/poll|select|poll|eventport]
+  # or false to use OS default
   $nx_events_use              = false
   $nx_sendfile                = on
   $nx_keepalive_timeout       = 65


### PR DESCRIPTION
`puppetresources` is complaining about the wrong indentation scheme.
