### PR TITLE
workaround missing librarian-puppet-maestrodev dependencies

### DIFF
--- a/.travis/Gemfile
+++ b/.travis/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 group :rake do
   gem 'puppetlabs_spec_helper'
   gem 'librarian-puppet-maestrodev'
+  gem 'open3_backport', :platforms => :ruby_18
+  gem 'json',           :platforms => :ruby_18
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
librarian-puppet-maestrodev gem specifies Ruby 1.8 dependencies incorrectly. open3_backport and json are required on Ruby 1.8 but are not currently installed. See https://github.com/maestrodev/librarian-puppet/issues/16

This ~~should address~~ addresses the build failures in Ruby 1.8.7.
