### PR TITLE
Sort @passenger_cgi_param to make sure generated config file content is stable.

### DIFF
--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -20,8 +20,8 @@ server {
 <% if @root -%>
   root <%= @root %>;
 <% end -%>
-<% if @passenger_cgi_param -%><% @passenger_cgi_param.each do |key,value| -%>
-  passenger_set_cgi_param  <%= key %> <%= value %>;
+<% if @passenger_cgi_param -%><% @passenger_cgi_param.keys.sort.each do |key| -%>
+  passenger_set_cgi_param  <%= key %> <%= @passenger_cgi_param[key] %>;
 <% end -%><% end -%>
 <% @proxy_set_header.each do |header| -%>
   proxy_set_header        <%= header %>;


### PR DESCRIPTION
I see a strange issue when I use @passenger_cgi_param in nginx::resource::vhost. The `passenger_set_cgi_param` part in generated nginx site config is keeping changing. It makes nginx service restarted after every puppet agent run.

It seems `each` on hash map is not stable. My solution is to get hash keys and sort them to make sure it's stable.
