### PR TITLE
move ipv6only=on into ipv6_listen_options

### DIFF
--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -49,7 +49,7 @@ define nginx::resource::mailhost (
   $ipv6_enable         = false,
   $ipv6_listen_ip      = '::',
   $ipv6_listen_port    = '80',
-  $ipv6_listen_options = 'default',
+  $ipv6_listen_options = 'default ipv6only=on',
   $ssl                 = false,
   $ssl_cert            = undef,
   $ssl_key             = undef,

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -123,7 +123,7 @@ define nginx::resource::vhost (
   $ipv6_enable            = false,
   $ipv6_listen_ip         = '::',
   $ipv6_listen_port       = '80',
-  $ipv6_listen_options    = 'default',
+  $ipv6_listen_options    = 'default ipv6only=on',
   $add_header             = undef,
   $ssl                    = false,
   $ssl_cert               = undef,

--- a/templates/mailhost/mailhost.erb
+++ b/templates/mailhost/mailhost.erb
@@ -3,7 +3,7 @@ server {
   listen                <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
   <% # check to see if ipv6 support exists in the kernel before applying %>
   <% if @ipv6_enable && (defined? @ipaddress6) %>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %> ipv6only=on;
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
   <% end %>
   server_name           <%= @server_name.join(" ") %>;
   protocol              <%= @protocol %>;

--- a/templates/mailhost/mailhost_ssl.erb
+++ b/templates/mailhost/mailhost_ssl.erb
@@ -3,7 +3,7 @@ server {
   listen       <%= @ssl_port %>;
   <% # check to see if ipv6 support exists in the kernel before applying %>
   <% if @ipv6_enable && (defined? @ipaddress6) %>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %> ipv6only=on;
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
   <% end %>
   server_name           <%= @server_name.join(" ") %>;
   protocol              <%= @protocol %>;

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -2,7 +2,7 @@ server {
   listen                <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
 <% # check to see if ipv6 support exists in the kernel before applying %>
 <% if @ipv6_enable && (defined? @ipaddress6) %>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %> ipv6only=on;
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
 <% end %>
   server_name           <%= @rewrite_www_to_non_www ? @name.gsub(/^www\./, '') : @server_name.join(" ") %>;
 <% if defined? @auth_basic -%>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -1,7 +1,7 @@
 server {
   listen       <%= @listen_ip %>:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
   <% if @ipv6_enable && (defined? @ipaddress6) %>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %> ipv6only=on;
+  listen [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %> ;
   <% end %>
   server_name  <%= @rewrite_www_to_non_www ? @name.gsub(/^www\./, '') : @server_name.join(" ") %>;
 


### PR DESCRIPTION
I think i created an issue for this but i may have forgot to hit submit.  Anyway this is similar to issue 30.  as well as the default value ipv6only=on can only be placed on one listen statement for a specific socket.
