### PR TITLE
Fix nginx::params deprecation notice

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@
 # This class file is not called directly
 class nginx::params {
 
-  if $caller_module_name != $module_name {
+  if $caller_module_name != undef and $caller_module_name != $module_name {
     warning("${name} is deprecated as a public API of the ${module_name} module and should no longer be directly included in the manifest.")
   }
 


### PR DESCRIPTION
When calling `class { 'nginx': }` from outside the nginx module and because `nginx` inherits from `nginx::params` it is triggering [this statement](https://github.com/jfryman/puppet-nginx/blob/master/manifests/params.pp#L18-L20) incorrectly.

`$caller_module_name` is undefined when `class { 'nginx': }` is called in the global scope (i.e. within your `site.pp`) so this check for that first to avoid the false matches.
