### PR TITLE
Puppet removes dir only if "force => true"

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -119,11 +119,13 @@ class nginx::config(
     ensure  => absent,
     purge   => true,
     recurse => true,
+    force   => true,
   }
 
   file { "${nginx::config::nx_temp_dir}/nginx.mail.d":
     ensure  => absent,
     purge   => true,
     recurse => true,
+    force   => true,
   }
 }


### PR DESCRIPTION
Add missing `force => true`.
