### PR TITLE
Ensure that vhosts are purged with new parameter purge_vhost

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,6 +17,7 @@ class nginx::config(
   $worker_processes       = $nginx::params::nx_worker_processes,
   $worker_connections     = $nginx::params::nx_worker_connections,
   $confd_purge            = $nginx::params::nx_confd_purge,
+  $vhost_purge            = $nginx::params::nx_vhost_purge,
   $server_tokens          = $nginx::params::nx_server_tokens,
   $proxy_set_header       = $nginx::params::nx_proxy_set_header,
   $proxy_cache_path       = $nginx::params::nx_proxy_cache_path,
@@ -98,8 +99,22 @@ class nginx::config(
     ensure => directory,
   }
 
+  if $vhost_purge == true {
+    File["${nginx::params::nx_conf_dir}/sites-available"] {
+      purge   => true,
+      recurse => true,
+    }
+  }
+
   file { "${nginx::params::nx_conf_dir}/sites-enabled":
     ensure => directory,
+  }
+
+  if $vhost_purge == true {
+    File["${nginx::params::nx_conf_dir}/sites-enabled"] {
+      purge   => true,
+      recurse => true,
+    }
   }
 
   file { '/etc/nginx/sites-enabled/default':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class nginx (
   $proxy_set_header       = $nginx::params::nx_proxy_set_header,
   $proxy_http_version     = $nginx::params::nx_proxy_http_version,
   $confd_purge            = $nginx::params::nx_confd_purge,
+  $vhost_purge            = $nginx::params::nx_vhost_purge,
   $proxy_cache_path       = $nginx::params::nx_proxy_cache_path,
   $proxy_cache_levels     = $nginx::params::nx_proxy_cache_levels,
   $proxy_cache_keys_zone  = $nginx::params::nx_proxy_cache_keys_zone,
@@ -75,6 +76,7 @@ class nginx (
   validate_array($proxy_set_header)
   validate_string($proxy_http_version)
   validate_bool($confd_purge)
+  validate_bool($vhost_purge)
   if ($proxy_cache_path != false) {
     validate_string($proxy_cache_path)
   }
@@ -126,6 +128,7 @@ class nginx (
     proxy_cache_max_size   => $proxy_cache_max_size,
     proxy_cache_inactive   => $proxy_cache_inactive,
     confd_purge            => $confd_purge,
+    vhost_purge            => $vhost_purge,
     server_tokens          => $server_tokens,
     client_max_body_size   => $client_max_body_size,
     names_hash_bucket_size => $names_hash_bucket_size,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class nginx::params {
 
   $nx_conf_dir                = '/etc/nginx'
   $nx_confd_purge             = false
+  $nx_vhost_purge             = false
   $nx_worker_processes        = 1
   $nx_worker_connections      = 1024
   $nx_types_hash_max_size     = 1024

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -288,5 +288,31 @@ describe 'nginx::config' do
         'recurse'
       ])}
     end
+
+    context "when vhost_purge true" do
+      let(:params) {{:vhost_purge => true}}
+      it { should contain_file('/etc/nginx/sites-available').with(
+        :purge => true,
+        :recurse => true
+      )}
+      it { should contain_file('/etc/nginx/sites-enabled').with(
+        :purge => true,
+        :recurse => true
+      )}
+    end
+
+    context "when vhost_purge false" do
+      let(:params) {{:vhost_purge => false}}
+      it { should contain_file('/etc/nginx/sites-available').without([
+        'ignore',
+        'purge',
+        'recurse'
+      ])}
+      it { should contain_file('/etc/nginx/sites-enabled').without([
+        'ignore',
+        'purge',
+        'recurse'
+      ])}
+    end
   end
 end


### PR DESCRIPTION
Added new parameter to purge_vhost enable purging vhosts, a wanted feature to keep sites-enabled and sites-available clean
