### PR TITLE
Make template for nginx.conf.erb configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,6 +38,7 @@ class nginx::config(
   $proxy_buffer_size      = $nginx::params::nx_proxy_buffer_size,
   $gzip                   = $nginx::params::nx_gzip,
   $conf_template          = $nginx::params::nx_conf_template,
+  $proxy_conf_template    = $nginx::params::nx_proxy_conf_template,
 ) inherits nginx::params {
 
   if $caller_module_name != $module_name {
@@ -129,7 +130,7 @@ class nginx::config(
 
   file { "${nginx::params::nx_conf_dir}/conf.d/proxy.conf":
     ensure  => file,
-    content => template('nginx/conf.d/proxy.conf.erb'),
+    content => template($proxy_conf_template),
   }
 
   file { "${nginx::config::nx_temp_dir}/nginx.d":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,6 +57,7 @@ class nginx (
   $http_access_log        = $nginx::params::nx_http_access_log,
   $gzip                   = $nginx::params::nx_gzip,
   $conf_template          = $nginx::params::nx_conf_template,
+  $proxy_conf_template    = $nginx::params::nx_proxy_conf_template,
   $nginx_vhosts           = {},
   $nginx_upstreams        = {},
   $nginx_locations        = {},
@@ -141,6 +142,7 @@ class nginx (
     http_access_log        => $http_access_log,
     gzip                   => $gzip,
     conf_template          => $conf_template,
+    proxy_conf_template    => $proxy_conf_template,
     require                => Class['nginx::package'],
     notify                 => Class['nginx::service'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class nginx::params {
 
   $nx_conf_dir                = '/etc/nginx'
   $nx_conf_template           = 'nginx/conf.d/nginx.conf.erb'
+  $nx_proxy_conf_template     = 'nginx/conf.d/proxy.conf.erb'
   $nx_confd_purge             = false
   $nx_vhost_purge             = false
   $nx_worker_processes        = 1


### PR DESCRIPTION
I want to use the module, without forking it. Currently I have to do so, because the nginx.conf-template is not configurable.

This small pull request adds a conf_template-variable vor nginx-class and nginx-config-class.
