### PR TITLE
remove unknown parameter

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -20,7 +20,6 @@ http {
   sendfile    <%= scope.lookupvar('nginx::params::nx_sendfile')%>;
 
   server_tokens <%= @server_tokens %>;
-  <% if scope.lookupvar('nginx::params::nx_tcp_nopush') == 'on' %>tcp_nopush on;<% end %>
 
   types_hash_max_size <%= scope.lookupvar('nginx::params::nx_types_hash_max_size')%>;
   types_hash_bucket_size <%= scope.lookupvar('nginx::params::nx_types_hash_bucket_size')%>;


### PR DESCRIPTION
The parameter nginx::params::nx_tcp_nopush is never defined.
