### PR TITLE
fix missing ensure on concat::fragment resources

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -270,6 +270,7 @@ define nginx::resource::location (
   ## Create stubs for vHost File Fragment Pattern
   if ($ssl_only != true) {
     concat::fragment { "${vhost_sanitized}-${priority}-${location_sanitized}":
+      ensure  => present,
       target  => $config_file,
       content => $content_real,
       order   => "${priority}",
@@ -280,6 +281,7 @@ define nginx::resource::location (
   if ($ssl == true) {
     $ssl_priority = $priority + 300
     concat::fragment {"${vhost_sanitized}-${ssl_priority}-${location_sanitized}-ssl":
+      ensure  => present,
       target  => $config_file,
       content => $content_real,
       order   => "${ssl_priority}",

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -125,6 +125,7 @@ define nginx::resource::mailhost (
 
   if ($listen_port != $ssl_port) {
     concat::fragment { "${name}-header":
+      ensure  => present,
       target  => $config_file,
       content => template('nginx/mailhost/mailhost.erb'),
       order   => '001',
@@ -134,6 +135,7 @@ define nginx::resource::mailhost (
   # Create SSL File Stubs if SSL is enabled
   if ($ssl) {
     concat::fragment { "${name}-ssl":
+      ensure  => present,
       target  => $config_file,
       content => template('nginx/mailhost/mailhost_ssl.erb'),
       order   => '700',

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -423,6 +423,7 @@ define nginx::resource::vhost (
 
   if ($listen_port != $ssl_port) {
     concat::fragment { "${name_sanitized}-header":
+      ensure  => present,
       target  => $config_file,
       content => template('nginx/vhost/vhost_header.erb'),
       order   => '001',
@@ -432,6 +433,7 @@ define nginx::resource::vhost (
   # Create a proper file close stub.
   if ($listen_port != $ssl_port) {
     concat::fragment { "${name_sanitized}-footer":
+      ensure  => present,
       target  => $config_file,
       content => template('nginx/vhost/vhost_footer.erb'),
       order   => '699',


### PR DESCRIPTION
concat::fragement should define ensure parameter. We should not rely on default value
