### PR TITLE
Add additional config to the locations resource and fix set_header in vhost resource

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -20,8 +20,14 @@
 #   [*proxy*]                - Proxy server(s) for a location to connect to.
 #     Accepts a single value, can be used in conjunction with
 #     nginx::resource::upstream
+#   [*proxy_redirect*]       - sets the text, which must be changed in
+#     response-header "Location" and "Refresh" in the response of the proxied
+#     server.
 #   [*proxy_read_timeout*]   - Override the default the proxy read timeout
 #     value of 90 seconds
+#   [*proxy_connect_timeout*] - Override the default the proxy connect timeout
+#     value of 90 seconds
+#   [*proxy_set_header*]     - Array of vhost headers to set
 #   [*fastcgi*]              - location of fastcgi (host:port)
 #   [*fastcgi_params*]       - optional alternative fastcgi_params file to use
 #   [*fastcgi_script*]       - optional SCRIPT_FILE parameter
@@ -105,7 +111,10 @@ define nginx::resource::location (
     'index.htm',
     'index.php'],
   $proxy                = undef,
+  $proxy_redirect       = $nginx::params::nx_proxy_redirect,
   $proxy_read_timeout   = $nginx::params::nx_proxy_read_timeout,
+  $proxy_connect_timeout = $nginx::params::nx_proxy_connect_timeout,
+  $proxy_set_header     = $nginx::params::nx_proxy_set_header,
   $fastcgi              = undef,
   $fastcgi_params       = '/etc/nginx/fastcgi_params',
   $fastcgi_script       = undef,
@@ -155,7 +164,10 @@ define nginx::resource::location (
   if ($proxy != undef) {
     validate_string($proxy)
   }
+  validate_string($proxy_redirect)
   validate_string($proxy_read_timeout)
+  validate_string($proxy_connect_timeout)
+  validate_array($proxy_set_header)
   if ($fastcgi != undef) {
     validate_string($fastcgi)
   }

--- a/templates/vhost/vhost_location_proxy.erb
+++ b/templates/vhost/vhost_location_proxy.erb
@@ -33,6 +33,11 @@
 <% end -%>
     proxy_pass          <%= @proxy %>;
     proxy_read_timeout  <%= @proxy_read_timeout %>;
+    proxy_connect_timeout  <%= @proxy_connect_timeout %>;
+    proxy_redirect  <%= @proxy_redirect %>;
+<% @proxy_set_header.each do |header| -%>
+    proxy_set_header        <%= header %>;
+<% end -%>
 <% if @proxy_method -%>
     proxy_method        <%= @proxy_method %>;
 <% end -%>


### PR DESCRIPTION
Following parameters where added to the location resource.  These
already existed in the vhost resource so the same logic and defaults
where used
- proxy_set_header
- proxy_connect_timeout
- proxy_redirect

The set_header variable expectes a hash of headers to set.  Puppet is
does not allow hash keys to have a hyphen in the name or begin with an
capital leter.  As (i belive) all headers start with a
capital letter this limitation means you can not set any header.
further more the majority of headers also contain an underscore.

I have included a patch which allows a key to be passed all in lower case and
use underscores in place of hyphens.  The template will then make the
conversion.  e.g. to set the header Accept-Charset: utf-8.  one would
pass

set_header => { accept_charset => 'utf-8' }
