### PR TITLE
Added sendfile support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,6 +38,7 @@ class nginx::config(
   $http_access_log        = $nginx::params::nx_http_access_log,
   $proxy_buffer_size      = $nginx::params::nx_proxy_buffer_size,
   $gzip                   = $nginx::params::nx_gzip,
+  $sendfile               = $nginx::params::nx_sendfile,
   $conf_template          = $nginx::params::nx_conf_template,
   $proxy_conf_template    = $nginx::params::nx_proxy_conf_template,
   $proxy_redirect         = $nginx::params::nx_proxy_redirect,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,6 +113,7 @@ class nginx (
   }
   validate_string($nginx_error_log)
   validate_string($http_access_log)
+  validate_string($sendfile)
   validate_hash($nginx_upstreams)
   validate_hash($nginx_vhosts)
   validate_hash($nginx_locations)
@@ -149,6 +150,7 @@ class nginx (
     nginx_error_log        => $nginx_error_log,
     http_access_log        => $http_access_log,
     gzip                   => $gzip,
+    sendfile               => $sendfile,
     conf_template          => $conf_template,
     proxy_conf_template    => $proxy_conf_template,
     proxy_redirect         => $proxy_redirect,

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -17,7 +17,7 @@ http {
 
   access_log  <%= @http_access_log %>;
 
-  sendfile    <%= scope.lookupvar('nginx::params::nx_sendfile')%>;
+  sendfile    <%= @sendfile %>;
 
   server_tokens <%= @server_tokens %>;
 


### PR DESCRIPTION
There seems to be an issue in nginx on VirtualBox/Vagrant when sendfile is set to 'on'. This PR simply allows the user to override the default sendfile setting like this:

``` puppet
class { 'nginx': 
    sendfile             => 'off',
    proxy_http_version   => '1.1',
    proxy_set_header     => [
        'Upgrade $http_upgrade',
        'Connection "upgrade"',
        'Host $host'
    ]
}
```
