### PR TITLE
Added nginx::resource::mailhost to be configured via hiera

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -111,6 +111,13 @@ nginx::nginx_locations:
     location: /userContent
     vhost: www.puppetlabs.com
     www_root: /var/www/html
+nginx::nginx_mailhosts:
+  'smtp':
+    auth_http: server2.example/cgi-bin/auth
+    protocol: smtp
+    listen_port: 587
+    ssl_port: 465
+    starttls: only
 ```
 
 ## Nginx with precompiled Passenger

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,7 @@ class nginx (
   $nginx_vhosts           = {},
   $nginx_upstreams        = {},
   $nginx_locations        = {},
+  $nginx_mailhosts        = {},
   $manage_repo            = $nginx::params::manage_repo,
 ) inherits nginx::params {
 
@@ -115,6 +116,7 @@ class nginx (
   validate_hash($nginx_upstreams)
   validate_hash($nginx_vhosts)
   validate_hash($nginx_locations)
+  validate_hash($nginx_mailhosts)
   validate_bool($manage_repo)
 
   class { 'nginx::package':
@@ -161,6 +163,7 @@ class nginx (
   create_resources('nginx::resource::upstream', $nginx_upstreams)
   create_resources('nginx::resource::vhost', $nginx_vhosts)
   create_resources('nginx::resource::location', $nginx_locations)
+  create_resources('nginx::resource::mailhost', $nginx_mailhosts)
 
   # Allow the end user to establish relationships to the "main" class
   # and preserve the relationship to the implementation classes through

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -5,7 +5,8 @@ describe 'nginx' do
     {
       :nginx_upstreams => { 'upstream1' => { 'members' => ['localhost:3000']} },
       :nginx_vhosts    => { 'test2.local' => { 'www_root' => '/' } },
-      :nginx_locations => { 'test2.local' => { 'vhost' => 'test2.local', 'www_root' => '/'} }
+      :nginx_locations => { 'test2.local' => { 'vhost' => 'test2.local', 'www_root' => '/'} },
+      :nginx_mailhosts => { 'smtp.test2.local' => { 'auth_http' => 'server2.example/cgi-bin/auth', 'protocol' => 'smtp', 'listen_port' => 587} }
     }
   end
 
@@ -23,6 +24,7 @@ describe 'nginx' do
     it { should contain_nginx__resource__upstream("upstream1") }
     it { should contain_nginx__resource__vhost("test2.local") }
     it { should contain_nginx__resource__location("test2.local") }
+    it { should contain_nginx__resource__mailhost("smtp.test2.local") }
   end
 
   context "Debian OS" do


### PR DESCRIPTION
There is a slight chance the SSL 'concat::fragment' of the mailhost and
virtualhost are get in the way, if the name is declared the same.
