### PR TITLE
fix location sanitizing with parser 'future'

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -243,7 +243,7 @@ define nginx::resource::location (
   $config_file = "${nginx::config::nx_conf_dir}/sites-available/${vhost_sanitized}.conf"
 
   $location_sanitized_tmp = regsubst($location, '\/', '_', 'G')
-  $location_sanitized = regsubst($location_sanitized_tmp, '\\', '_', 'G')
+  $location_sanitized = regsubst($location_sanitized_tmp, "\\\\", '_', 'G')
 
   ## Check for various error conditions
   if ($vhost == undef) {


### PR DESCRIPTION
With parser 'future', a '\' counts as one backslash whereas with
parser 'current' it's two. Therefore with 'future' only one gets passed
to regsubst which in turn aborts with

 Error: regsubst(): Bad regular expression `\'

Probably the 'current' behaviour is a bug, as
http://docs.puppetlabs.com/puppet/latest/reference/lang_datatypes.html#single-quoted-strings
states:

 When a literal double backslash is intended, a quadruple backslash must
 be used.

Yet, fixing either parser will break code so test here if '\' is two
characters or one. Clumsy, but works.
