### PR TITLE
nginx::package::debian: only include ::apt when needed

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -29,9 +29,9 @@ class nginx::package::debian(
 
   anchor { 'nginx::apt_repo' : }
 
-  include '::apt'
-
   if $manage_repo {
+    include '::apt'
+
     case $package_source {
       'nginx': {
         apt::source { 'nginx':


### PR DESCRIPTION
Only include ::apt when $manage_repo is true, it's not needed otherwise.
