### PR TITLE
Adding autoindex to location alias

### DIFF
--- a/templates/vhost/vhost_location_alias.erb
+++ b/templates/vhost/vhost_location_alias.erb
@@ -22,6 +22,9 @@
 <% end -%>
 <% end -%><% end -%>
     alias      <%= @location_alias %>;
+<% if defined? @autoindex -%>
+    autoindex <%= @autoindex %>;
+<% end -%>
 <% if @location_cfg_append -%><% @location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
 <% if value.is_a?(Hash) -%><% value.each do |subkey,subvalue| -%>
 <% Array(subvalue).each do |asubvalue| -%>


### PR DESCRIPTION
Fix for issue #304

I don't see any reason why autoindex shouldn't be used with alias
directive, nor does jaybe on #nginx.
