### PR TITLE
Use first server name for non-www redirects to prevent issues with naming of vhosts within defined types.

### DIFF
--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -19,7 +19,7 @@ include <%= file %>;
 <% if @rewrite_www_to_non_www -%>
 server {
   listen       <%= @listen_ip %>:<%= @listen_port %>;
-  server_name  www.<%= @name.gsub(/^www\./, '') %>;
-  return       301 http://<%= @name.gsub(/^www\./, '') %>$uri;
+  server_name  www.<%= @server_name[0].gsub(/^www\./, '') %>;
+  return       301 http://<%= @server_name[0].gsub(/^www\./, '') %>$uri;
 }
 <% end -%>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -4,7 +4,7 @@ server {
 <% if @ipv6_enable && (defined? @ipaddress6) %>
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
 <% end %>
-  server_name           <%= @rewrite_www_to_non_www ? @name.gsub(/^www\./, '') : @server_name.join(" ") %>;
+  server_name           <%= @rewrite_www_to_non_www ? @server_name[0].gsub(/^www\./, '') : @server_name.join(" ") %>;
 <% if defined? @auth_basic -%>
   auth_basic           "<%= @auth_basic %>";
 <% end -%>

--- a/templates/vhost/vhost_ssl_footer.erb
+++ b/templates/vhost/vhost_ssl_footer.erb
@@ -27,7 +27,7 @@ include <%= file %>;
 <% if @rewrite_www_to_non_www -%>
 server {
   listen       <%= @listen_ip %>:<%= @ssl_port %> ssl;
-  server_name  www.<%= @name.gsub(/^www\./, '') %>;
-  return       301 https://<%= @name.gsub(/^www\./, '') %>$uri;
+  server_name  www.<%= @server_name[0].gsub(/^www\./, '') %>;
+  return       301 https://<%= @server_name[0].gsub(/^www\./, '') %>$uri;
 }
 <% end %>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -3,7 +3,7 @@ server {
   <% if @ipv6_enable && (defined? @ipaddress6) %>
   listen [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
   <% end %>
-  server_name  <%= @rewrite_www_to_non_www ? @name.gsub(/^www\./, '') : @server_name.join(" ") %>;
+  server_name  <%= @rewrite_www_to_non_www ? @server_name[0].gsub(/^www\./, '') : @server_name.join(" ") %>;
 
   ssl on;
 


### PR DESCRIPTION
If I were to define a type named `reverse_proxy_vhost` and name the nginx vhosts inside `reverse_proxy_${name}` while providing custom values for `server_name` and setting `rewrite_www_to_non_www` to true, it would result in something like `reverse_proxy_mydomain.net` as the server name.

This PR resolves that.
