### PR TITLE
Fixing hardcoded path for fastcgi_params in manifests/resource/location.pp

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -116,7 +116,7 @@ define nginx::resource::location (
   $proxy_connect_timeout = $nginx::params::nx_proxy_connect_timeout,
   $proxy_set_header     = $nginx::params::nx_proxy_set_header,
   $fastcgi              = undef,
-  $fastcgi_params       = '/etc/nginx/fastcgi_params',
+  $fastcgi_params       = "${nginx::params::nx_conf_dir}/fastcgi_params",
   $fastcgi_script       = undef,
   $fastcgi_split_path   = undef,
   $ssl                  = false,
@@ -271,8 +271,8 @@ define nginx::resource::location (
     $content_real = template('nginx/vhost/vhost_location_empty.erb')
   }
 
-  if $fastcgi != undef and !defined(File['/etc/nginx/fastcgi_params']) {
-    file { '/etc/nginx/fastcgi_params':
+  if $fastcgi != undef and !defined(File["${fastcgi_params}"]) {
+    file { "${fastcgi_params}":
       ensure  => present,
       mode    => '0770',
       content => template('nginx/vhost/fastcgi_params.erb'),


### PR DESCRIPTION
Changed the hard coded path for fastcgi_params to make use of nx_conf_dir
which is provided by manifests/params.pp
