### PR TITLE
Enabled undef for service where we dont want puppet control service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -23,11 +23,18 @@ class nginx::service(
     running => true,
     absent => false,
     stopped => false,
+    'undef' => undef,
     default => true,
   }
 
+  if $service_ensure == 'undef' {
+    $service_ensure_real = undef
+  } else {
+    $service_ensure_real = $service_ensure
+  }
+
   service { 'nginx':
-    ensure     => $service_ensure,
+    ensure     => $service_ensure_real,
     enable     => $service_enable,
     hasstatus  => true,
     hasrestart => true,


### PR DESCRIPTION
In cases, where nginx is managed within cluster by pacemaker, we need this module not to manage the service by default, although we would like to send it restart notifications on config changes. Therefore 'undef' string can be send, which will then get evaluated and properly send to service class not to manage it.
