### PR TITLE
make ssl listen option configurable

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -137,6 +137,7 @@ define nginx::resource::vhost (
   $ipv6_listen_options    = 'default ipv6only=on',
   $add_header             = undef,
   $ssl                    = false,
+  $ssl_listen_option      = true,
   $ssl_cert               = undef,
   $ssl_dhparam            = undef,
   $ssl_key                = undef,
@@ -219,6 +220,7 @@ define nginx::resource::vhost (
   if ($ssl_cert != undef) {
     validate_string($ssl_cert)
   }
+  validate_bool($ssl_listen_option)
   if ($ssl_dhparam != undef) {
     validate_string($ssl_dhparam)
   }

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -1,5 +1,5 @@
 server {
-  listen       <%= @listen_ip %>:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+  listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
   <% if @ipv6_enable && (defined? @ipaddress6) %>
   listen [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
   <% end %>


### PR DESCRIPTION
listen options can only occur once per ip:port combination. Running more than one ssl vhost on the same ip:port combination isn't possible right now.

This PR adds a new parameter 'ssl_listen_option'. With this change, it's possible to disable the ssl listen option on specific vhosts.
