### PR TITLE
Fix all hardcoded /etc/nginx paths

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -133,7 +133,7 @@ class nginx::config(
     }
   }
 
-  file { '/etc/nginx/sites-enabled/default':
+  file { "${nginx::params::nx_conf_dir}/sites-enabled/default":
     ensure => absent,
   }
 

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -116,7 +116,7 @@ define nginx::resource::location (
   $proxy_connect_timeout = $nginx::config::proxy_connect_timeout,
   $proxy_set_header     = $nginx::config::proxy_set_header,
   $fastcgi              = undef,
-  $fastcgi_params       = '/etc/nginx/fastcgi_params',
+  $fastcgi_params       = "${nginx::params::nx_conf_dir}/fastcgi_params",
   $fastcgi_script       = undef,
   $fastcgi_split_path   = undef,
   $ssl                  = false,
@@ -271,12 +271,12 @@ define nginx::resource::location (
     $content_real = template('nginx/vhost/vhost_location_empty.erb')
   }
 
-  if $fastcgi != undef and !defined(File['/etc/nginx/fastcgi_params']) {
-    file { '/etc/nginx/fastcgi_params':
+  if ($fastcgi != undef) {
+    ensure_resource('file', "${nginx::params::nx_conf_dir}/fastcgi_params", {
       ensure  => present,
       mode    => '0770',
       content => template('nginx/vhost/fastcgi_params.erb'),
-    }
+    })
   }
 
   ## Create stubs for vHost File Fragment Pattern

--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -39,9 +39,9 @@
 #    upstream_cfg_prepend => $my_config,
 #  }
 define nginx::resource::upstream (
-  $members = undef,
-  $ensure = 'present',
-  $upstream_cfg_prepend = undef,
+  $members               = undef,
+  $ensure                = 'present',
+  $upstream_cfg_prepend  = undef,
   $upstream_fail_timeout = '10s',
 ) {
 
@@ -60,7 +60,7 @@ define nginx::resource::upstream (
     mode  => '0644',
   }
 
-  concat { "/etc/nginx/conf.d/${name}-upstream.conf":
+  concat { "${nginx::params::nx_conf_dir}/conf.d/${name}-upstream.conf":
     ensure  => $ensure ? {
       'absent' => absent,
       'file'   => present,
@@ -71,7 +71,7 @@ define nginx::resource::upstream (
 
   # Uses: $name, $upstream_cfg_prepend
   concat::fragment { "${name}_upstream_header":
-    target  => "/etc/nginx/conf.d/${name}-upstream.conf",
+    target  => "${nginx::params::nx_conf_dir}/conf.d/${name}-upstream.conf",
     order   => 10,
     content => template('nginx/conf.d/upstream_header.erb'),
   }
@@ -79,7 +79,7 @@ define nginx::resource::upstream (
   if $members != undef {
     # Uses: $members, $upstream_fail_timeout
     concat::fragment { "${name}_upstream_members":
-      target  => "/etc/nginx/conf.d/${name}-upstream.conf",
+      target  => "${nginx::params::nx_conf_dir}/conf.d/${name}-upstream.conf",
       order   => 50,
       content => template('nginx/conf.d/upstream_members.erb'),
     }
@@ -89,7 +89,7 @@ define nginx::resource::upstream (
   }
 
   concat::fragment { "${name}_upstream_footer":
-    target  => "/etc/nginx/conf.d/${name}-upstream.conf",
+    target  => "${nginx::params::nx_conf_dir}/conf.d/${name}-upstream.conf",
     order   => 90,
     content => "}\n",
   }

--- a/manifests/resource/upstream/member.pp
+++ b/manifests/resource/upstream/member.pp
@@ -41,7 +41,7 @@ define nginx::resource::upstream::member (
 
   # Uses: $server, $port, $upstream_fail_timeout
   concat::fragment { "${upstream}_upstream_member_${name}":
-    target  => "/etc/nginx/conf.d/${upstream}-upstream.conf",
+    target  => "${nginx::params::nx_conf_dir}/conf.d/${upstream}-upstream.conf",
     order   => 40,
     content => template('nginx/conf.d/upstream_member.erb'),
   }

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -161,7 +161,7 @@ define nginx::resource::vhost (
   $proxy_set_body         = undef,
   $resolver               = [],
   $fastcgi                = undef,
-  $fastcgi_params         = '/etc/nginx/fastcgi_params',
+  $fastcgi_params         = "${nginx::params::nx_conf_dir}/fastcgi_params",
   $fastcgi_script         = undef,
   $index_files            = [
     'index.html',
@@ -454,12 +454,12 @@ define nginx::resource::vhost (
       location_custom_cfg_append => $location_custom_cfg_append }
   }
 
-  if $fastcgi != undef and !defined(File['/etc/nginx/fastcgi_params']) {
-    file { '/etc/nginx/fastcgi_params':
+  if ($fastcgi != undef) {
+    ensure_resource('file', "${nginx::params::nx_conf_dir}/fastcgi_params", {
       ensure  => present,
       mode    => '0770',
       content => template('nginx/vhost/fastcgi_params.erb'),
-    }
+    })
   }
 
   if ($listen_port != $ssl_port) {


### PR DESCRIPTION
use nginx::params::nx_conf_dir instead of hardcoded /etc/nginx
