### PR TITLE
use 'return' over 'rewrite'

### DIFF
--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -232,9 +232,9 @@ describe 'nginx::resource::vhost' do
           :attr  => 'rewrite_www_to_non_www',
           :value => true,
           :match => [
-            '  listen                *:80;',
-            '  server_name           www.rspec.example.com;',
-            '  rewrite               ^ http://rspec.example.com$uri permanent;',
+            '  listen       *:80;',
+            '  server_name  www.rspec.example.com;',
+            '  return       301 http://rspec.example.com$uri;',
           ],
         },
         {
@@ -242,9 +242,9 @@ describe 'nginx::resource::vhost' do
           :attr     => 'rewrite_www_to_non_www',
           :value    => false,
           :notmatch => [
-            /  listen                \*:80;/,
-            /  server_name           www\.rspec\.example\.com;/,
-            /  rewrite               \^ http:\/\/rspec\.example\.com\$uri permanent;/,
+            %r|  listen       \*:80;|,
+            %r|  server_name  www\.rspec\.example\.com;|,
+            %r|  return       301 http://rspec\.example\.com\$uri;|
           ],
         },
       ].each do |param|
@@ -476,9 +476,9 @@ describe 'nginx::resource::vhost' do
           :attr  => 'rewrite_www_to_non_www',
           :value => true,
           :match => [
-            '  listen                *:443 ssl;',
-            '  server_name           www.rspec.example.com;',
-            '  rewrite               ^ https://rspec.example.com$uri permanent;',
+            '  listen       *:443 ssl;',
+            '  server_name  www.rspec.example.com;',
+            '  return       301 https://rspec.example.com$uri;',
           ],
         },
         {
@@ -486,9 +486,9 @@ describe 'nginx::resource::vhost' do
           :attr     => 'rewrite_www_to_non_www',
           :value    => false,
           :notmatch => [
-            /  listen                \*:443 ssl;/,
-            /  server_name           www\.rspec\.example\.com;/,
-            /  rewrite               \^ https:\/\/rspec\.example\.com\$uri permanent;/,
+            %r|  listen       \*:443 ssl;|,
+            %r|  server_name  www\.rspec\.example\.com;|,
+            %r|  return       301 https://rspec\.example\.com\$uri;|
           ],
         },
       ].each do |param|

--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -18,8 +18,8 @@ include <%= file %>;
 }
 <% if @rewrite_www_to_non_www -%>
 server {
-  listen                <%= @listen_ip %>:<%= @listen_port %>;
-  server_name           www.<%= @name.gsub(/^www\./, '') %>;
-  rewrite               ^ http://<%= @name.gsub(/^www\./, '') %>$uri permanent;
+  listen       <%= @listen_ip %>:<%= @listen_port %>;
+  server_name  www.<%= @name.gsub(/^www\./, '') %>;
+  return       301 http://<%= @name.gsub(/^www\./, '') %>$uri;
 }
 <% end -%>

--- a/templates/vhost/vhost_ssl_footer.erb
+++ b/templates/vhost/vhost_ssl_footer.erb
@@ -26,8 +26,8 @@ include <%= file %>;
 }
 <% if @rewrite_www_to_non_www -%>
 server {
-  listen                <%= @listen_ip %>:<%= @ssl_port %> ssl;
-  server_name           www.<%= @name.gsub(/^www\./, '') %>;
-  rewrite               ^ https://<%= @name.gsub(/^www\./, '') %>$uri permanent;
+  listen       <%= @listen_ip %>:<%= @ssl_port %> ssl;
+  server_name  www.<%= @name.gsub(/^www\./, '') %>;
+  return       301 https://<%= @name.gsub(/^www\./, '') %>$uri;
 }
 <% end %>


### PR DESCRIPTION
use return instead of rewrite for simple redirects (e.g., www -> naked domain)
see: http://nginx.org/en/docs/http/converting_rewrite_rules.html
