### PR TITLE
Always set the `root` parameter in `nginx::vhost` resources.

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -432,10 +432,8 @@ define nginx::resource::vhost (
       notify                => Class['nginx::service'],
       rewrite_rules         => $rewrite_rules,
     }
-    $root = undef
-  } else {
-    $root = $www_root
   }
+  $root = $www_root
 
   # Support location_cfg_prepend and location_cfg_append on default location created by vhost
   if $location_cfg_prepend {

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -145,10 +145,10 @@ describe 'nginx::resource::vhost' do
           :match => '  root /;',
         },
         {
-          :title    => 'should not set root',
+          :title    => 'should set root',
           :attr     => 'use_default_location',
           :value    => true,
-          :notmatch => /  root \/;/,
+          :match    => '  root /;',
         },
         {
           :title => 'should set proxy_set_header',
@@ -417,7 +417,7 @@ describe 'nginx::resource::vhost' do
           :title    => 'should not set root',
           :attr     => 'use_default_location',
           :value    => true,
-          :notmatch => /  root \/;/,
+          :match    => '  root /;',
         },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do


### PR DESCRIPTION
The `root` parameter should always be set to `$www_root`, even if `use_default_location` is set to true. This is a lot easier than the alternative of explicitly specifying `www_root` in all location blocks.
