### PR TITLE
new raw_prepend / raw_append feature for vhosts & locations

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -43,6 +43,12 @@
 #     for this location
 #   [*stub_status*]          - If true it will point configure module
 #     stub_status to provide nginx stats on location
+#   [*raw_prepend*]          - A single string, or an array of strings to
+#     prepend to the location directive (after custom_cfg directives). NOTE:
+#     YOU are responsible for a semicolon on each line that requires one.
+#   [*raw_append*]           - A single string, or an array of strings to
+#     append to the location directive (after custom_cfg directives). NOTE:
+#     YOU are responsible for a semicolon on each line that requires one.
 #   [*location_custom_cfg*]  - Expects a hash with custom directives, cannot
 #     be used with other location types (proxy, fastcgi, root, or stub_status)
 #   [*location_cfg_prepend*] - Expects a hash with extra directives to put
@@ -129,6 +135,8 @@ define nginx::resource::location (
   $location_deny        = undef,
   $option               = undef,
   $stub_status          = undef,
+  $raw_prepend          = undef,
+  $raw_append           = undef,
   $location_custom_cfg  = undef,
   $location_cfg_prepend = undef,
   $location_cfg_append  = undef,
@@ -200,6 +208,20 @@ define nginx::resource::location (
   }
   if ($stub_status != undef) {
     validate_bool($stub_status)
+  }
+  if ($raw_prepend != undef) {
+    if (is_array($raw_prepend)) {
+      validate_array($raw_prepend)
+    } else {
+      validate_string($raw_prepend)
+    }
+  }
+  if ($raw_append != undef) {
+    if (is_array($raw_append)) {
+      validate_array($raw_append)
+    } else {
+      validate_string($raw_append)
+    }
   }
   if ($location_custom_cfg != undef) {
     validate_hash($location_custom_cfg)

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -90,6 +90,18 @@
 #   [*auth_basic_user_file*]    - This directive sets the htpasswd filename for
 #     the authentication realm.
 #   [*client_max_body_size*]    - This directive sets client_max_body_size.
+#   [*raw_prepend*]            - A single string, or an array of strings to
+#     prepend to the server directive (after cfg prepend directives). NOTE:
+#     YOU are responsible for a semicolon on each line that requires one.
+#   [*raw_append*]             - A single string, or an array of strings to
+#     append to the server directive (after cfg append directives). NOTE:
+#     YOU are responsible for a semicolon on each line that requires one.
+#   [*location_raw_prepend*]          - A single string, or an array of strings
+#     to prepend to the location directive (after custom_cfg directives). NOTE:
+#     YOU are responsible for a semicolon on each line that requires one.
+#   [*location_raw_append*]           - A single string, or an array of strings
+#     to append to the location directive (after custom_cfg directives). NOTE:
+#     YOU are responsible for a semicolon on each line that requires one.
 #   [*vhost_cfg_append*]        - It expects a hash with custom directives to
 #     put after everything else inside vhost
 #   [*vhost_cfg_prepend*]       - It expects a hash with custom directives to
@@ -183,6 +195,10 @@ define nginx::resource::vhost (
   $auth_basic             = undef,
   $auth_basic_user_file   = undef,
   $client_max_body_size   = undef,
+  $raw_prepend            = undef,
+  $raw_append             = undef,
+  $location_raw_prepend   = undef,
+  $location_raw_append    = undef,
   $vhost_cfg_prepend      = undef,
   $vhost_cfg_append       = undef,
   $vhost_cfg_ssl_prepend      = undef,
@@ -286,6 +302,34 @@ define nginx::resource::vhost (
   validate_bool($rewrite_www_to_non_www)
   if ($rewrite_to_https != undef) {
     validate_bool($rewrite_to_https)
+  }
+  if ($raw_prepend != undef) {
+    if (is_array($raw_prepend)) {
+      validate_array($raw_prepend)
+    } else {
+      validate_string($raw_prepend)
+    }
+  }
+  if ($raw_append != undef) {
+    if (is_array($raw_append)) {
+      validate_array($raw_append)
+    } else {
+      validate_string($raw_append)
+    }
+  }
+  if ($location_raw_prepend != undef) {
+    if (is_array($location_raw_prepend)) {
+      validate_array($location_raw_prepend)
+    } else {
+      validate_string($location_raw_prepend)
+    }
+  }
+  if ($location_raw_append != undef) {
+    if (is_array($location_raw_append)) {
+      validate_array($location_raw_append)
+    } else {
+      validate_string($location_raw_append)
+    }
   }
   if ($location_custom_cfg != undef) {
     validate_hash($location_custom_cfg)
@@ -431,6 +475,8 @@ define nginx::resource::vhost (
       location_custom_cfg   => $location_custom_cfg,
       notify                => Class['nginx::service'],
       rewrite_rules         => $rewrite_rules,
+      raw_prepend           => $location_raw_prepend,
+      raw_append            => $location_raw_append
     }
     $root = undef
   } else {

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -34,7 +34,7 @@ describe 'nginx::resource::location' do
       it { should_not contain_file("/etc/nginx/rspec-test_htpasswd") }
     end
 
-    describe "vhost_location_proxy template content" do
+    describe "vhost/location_header template content" do
       [
         {
           :title => 'should set the location',
@@ -55,13 +55,30 @@ describe 'nginx::resource::location' do
           :match => '    internal;'
         },
         {
+          :title => 'should set location_allow',
+          :attr  => 'location_allow',
+          :value => %w( 127.0.0.1 10.0.0.1 ),
+          :match => [
+            '    allow 127.0.0.1;',
+            '    allow 10.0.0.1;',
+          ],
+        },
+        {
+          :title => 'should set location_deny',
+          :attr  => 'location_deny',
+          :value => %w( 127.0.0.1 10.0.0.1 ),
+          :match => [
+            '    deny 127.0.0.1;',
+            '    deny 10.0.0.1;',
+          ],
+        },
+        {
           :title => 'should contain ordered prepended directives',
           :attr  => 'location_cfg_prepend',
-          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3',
+          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'],
                       'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
                                   'subtest2' => '"sub test value2"' } },
           :match => [
-            '    allow test value 3;',
             '    test1 test value 1;',
             '    test2 test value 2a;',
             '    test2 test value 2b;',
@@ -71,56 +88,190 @@ describe 'nginx::resource::location' do
           ],
         },
         {
-          :title => 'should set proxy_cache',
-          :attr  => 'proxy_cache',
-          :value => 'value',
-          :match => '    proxy_cache         value;',
+          :title => 'should contain custom prepended directives',
+          :attr  => 'location_custom_cfg_prepend',
+          :value => { 'test1' => 'bar', 'test2' => ['foobar', 'barbaz'],
+                      'test3' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
+                                  'subtest2' => '"sub test value2"' } },
+          :regexp_match => [
+            /    test1 bar;/,
+            /    test2 foobar;/,
+            /    test2 barbaz;/,
+            /    test4 subtest1 "sub test value1a";/,
+            /    test4 subtest1 "sub test value1b";/,
+            /    test4 subtest2 "sub test value2";/,
+          ],
         },
         {
-          :title    => 'should not set proxy_cache',
-          :attr     => 'proxy_cache',
-          :value    => false,
-          :notmatch => /proxy_cache/
+          :title => 'should contain raw_prepend directives',
+          :attr  => 'raw_prepend',
+          :value => [
+            'if (a) {',
+            '  b;',
+            '}'
+          ],
+          :regexp_match => /^\s+if \(a\) {\n\s++b;\n\s+\}/,
         },
-        {
-          :title => 'should set proxy_method',
-          :attr  => 'proxy_method',
-          :value => 'value',
-          :match => '    proxy_method        value;',
-        },
-        {
-          :title => 'should set proxy_set_body',
-          :attr  => 'proxy_set_body',
-          :value => 'value',
-          :match => '    proxy_set_body      value;',
-        },
-        {
-          :title => 'should set proxy_pass',
-          :attr  => 'proxy',
-          :value => 'value',
-          :match => '    proxy_pass          value;',
-        },
-        {
-          :title => 'should set proxy_read_timeout',
-          :attr  => 'proxy_read_timeout',
-          :value => 'value',
-          :match => '    proxy_read_timeout  value;',
-        },
+      ].each do |param|
+        context "when #{param[:attr]} is #{param[:value]}" do
+          let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
+          let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
+
+          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+
+          it param[:title] do
+            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            matches  = Array(param[:match])
+
+            if matches.all? { |m| m.is_a? Regexp }
+              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+            else
+              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              (lines & matches).should == matches
+            end
+
+            Array(param[:notmatch]).each do |item|
+              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+            end
+          end
+        end
+      end
+    end
+
+    describe "vhost/location_footer template content" do
+      [
         {
           :title => 'should contain ordered appended directives',
           :attr  => 'location_cfg_append',
-          :value => { 'test1' => ['test value 1a', 'test value 1b'], 'test2' => 'test value 2', 'allow' => 'test value 3',
+          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'],
                       'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
                                   'subtest2' => '"sub test value2"' } },
           :match => [
-            '    allow test value 3;',
-            '    test1 test value 1a;',
-            '    test1 test value 1b;',
-            '    test2 test value 2;',
+            '    test1 test value 1;',
+            '    test2 test value 2a;',
+            '    test2 test value 2b;',
             '    test4 subtest1 "sub test value1a";',
             '    test4 subtest1 "sub test value1b";',
             '    test4 subtest2 "sub test value2";',
           ],
+        },
+        {
+          :title => 'should contain custom appended directives',
+          :attr  => 'location_custom_cfg_append',
+          :value => { 'test1' => 'bar', 'test2' => ['foobar', 'barbaz'],
+                      'test3' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
+                                  'subtest2' => '"sub test value2"' } },
+          :regexp_match => [
+            /    test1 bar;/,
+            /    test2 foobar;/,
+            /    test2 barbaz;/,
+            /    test4 subtest1 "sub test value1a";/,
+            /    test4 subtest1 "sub test value1b";/,
+            /    test4 subtest2 "sub test value2";/,
+          ],
+        },
+        {
+          :title => 'should contain raw_append directives',
+          :attr  => 'raw_append',
+          :value => [
+            'if (a) {',
+            '  b;',
+            '}'
+          ],
+          :regexp_match => /^\s+if \(a\) {\n\s++b;\n\s+\}/,
+        },
+      ].each do |param|
+        context "when #{param[:attr]} is #{param[:value]}" do
+          let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
+          let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
+
+          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+
+          it param[:title] do
+            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            matches  = Array(param[:match])
+
+            if matches.all? { |m| m.is_a? Regexp }
+              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+            else
+              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              (lines & matches).should == matches
+            end
+
+            Array(param[:notmatch]).each do |item|
+              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+            end
+          end
+
+          it "should end with a closing brace" do
+            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            content = subject.resource('concat::fragment', fragment).send(:parameters)[:content]
+            (content.split("\n").reject {|l| l =~ /^(\s*#|$)/ }.last).strip.should == '}'
+          end
+        end
+      end
+    end
+
+    describe "vhost_location_alias template content" do
+      let :default_params do
+        { :location => 'location', :vhost => 'vhost1', :location_alias => 'value' }
+      end
+
+      context "when location_alias is 'value'" do
+        let :params do default_params end
+        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it "should set alias" do
+          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+                  with_content(/^[ ]+alias\s+value;/)
+        end
+      end
+
+      context "when autoindex is 'on'" do
+        let :params do default_params.merge({ :autoindex => 'on' }) end
+        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it "should set autoindex" do
+          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+                  with_content(/^[ ]+autoindex\s+on;/)
+        end
+      end
+
+      context "when autoindex is not set" do
+        let :params do default_params end
+        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it "should not set autoindex" do
+          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+                  without_content(/^[ ]+autoindex[^;]+;/)
+        end
+      end
+    end
+
+    describe "vhost_location_directory template content" do
+      let :default_params do
+        {
+          :location => 'location',
+          :www_root => '/var/www/root',
+          :vhost    => 'vhost1'
+        }
+      end
+
+      [
+        {
+          :title => 'should set www_root',
+          :attr  => 'www_root',
+          :value => '/',
+          :match => '    root  /;'
+        },
+        {
+          :title => 'should set try_file(s)',
+          :attr  => 'try_files',
+          :value => ['name1','name2'],
+          :match => '    try_files name1 name2;',
+        },
+        {
+          :title => 'should set index_file(s)',
+          :attr  => 'index_files',
+          :value => ['name1','name2'],
+          :match => '    index  name1 name2;',
         },
         {
           :title => 'should contain rewrite rules',
@@ -142,157 +293,73 @@ describe 'nginx::resource::location' do
           :value    => [],
           :notmatch => /rewrite/
         },
-      ].each do |param|
-        context "when #{param[:attr]} is #{param[:value]}" do
-          let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
-          let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
-
-          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
-          it param[:title] do
-            lines = subject.resource('concat::fragment', Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
-            Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
-            end
-          end
-        end
-      end
-
-      context "when proxy_cache_valid is 10m" do
-        let :params do {
-          :location => 'location',
-          :proxy => 'proxy_value',
-          :vhost => 'vhost1',
-          :proxy_cache => 'true',
-          :proxy_cache_valid => '10m',
-        } end
-
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).with_content(/proxy_cache_valid   10m;/) }
-      end
-    end
-
-    describe "vhost_location_alias template content" do
-      [
         {
-          :title => 'should set the location',
-          :attr  => 'location',
-          :value => 'my_location',
-          :match => '  location my_location {',
-        },
-        {
-          :title    => 'should not set internal',
-          :attr     => 'internal',
-          :value    => false,
-          :notmatch => /internal;/
-        },
-        {
-          :title => 'should set internal',
-          :attr  => 'internal',
-          :value => true,
-          :match => '    internal;'
-        },
-        {
-          :title => 'should contain ordered prepended directives',
-          :attr  => 'location_cfg_prepend',
-          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3',
-                      'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
-                                  'subtest2' => '"sub test value2"' } },
-          :match => [
-            '    allow test value 3;',
-            '    test1 test value 1;',
-            '    test2 test value 2a;',
-            '    test2 test value 2b;',
-            '    test4 subtest1 "sub test value1a";',
-            '    test4 subtest1 "sub test value1b";',
-            '    test4 subtest2 "sub test value2";',
-          ],
-        },
-        {
-          :title => 'should set alias',
-          :attr  => 'location_alias',
+          :title => 'should set auth_basic',
+          :attr  => 'auth_basic',
           :value => 'value',
-          :match => '    alias      value;',
+          :match => '    auth_basic           "value";',
         },
         {
-          :title => 'should contain ordered appended directives',
-          :attr  => 'location_cfg_append',
-          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3',
-                      'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
-                                  'subtest2' => '"sub test value2"' } },
-          :match => [
-            '    allow test value 3;',
-            '    test1 test value 1;',
-            '    test2 test value 2a;',
-            '    test2 test value 2b;',
-            '    test4 subtest1 "sub test value1a";',
-            '    test4 subtest1 "sub test value1b";',
-            '    test4 subtest2 "sub test value2";',
-          ],
+          :title => 'should set auth_basic_user_file',
+          :attr  => 'auth_basic_user_file',
+          :value => 'value',
+          :match => '    auth_basic_user_file value;',
         },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do
-          let :default_params do { :location => 'location', :location_alias => 'location_alias_value', :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
           it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
           it param[:title] do
-            lines = subject.resource('concat::fragment', Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            matches  = Array(param[:match])
+
+            if matches.all? { |m| m.is_a? Regexp }
+              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+            else
+              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              (lines & matches).should == matches
+            end
+
             Array(param[:notmatch]).each do |item|
               should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
           end
         end
       end
+
+      context "when autoindex is 'on'" do
+        let :params do default_params.merge({ :autoindex => 'on' }) end
+        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it "should set autoindex" do
+          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+                  with_content(/^[ ]+autoindex\s+on;/)
+        end
+      end
+
+      context "when autoindex is not set" do
+        let :params do default_params end
+        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it "should not set autoindex" do
+          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+                  without_content(/^[ ]+autoindex[^;]+;/)
+        end
+      end
     end
 
-    describe "vhost_location_stub_status template content" do
+    describe "vhost_location_empty template content" do
       [
         {
-          :title => 'should set the location',
-          :attr  => 'location',
-          :value => 'my_location',
-          :match => '  location my_location {',
-        },
-        {
-          :title    => 'should not set internal',
-          :attr     => 'internal',
-          :value    => false,
-          :notmatch => /internal;/
-        },
-        {
-          :title => 'should set internal',
-          :attr  => 'internal',
-          :value => true,
-          :match => '    internal;'
-        },
-        {
-          :title => 'should contain ordered prepended directives',
-          :attr  => 'location_cfg_prepend',
-          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3',
+          :title => 'should contain ordered config directives',
+          :attr  => 'location_custom_cfg',
+          :value => { 'test1' => ['test value 1a', 'test value 1b'], 'test2' => 'test value 2', 'allow' => 'test value 3',
                       'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
                                   'subtest2' => '"sub test value2"' } },
           :match => [
             '    allow test value 3;',
-            '    test1 test value 1;',
-            '    test2 test value 2a;',
-            '    test2 test value 2b;',
-            '    test4 subtest1 "sub test value1a";',
-            '    test4 subtest1 "sub test value1b";',
-            '    test4 subtest2 "sub test value2";',
-          ],
-        },
-        {
-          :title => 'should contain ordered appended directives',
-          :attr  => 'location_cfg_append',
-          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3',
-                      'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
-                                  'subtest2' => '"sub test value2"' } },
-          :match => [
-            '    allow test value 3;',
-            '    test1 test value 1;',
-            '    test2 test value 2a;',
-            '    test2 test value 2b;',
+            '    test1 test value 1a;',
+            '    test1 test value 1b;',
+            '    test2 test value 2;',
             '    test4 subtest1 "sub test value1a";',
             '    test4 subtest1 "sub test value1b";',
             '    test4 subtest2 "sub test value2";',
@@ -300,13 +367,21 @@ describe 'nginx::resource::location' do
         },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do
-          let :default_params do { :location => 'location', :stub_status => true, :vhost => 'vhost1' } end
+          let :default_params do { :location => 'location', :location_custom_cfg => {'test1'=>'value1'}, :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
           it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
           it param[:title] do
-            lines = subject.resource('concat::fragment', Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            matches  = Array(param[:match])
+
+            if matches.all? { |m| m.is_a? Regexp }
+              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+            else
+              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              (lines & matches).should == matches
+            end
+
             Array(param[:notmatch]).each do |item|
               should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
@@ -316,41 +391,15 @@ describe 'nginx::resource::location' do
     end
 
     describe "vhost_location_fastcgi template content" do
+      let :default_params do
+        {
+          :location => 'location',
+          :fastcgi  => 'localhost:9000',
+          :vhost    => 'vhost1'
+        }
+      end
+
       [
-        {
-          :title => 'should set the location',
-          :attr  => 'location',
-          :value => 'my_location',
-          :match => '  location my_location {',
-        },
-        {
-          :title    => 'should not set internal',
-          :attr     => 'internal',
-          :value    => false,
-          :notmatch => /internal;/
-        },
-        {
-          :title => 'should set internal',
-          :attr  => 'internal',
-          :value => true,
-          :match => '    internal;'
-        },
-        {
-          :title => 'should contain ordered prepended directives',
-          :attr  => 'location_cfg_prepend',
-          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3',
-                      'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
-                                  'subtest2' => '"sub test value2"' } },
-          :match => [
-            '    allow test value 3;',
-            '    test1 test value 1;',
-            '    test2 test value 2a;',
-            '    test2 test value 2b;',
-            '    test4 subtest1 "sub test value1a";',
-            '    test4 subtest1 "sub test value1b";',
-            '    test4 subtest2 "sub test value2";',
-          ],
-        },
         {
           :title => 'should set www_root',
           :attr  => 'www_root',
@@ -381,138 +430,106 @@ describe 'nginx::resource::location' do
           :value => 'value',
           :match => '    fastcgi_pass value;'
         },
-        {
-          :title => 'should set fastcgi_param',
-          :attr  => 'fastcgi_script',
-          :value => 'value',
-          :match => '    fastcgi_param SCRIPT_FILENAME value;',
-        },
-        {
-          :title => 'should contain ordered appended directives',
-          :attr  => 'location_cfg_append',
-          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3',
-                      'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
-                                  'subtest2' => '"sub test value2"' } },
-          :match => [
-            '    allow test value 3;',
-            '    test1 test value 1;',
-            '    test2 test value 2a;',
-            '    test2 test value 2b;',
-            '    test4 subtest1 "sub test value1a";',
-            '    test4 subtest1 "sub test value1b";',
-            '    test4 subtest2 "sub test value2";',
-          ],
-        },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do
-          let :default_params do { :location => 'location', :fastcgi => 'localhost:9000', :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
           it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
           it param[:title] do
-            lines = subject.resource('concat::fragment', Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            matches  = Array(param[:match])
+
+            if matches.all? { |m| m.is_a? Regexp }
+              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+            else
+              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              (lines & matches).should == matches
+            end
+
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(/#{item}/)
+              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
           end
         end
       end
+
+      context "when fastcgi_script is 'value'" do
+        let :params do default_params.merge({ :fastcgi_script => 'value' }) end
+        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+        it "should set fastcgi_script" do
+          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+                  with_content(%r|^[ ]+fastcgi_param\s+SCRIPT_FILENAME\s+value;|)
+        end
+      end
+
+      context "when fastcgi_script is not set" do
+        let :params do default_params end
+        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+        it "should not set fastcgi_script" do
+          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+                  without_content(/^[ ]+fastcgi_param\s+SCRIPT_FILENAME\s+.+?;/)
+        end
+      end
     end
 
-    describe "vhost_location_directory template content" do
+    describe "vhost_location_proxy template content" do
       [
         {
-          :title => 'should set the location',
-          :attr  => 'location',
-          :value => 'my_location',
-          :match => '  location my_location {',
+          :title => 'should set proxy_cache',
+          :attr  => 'proxy_cache',
+          :value => 'value',
+          :regexp_match => /^[ ]+proxy_cache\s+value;/,
         },
         {
-          :title    => 'should not set internal',
-          :attr     => 'internal',
+          :title    => 'should not set proxy_cache',
+          :attr     => 'proxy_cache',
           :value    => false,
-          :notmatch => /internal;/
+          :notmatch => /proxy_cache\b/
         },
         {
-          :title => 'should set internal',
-          :attr  => 'internal',
-          :value => true,
-          :match => '    internal;'
-        },
-        {
-          :title => 'should set the allow directive',
-          :attr  => 'location_allow',
-          :value => ['rule1','rule2'],
-          :match => ['    allow rule1;', '    allow rule2;'],
-        },
-        {
-          :title => 'should set the deny directive',
-          :attr  => 'location_deny',
-          :value => ['rule1','rule2'],
-          :match => ['    deny rule1;', '    deny rule2;'],
-        },
-        {
-          :title => 'should contain ordered prepended directives',
-          :attr  => 'location_cfg_prepend',
-          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3',
-                      'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
-                                  'subtest2' => '"sub test value2"' } },
-          :match => [
-            '    allow test value 3;',
-            '    test1 test value 1;',
-            '    test2 test value 2a;',
-            '    test2 test value 2b;',
-            '    test4 subtest1 "sub test value1a";',
-            '    test4 subtest1 "sub test value1b";',
-            '    test4 subtest2 "sub test value2";',
-          ],
-        },
-        {
-          :title => 'should set www_root',
-          :attr  => 'www_root',
-          :value => '/',
-          :match => '    root  /;'
-        },
-        {
-          :title => 'should set try_file(s)',
-          :attr  => 'try_files',
-          :value => ['name1','name2'],
-          :match => '    try_files name1 name2;',
-        },
-        {
-          :title => 'should set index_file(s)',
-          :attr  => 'index_files',
-          :value => ['name1','name2'],
-          :match => '    index  name1 name2;',
-        },
-        {
-          :title => 'should set auth_basic',
-          :attr  => 'auth_basic',
+          :title => 'should set proxy_pass',
+          :attr  => 'proxy',
           :value => 'value',
-          :match => '    auth_basic           "value";',
+          :regexp_match => /^[ ]+proxy_pass\s+value;/,
         },
         {
-          :title => 'should set auth_basic_user_file',
-          :attr  => 'auth_basic_user_file',
+          :title => 'should set proxy_read_timeout',
+          :attr  => 'proxy_read_timeout',
           :value => 'value',
-          :match => '    auth_basic_user_file value;',
+          :regexp_match => '    proxy_read_timeout  value;',
         },
         {
-          :title => 'should contain ordered appended directives',
-          :attr  => 'location_cfg_append',
-          :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3',
-                      'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
-                                  'subtest2' => '"sub test value2"' } },
-          :match => [
-            '    allow test value 3;',
-            '    test1 test value 1;',
-            '    test2 test value 2a;',
-            '    test2 test value 2b;',
-            '    test4 subtest1 "sub test value1a";',
-            '    test4 subtest1 "sub test value1b";',
-            '    test4 subtest2 "sub test value2";',
-          ],
+          :title => 'should set proxy_connect_timeout',
+          :attr  => 'proxy_connect_timeout',
+          :value => 'value',
+          :regexp_match => '    proxy_connect_timeout  value;',
+        },
+        {
+          :title => 'should set proxy_read_timeout',
+          :attr  => 'proxy_read_timeout',
+          :value => 'value',
+          :regexp_match => '    proxy_read_timeout  value;',
+        },
+        {
+          :title => 'should set proxy headers',
+          :attr  => 'proxy_set_header',
+          :value => [ 'X-TestHeader1 value1', 'X-TestHeader2 value2' ],
+          :regexp_match => [
+            /^[ ]+proxy_set_header\s+X-TestHeader1 value1;/,
+            /^[ ]+proxy_set_header\s+X-TestHeader2 value2;/,
+          ]
+        },
+        {
+          :title => 'should set proxy_method',
+          :attr  => 'proxy_method',
+          :value => 'value',
+          :match => '    proxy_method        value;',
+        },
+        {
+          :title => 'should set proxy_set_body',
+          :attr  => 'proxy_set_body',
+          :value => 'value',
+          :match => '    proxy_set_body      value;',
         },
         {
           :title => 'should contain rewrite rules',
@@ -536,71 +553,46 @@ describe 'nginx::resource::location' do
         },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do
-          let :default_params do { :location => 'location', :www_root => '/var/www/root', :vhost => 'vhost1' } end
+          let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
           it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
           it param[:title] do
-            lines = subject.resource('concat::fragment', Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
+            matches  = Array(param[:match])
+
+            if matches.all? { |m| m.is_a? Regexp }
+              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+            else
+              lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
+              (lines & matches).should == matches
+            end
+
             Array(param[:notmatch]).each do |item|
               should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
           end
         end
       end
+
+      context "when proxy_cache_valid is 10m" do
+        let :params do {
+          :location => 'location',
+          :proxy => 'proxy_value',
+          :vhost => 'vhost1',
+          :proxy_cache => 'true',
+          :proxy_cache_valid => '10m',
+        } end
+
+        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).with_content(/proxy_cache_valid   10m;/) }
+      end
     end
 
-    describe "vhost_location_empty template content" do
-      [
-        {
-          :title => 'should set the location',
-          :attr  => 'location',
-          :value => 'my_location',
-          :match => '  location my_location {',
-        },
-        {
-          :title    => 'should not set internal',
-          :attr     => 'internal',
-          :value    => false,
-          :notmatch => /internal;/
-        },
-        {
-          :title => 'should set internal',
-          :attr  => 'internal',
-          :value => true,
-          :match => '    internal;'
-        },
-        {
-          :title => 'should contain ordered config directives',
-          :attr  => 'location_custom_cfg',
-          :value => { 'test1' => ['test value 1a', 'test value 1b'], 'test2' => 'test value 2', 'allow' => 'test value 3',
-                      'test4' => { 'subtest1' => ['"sub test value1a"', '"sub test value1b"'],
-                                  'subtest2' => '"sub test value2"' } },
-          :match => [
-            '    allow test value 3;',
-            '    test1 test value 1a;',
-            '    test1 test value 1b;',
-            '    test2 test value 2;',
-            '    test4 subtest1 "sub test value1a";',
-            '    test4 subtest1 "sub test value1b";',
-            '    test4 subtest2 "sub test value2";',
-          ],
-        },
-      ].each do |param|
-        context "when #{param[:attr]} is #{param[:value]}" do
-          let :default_params do { :location => 'location', :location_custom_cfg => {'test1'=>'value1'}, :vhost => 'vhost1' } end
-          let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
-
-          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
-          it param[:title] do
-            lines = subject.resource('concat::fragment', Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
-            Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
-            end
-          end
-        end
+    describe "vhost_location_stub_status template content" do
+      let :params do { :location => 'location', :stub_status => true, :vhost => 'vhost1' }  end
+      it do
+        should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+                 with_content(/stub_status\s+on/)
       end
     end
 

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -50,6 +50,27 @@ describe 'nginx::resource::vhost' do
     describe "vhost_header template content" do
       [
         {
+          :title    => 'should not contain www to non-www rewrite',
+          :attr     => 'rewrite_www_to_non_www',
+          :value    => false,
+          :notmatch => %r|
+            ^
+            \s+listen\s+\*:443\s+ssl;\n
+            \s+server_name\s+www\.rspec\.example\.com;\n
+            \s+return\s+301\s+https://rspec\.example\.com\$uri;
+          |x,
+        },
+        {
+          :title => 'should contain www to non-www rewrite',
+          :attr  => 'rewrite_www_to_non_www',
+          :value => true,
+          :match => [
+            '  listen       *:80;',
+            '  server_name  www.rspec.example.com;',
+            '  return       301 http://rspec.example.com$uri;',
+          ],
+        },
+        {
           :title => 'should set the IPv4 listen IP',
           :attr  => 'listen_ip',
           :value => '127.0.0.1',
@@ -128,6 +149,16 @@ describe 'nginx::resource::vhost' do
           :match => '  auth_basic_user_file value;',
         },
         {
+          :title => 'should contain raw_prepend directives',
+          :attr  => 'raw_prepend',
+          :value => [
+            'if (a) {',
+            '  b;',
+            '}'
+          ],
+          :regexp_match => /^\s+if \(a\) {\n\s++b;\n\s+\}/,
+        },
+        {
           :title => 'should contain ordered prepended directives',
           :attr  => 'vhost_cfg_prepend',
           :value => { 'test1' => ['test value 1a', 'test value 1b'], 'test2' => 'test value 2', 'allow' => 'test value 3' },
@@ -195,8 +226,14 @@ describe 'nginx::resource::vhost' do
 
           it { should contain_concat__fragment("#{title}-header") }
           it param[:title] do
-            lines = subject.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            if param[:regexp_match]
+              Array(param[:regexp]).each do |item|
+                should contain_concat__fragment("#{title}-header").with_content(item)
+              end
+            else
+              lines = subject.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
+              (lines & Array(param[:match])).should == Array(param[:match])
+            end
             Array(param[:notmatch]).each do |item|
               should contain_concat__fragment("#{title}-header").without_content(item)
             end
@@ -207,6 +244,17 @@ describe 'nginx::resource::vhost' do
 
     describe "vhost_footer template content" do
       [
+        {
+          :title    => 'should not contain www to non-www rewrite',
+          :attr     => 'rewrite_www_to_non_www',
+          :value    => false,
+          :notmatch => %r|
+            ^
+            \s+listen\s+\*:443\s+ssl;\n
+            \s+server_name\s+www\.rspec\.example\.com;\n
+            \s+return\s+301\s+https://rspec\.example\.com\$uri;
+          |x,
+        },
         {
           :title => 'should contain include directives',
           :attr  => 'include_files',
@@ -228,24 +276,14 @@ describe 'nginx::resource::vhost' do
           ],
         },
         {
-          :title => 'should contain www to non-www rewrite',
-          :attr  => 'rewrite_www_to_non_www',
-          :value => true,
-          :match => [
-            '  listen       *:80;',
-            '  server_name  www.rspec.example.com;',
-            '  return       301 http://rspec.example.com$uri;',
+          :title => 'should contain raw_append directives',
+          :attr  => 'raw_append',
+          :value => [
+            'if (a) {',
+            '  b;',
+            '}'
           ],
-        },
-        {
-          :title    => 'should not contain www to non-www rewrite',
-          :attr     => 'rewrite_www_to_non_www',
-          :value    => false,
-          :notmatch => [
-            %r|  listen       \*:80;|,
-            %r|  server_name  www\.rspec\.example\.com;|,
-            %r|  return       301 http://rspec\.example\.com\$uri;|
-          ],
+          :regexp_match => /^\s+if \(a\) {\n\s++b;\n\s+\}/,
         },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do
@@ -253,8 +291,14 @@ describe 'nginx::resource::vhost' do
 
           it { should contain_concat__fragment("#{title}-footer") }
           it param[:title] do
-            lines = subject.resource('concat::fragment', "#{title}-footer").send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            if param[:regexp_match]
+              Array(param[:regexp]).each do |item|
+                should contain_concat__fragment("#{title}-footer").with_content(item)
+              end
+            else
+              lines  = subject.resource('concat::fragment', "#{title}-footer").send(:parameters)[:content].split("\n")
+              (lines & Array(param[:match])).should == Array(param[:match])
+            end
             Array(param[:notmatch]).each do |item|
               should contain_concat__fragment("#{title}-footer").without_content(item)
             end
@@ -265,6 +309,27 @@ describe 'nginx::resource::vhost' do
 
     describe "vhost_ssl_header template content" do
       [
+        {
+          :title    => 'should not contain www to non-www rewrite',
+          :attr     => 'rewrite_www_to_non_www',
+          :value    => false,
+          :notmatch => %r|
+            ^
+            \s+listen\s+\*:443\s+ssl;\n
+            \s+server_name\s+www\.rspec\.example\.com;\n
+            \s+return\s+301\s+https://rspec\.example\.com\$uri;
+          |x,
+        },
+        {
+          :title => 'should contain www to non-www rewrite',
+          :attr  => 'rewrite_www_to_non_www',
+          :value => true,
+          :match => [
+            '  listen       *:443 ssl;',
+            '  server_name  www.rspec.example.com;',
+            '  return       301 https://rspec.example.com$uri;',
+          ],
+        },
         {
           :title => 'should set the IPv4 listen IP',
           :attr  => 'listen_ip',
@@ -386,6 +451,16 @@ describe 'nginx::resource::vhost' do
           :match => '  error_log             /path/to/error.log;',
         },
         {
+          :title => 'should contain raw_prepend directives',
+          :attr  => 'raw_prepend',
+          :value => [
+            'if (a) {',
+            '  b;',
+            '}'
+          ],
+          :regexp_match => /^\s+if \(a\) {\n\s++b;\n\s+\}/,
+        },
+        {
           :title => 'should contain ordered prepend directives',
           :attr  => 'vhost_cfg_prepend',
           :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3' },
@@ -429,8 +504,14 @@ describe 'nginx::resource::vhost' do
           }) end
           it { should contain_concat__fragment("#{title}-ssl-header") }
           it param[:title] do
-            lines = subject.resource('concat::fragment', "#{title}-ssl-header").send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            if param[:regexp_match]
+              Array(param[:regexp]).each do |item|
+                should contain_concat__fragment("#{title}-ssl-header").with_content(item)
+              end
+            else
+              lines = subject.resource('concat::fragment', "#{title}-ssl-header").send(:parameters)[:content].split("\n")
+              (lines & Array(param[:match])).should == Array(param[:match])
+            end
             Array(param[:notmatch]).each do |item|
               should contain_concat__fragment("#{title}-ssl-header").without_content(item)
             end
@@ -441,6 +522,17 @@ describe 'nginx::resource::vhost' do
 
     describe "vhost_ssl_footer template content" do
       [
+        {
+          :title    => 'should not contain www to non-www rewrite',
+          :attr     => 'rewrite_www_to_non_www',
+          :value    => false,
+          :notmatch => %r|
+            ^
+            \s+listen\s+\*:443\s+ssl;\n
+            \s+server_name\s+www\.rspec\.example\.com;\n
+            \s+return\s+301\s+https://rspec\.example\.com\$uri;
+          |x,
+        },
         {
           :title => 'should contain include directives',
           :attr  => 'include_files',
@@ -461,6 +553,16 @@ describe 'nginx::resource::vhost' do
           ]
         },
         {
+          :title => 'should contain raw_append directives',
+          :attr  => 'raw_append',
+          :value => [
+            'if (a) {',
+            '  b;',
+            '}'
+          ],
+          :regexp_match => /^\s+if \(a\) {\n\s++b;\n\s+\}/,
+        },
+        {
           :title => 'should contain ordered ssl appended directives',
           :attr  => 'vhost_cfg_ssl_append',
           :value => { 'test1' => 'test value 1', 'test2' => ['test value 2a', 'test value 2b'], 'allow' => 'test value 3' },
@@ -470,26 +572,6 @@ describe 'nginx::resource::vhost' do
             '  test2 test value 2a;',
             '  test2 test value 2b;',
           ]
-        },
-        {
-          :title => 'should contain www to non-www rewrite',
-          :attr  => 'rewrite_www_to_non_www',
-          :value => true,
-          :match => [
-            '  listen       *:443 ssl;',
-            '  server_name  www.rspec.example.com;',
-            '  return       301 https://rspec.example.com$uri;',
-          ],
-        },
-        {
-          :title    => 'should not contain www to non-www rewrite',
-          :attr     => 'rewrite_www_to_non_www',
-          :value    => false,
-          :notmatch => [
-            %r|  listen       \*:443 ssl;|,
-            %r|  server_name  www\.rspec\.example\.com;|,
-            %r|  return       301 https://rspec\.example\.com\$uri;|
-          ],
         },
       ].each do |param|
         context "when #{param[:attr]} is #{param[:value]}" do
@@ -502,8 +584,14 @@ describe 'nginx::resource::vhost' do
 
           it { should contain_concat__fragment("#{title}-ssl-footer") }
           it param[:title] do
-            lines = subject.resource('concat::fragment', "#{title}-ssl-footer").send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            if param[:regexp_match]
+              Array(param[:regexp]).each do |item|
+                should contain_concat__fragment("#{title}-ssl-footer").with_content(item)
+              end
+            else
+              lines = subject.resource('concat::fragment', "#{title}-ssl-footer").send(:parameters)[:content].split("\n")
+              (lines & Array(param[:match])).should == Array(param[:match])
+            end
             Array(param[:notmatch]).each do |item|
               should contain_concat__fragment("#{title}-ssl-footer").without_content(item)
             end
@@ -546,6 +634,22 @@ describe 'nginx::resource::vhost' do
         }) end
 
         it { should contain_nginx__resource__location("#{title}-default").with_location_cfg_prepend({ 'key' => 'value' }) }
+      end
+
+      context "when location_raw_prepend => [ 'foo;' ]" do
+        let :params do default_params.merge({
+          :location_raw_prepend => [ 'foo;' ],
+        }) end
+
+        it { should contain_nginx__resource__location("#{title}-default").with_raw_prepend([ 'foo;' ]) }
+      end
+
+      context "when location_raw_append => [ 'foo;' ]" do
+        let :params do default_params.merge({
+          :location_raw_append => [ 'foo;' ],
+        }) end
+
+        it { should contain_nginx__resource__location("#{title}-default").with_raw_append([ 'foo;' ]) }
       end
 
       context 'when location_cfg_append => { key => value }' do

--- a/templates/vhost/location_footer.erb
+++ b/templates/vhost/location_footer.erb
@@ -1,31 +1,36 @@
 <% if @location_cfg_append -%>
-    <%- @location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
-        <%- if value.is_a?(Hash) -%>
-            <%- value.each do |subkey,subvalue| -%>
-                <%- Array(subvalue).each do |asubvalue| -%>
+  <%- @location_cfg_append.sort_by {|k,v| k}.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
     <%= key %> <%= subkey %> <%= asubvalue %>;
-                <%- end -%>
-            <%- end -%>
-        <%- else -%>
-            <%- Array(value).each do |asubvalue| -%>
-    <%= key %> <%= asubvalue %>;
-            <%- end -%>
         <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
+    <%= key %> <%= asubvalue %>;
+      <%- end -%>
     <%- end -%>
+  <%- end -%>
 <% end -%>
 <% if @location_custom_cfg_append -%>
-    <%- @location_custom_cfg_append.each do |key,value| -%>
-        <%- if value.is_a?(Hash) -%>
-            <%- value.each do |subkey,subvalue| -%>
-                <%- Array(subvalue).each do |asubvalue| -%>
+  <%- @location_custom_cfg_append.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
     <%= key %> <%= subkey %> <%= asubvalue %>
-                <%- end -%>
-            <%- end -%>
-        <%- else -%>
-            <%- Array(value).each do |asubvalue| -%>
-    <%= key %> <%= asubvalue %>
-            <%- end -%>
         <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
+    <%= key %> <%= asubvalue %>
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
+<% end -%>
+<% if @raw_append && Array(@raw_append).size > 0 -%>
+    <%- Array(@raw_append).each do |line| -%>
+    <%= line %>
     <%- end -%>
 <% end -%>
   }

--- a/templates/vhost/location_header.erb
+++ b/templates/vhost/location_header.erb
@@ -13,32 +13,37 @@
     <%- end -%>
 <% end -%>
 <% if @location_custom_cfg_prepend -%>
-    <%- @location_custom_cfg_prepend.each do |key,value| -%>
-        <%- if value.is_a?(Hash) -%>
-            <%- value.each do |subkey,subvalue| -%>
-                <%- Array(subvalue).each do |asubvalue| -%>
+  <%- @location_custom_cfg_prepend.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
     <%= key %> <%= subkey %> <%= asubvalue %>
-                <%- end -%>
-            <%- end -%>
-        <%- else -%>
-            <%- Array(value).each do |asubvalue| -%>
-    <%= key %> <%= asubvalue %>
-            <%- end -%>
         <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
+    <%= key %> <%= asubvalue %>
+      <%- end -%>
     <%- end -%>
+  <%- end -%>
 <% end -%>
 <% if @location_cfg_prepend -%>
-    <%- @location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
-        <%- if value.is_a?(Hash) -%>
-            <%- value.each do |subkey,subvalue| -%>
-                <%- Array(subvalue).each do |asubvalue| -%>
+  <%- @location_cfg_prepend.sort_by {|k,v| k}.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
     <%= key %> <%= subkey %> <%= asubvalue %>;
-                <%- end -%>
-            <%- end -%>
-        <%- else -%>
-            <%- Array(value).each do |asubvalue| -%>
-    <%= key %> <%= asubvalue %>;
-            <%- end -%>
         <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
+    <%= key %> <%= asubvalue %>;
+      <%- end -%>
     <%- end -%>
+  <%- end -%>
 <% end -%>
+<% if @raw_prepend && Array(@raw_prepend).size > 0 %>
+    <%- Array(@raw_prepend).each do |line| -%>
+    <%= line %>
+    <%- end -%>
+<% end %>

--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -1,25 +1,29 @@
-<% if @include_files %><% @include_files.each do |file| -%>
+<% if @include_files -%>
+  <%- @include_files.each do |file| -%>
 include <%= file %>;
-<% end -%><% end -%>
+  <%- end -%>
+<% end -%>
 <%# make sure that allow comes before deny by forcing the allow key (if it -%>
 <%# exists) to be first in the output order.  The hash keys also need to be -%>
 <%# sorted so that the ordering is stable. -%>
-<% if @vhost_cfg_append -%><% @vhost_cfg_append.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
-<% if value.is_a?(Hash) -%><% value.each do |subkey,subvalue| -%>
-<% Array(subvalue).each do |asubvalue| -%>
+<% if @vhost_cfg_append -%>
+  <%- @vhost_cfg_append.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
   <%= key %> <%= subkey %> <%= asubvalue %>;
-<% end -%>
-<% end -%><% else -%>
-<% Array(value).each do |asubvalue| -%>
+        <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
   <%= key %> <%= asubvalue %>;
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
 <% end -%>
+<% if @raw_append && Array(@raw_append).size > 0 -%>
+  <%- Array(@raw_append).each do |line| -%>
+  <%= line %>
+  <%- end -%>
 <% end -%>
-<% end -%><% end -%>
 }
-<% if @rewrite_www_to_non_www -%>
-server {
-  listen       <%= @listen_ip %>:<%= @listen_port %>;
-  server_name  www.<%= @name.gsub(/^www\./, '') %>;
-  return       301 http://<%= @name.gsub(/^www\./, '') %>$uri;
-}
-<% end -%>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -1,3 +1,11 @@
+<% if @rewrite_www_to_non_www -%>
+server {
+  listen       <%= @listen_ip %>:<%= @listen_port %>;
+  server_name  www.<%= @name.gsub(/^www\./, '') %>;
+  return       301 http://<%= @name.gsub(/^www\./, '') %>$uri;
+}
+
+<% end -%>
 server {
   listen                <%= @listen_ip %>:<%= @listen_port %><% if @listen_options %> <%= @listen_options %><% end %>;
 <% # check to see if ipv6 support exists in the kernel before applying %>
@@ -17,32 +25,45 @@ server {
 <%# make sure that allow comes before deny by forcing the allow key (if it -%>
 <%# exists) to be first in the output order.  The hash keys also need to be -%>
 <%# sorted so that the ordering is stable. -%>
-<% if @vhost_cfg_prepend -%><% @vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
-<% if value.is_a?(Hash) -%><% value.each do |subkey,subvalue| -%>
-<% Array(subvalue).each do |asubvalue| -%>
+<% if @vhost_cfg_prepend -%>
+  <%- @vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
   <%= key %> <%= subkey %> <%= asubvalue %>;
-<% end -%>
-<% end -%><% else -%>
-<% Array(value).each do |asubvalue| -%>
+        <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
   <%= key %> <%= asubvalue %>;
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
 <% end -%>
-<% end -%>
-<% end -%><% end -%>
+<% if @raw_prepend && Array(@raw_prepend).size > 0 %>
+  <%- Array(@raw_prepend).each do |line| -%>
+  <%= line %>
+  <%- end -%>
+<% end %>
 <% if @root -%>
   root <%= @root %>;
 <% end -%>
-<% if @passenger_cgi_param -%><% @passenger_cgi_param.keys.sort.each do |key| -%>
+<% if @passenger_cgi_param -%>
+  <%- @passenger_cgi_param.keys.sort.each do |key| -%>
   passenger_set_cgi_param  <%= key %> <%= @passenger_cgi_param[key] %>;
-<% end -%><% end -%>
+  <%- end -%>
+<% end -%>
 <% if @resolver.count > 0 -%>
   resolver                  <% Array(@resolver).each do |r| %> <%= r %><% end %>;
 <% end -%>
 <% @proxy_set_header.each do |header| -%>
   proxy_set_header        <%= header %>;
 <% end -%>
-<% if @add_header -%><% @add_header.each do |key,value| -%>
+<% if @add_header -%>
+  <%- @add_header.each do |key,value| -%>
   add_header              <%= key %> <%= value %>;
-<% end -%><% end -%>
+  <%- end -%>
+<% end -%>
 <% if @rewrite_to_https -%>
   if ($ssl_protocol = "") {
        return 301 https://$host$request_uri;
@@ -57,8 +78,6 @@ server {
 <% if defined? @log_by_lua_file -%>
   log_by_lua_file "<%= @log_by_lua_file %>";
 <% end -%>
-
-
 
   access_log            <%= @access_log_real %>;
   error_log             <%= @error_log_real %>;

--- a/templates/vhost/vhost_ssl_footer.erb
+++ b/templates/vhost/vhost_ssl_footer.erb
@@ -1,33 +1,41 @@
-<% if @include_files %><% @include_files.each do |file| -%>
+<% if @include_files %>
+  <%- @include_files.each do |file| -%>
 include <%= file %>;
-<% end -%><% end -%>
-<% if @vhost_cfg_append -%><% @vhost_cfg_append.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
-<% if value.is_a?(Hash) -%><% value.each do |subkey,subvalue| -%>
-<% Array(subvalue).each do |asubvalue| -%>
+  <%- end -%>
+<% end -%>
+<% if @vhost_cfg_append -%>
+  <%- @vhost_cfg_append.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
   <%= key %> <%= subkey %> <%= asubvalue %>;
-<% end -%>
-<% end -%><% else -%>
-<% Array(value).each do |asubvalue| -%>
+        <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
   <%= key %> <%= asubvalue %>;
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
 <% end -%>
-<% end -%>
-<% end -%><% end -%>
-<% if @vhost_cfg_ssl_append -%><% @vhost_cfg_ssl_append.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
-<% if value.is_a?(Hash) -%><% value.each do |subkey,subvalue| -%>
-<% Array(subvalue).each do |asubvalue| -%>
+<% if @vhost_cfg_ssl_append -%>
+  <%- @vhost_cfg_ssl_append.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
   <%= key %> <%= subkey %> <%= asubvalue %>;
-<% end -%>
-<% end -%><% else -%>
-<% Array(value).each do |asubvalue| -%>
+        <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
   <%= key %> <%= asubvalue %>;
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
 <% end -%>
+<% if @raw_append && Array(@raw_append).size > 0 -%>
+  <%- Array(@raw_append).each do |line| -%>
+  <%= line %>
+  <%- end -%>
 <% end -%>
-<% end -%><% end -%>
 }
-<% if @rewrite_www_to_non_www -%>
-server {
-  listen       <%= @listen_ip %>:<%= @ssl_port %> ssl;
-  server_name  www.<%= @name.gsub(/^www\./, '') %>;
-  return       301 https://<%= @name.gsub(/^www\./, '') %>$uri;
-}
-<% end %>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -1,8 +1,16 @@
+<% if @rewrite_www_to_non_www -%>
+server {
+  listen       <%= @listen_ip %>:<%= @ssl_port %> ssl;
+  server_name  www.<%= @name.gsub(/^www\./, '') %>;
+  return       301 https://<%= @name.gsub(/^www\./, '') %>$uri;
+}
+
+<% end %>
 server {
   listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
-  <% if @ipv6_enable && (defined? @ipaddress6) %>
+  <%- if @ipv6_enable && (defined? @ipaddress6) %>
   listen [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
-  <% end %>
+  <%- end %>
   server_name  <%= @rewrite_www_to_non_www ? @name.gsub(/^www\./, '') : @server_name.join(" ") %>;
 
   ssl on;
@@ -50,38 +58,51 @@ server {
 
   access_log            <%= @ssl_access_log_real %>;
   error_log             <%= @ssl_error_log_real %>;
-  
-<% if @vhost_cfg_prepend -%><% @vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
-<% if value.is_a?(Hash) -%><% value.each do |subkey,subvalue| -%>
-<% Array(subvalue).each do |asubvalue| -%>
+
+<% if @vhost_cfg_prepend -%>
+  <%- @vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
   <%= key %> <%= subkey %> <%= asubvalue %>;
-<% end -%>
-<% end -%><% else -%>
-<% Array(value).each do |asubvalue| -%>
+        <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
   <%= key %> <%= asubvalue %>;
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
 <% end -%>
-<% end -%>
-<% end -%><% end -%>
-<% if @vhost_cfg_ssl_prepend -%><% @vhost_cfg_ssl_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
-<% if value.is_a?(Hash) -%><% value.each do |subkey,subvalue| -%>
-<% Array(subvalue).each do |asubvalue| -%>
+<% if @vhost_cfg_ssl_prepend -%>
+  <%- @vhost_cfg_ssl_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
+    <%- if value.is_a?(Hash) -%>
+      <%- value.each do |subkey,subvalue| -%>
+        <%- Array(subvalue).each do |asubvalue| -%>
   <%= key %> <%= subkey %> <%= asubvalue %>;
-<% end -%>
-<% end -%><% else -%>
-<% Array(value).each do |asubvalue| -%>
+        <%- end -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(value).each do |asubvalue| -%>
   <%= key %> <%= asubvalue %>;
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
 <% end -%>
-<% end -%>
-<% end -%><% end -%>
+<% if @raw_prepend && Array(@raw_prepend).size > 0 %>
+  <%- Array(@raw_prepend).each do |line| -%>
+  <%= line %>
+  <%- end -%>
+<% end %>
 <% if @root -%>
   root <%= @root %>;
 <% end -%>
-<% if @passenger_cgi_param -%><% @passenger_cgi_param.each do |key,value| -%>
+<% Array(@passenger_cgi_param).each do |key,value| -%>
   passenger_set_cgi_param  <%= key %> <%= value %>;
-<% end -%><% end -%>
-<% @proxy_set_header.each do |header| -%>
+<% end -%>
+<% Array(@proxy_set_header).each do |header| -%>
   proxy_set_header        <%= header %>;
 <% end -%>
-<% if @add_header -%><% @add_header.each do |key,value| -%>
+<% Array(@add_header).each do |key,value| -%>
   add_header              <%= key %> <%= value %>;
-<% end -%><% end -%>
+<% end -%>


### PR DESCRIPTION
- added raw_prepend / raw_append to vhosts & locations, which
  adds raw lines to the vhost/location /without/ semicolons
- added location_raw_prepend / location_raw_append to vhost
  for passing through to default location
- added spec tests for new parameters
- cleaned up location specs to match new header/body/footer setup
  reducing duplicate checks by testing header/footer separately.
- cleaned up whitespace (2 space) in touched files
- used `<%-` in erb templates to allow the use of leading whitespace, making the logic flow more readable
