### PR TITLE
Allow using $http_cfg_append with list of lists

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,8 +162,11 @@ class nginx (
   validate_string($proxy_buffers)
   validate_string($proxy_buffer_size)
   if ($http_cfg_append != false) {
-    validate_hash($http_cfg_append)
+    if !is_hash($http_cfg_append) or !is_array($http_cfg_append) {
+      fail('$http_cfg_append must be either a hash or array')
+    }
   }
+
   validate_string($nginx_error_log)
   validate_string($http_access_log)
   validate_hash($nginx_upstreams)

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -204,13 +204,22 @@ describe 'nginx::config' do
           :notmatch => /  proxy_cache_path    \/path\/to\/proxy\.cache levels=1 keys_zone=d2:100m max_size=500m inactive=20m;/,
         },
         {
-          :title => 'should contain ordered appended directives',
+          :title => 'should contain ordered appended directives from hash',
           :attr  => 'http_cfg_append',
           :value => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'allow' => 'test value 3' },
           :match => [
             '  allow test value 3;',
             '  test1 test value 1;',
             '  test2 test value 2;',
+          ],
+        },
+        {
+          :title => 'should contain duplicate appended directives from list of hashes',
+          :attr  => 'http_cfg_append',
+          :value => [[ 'allow', 'test value 1'], ['allow', 'test value 2' ]],
+          :match => [
+            '  allow test value 1;',
+            '  allow test value 2;',
           ],
         },
         {


### PR DESCRIPTION
Since 5a9767dcd8e0126377ca0a53178b65fac61a63d0 we are not able to use list of lists in `$http_cfg_append`.

It should be possible to include a list of lists in order to have duplicate configuration keys, like:

```
nginx::http_cfg_append:
    - [include, /etc/nginx/vhosts/*.ngx]
    - [include, /etc/nginx/vhosts/*/*.ngx]
```

Discussion:
I reverted the validation, which is sub-optimal. However, ideally, the patch should look like:

``` patch
-    validate_hash($http_cfg_append)
+    validate_hash($http_cfg_append) || validate_array($http_cfg_append)
```

but since both functions raise Puppet::Error, there is no way that I know of to make such a conditional happen.
