### PR TITLE
Convert specs to RSpec 2.99.1 syntax with Transpec

### DIFF
--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -26,66 +26,66 @@ describe 'nginx::config' do
           }
         end
 
-        it { should contain_class("nginx::params") }
+        it { is_expected.to contain_class("nginx::params") }
 
-        it { should contain_file("/etc/nginx").only_with(
+        it { is_expected.to contain_file("/etc/nginx").only_with(
           :path   => "/etc/nginx",
           :ensure => 'directory',
           :owner => 'root',
           :group => 'root',
           :mode => '0644'
         )}
-        it { should contain_file("/etc/nginx/conf.d").only_with(
+        it { is_expected.to contain_file("/etc/nginx/conf.d").only_with(
           :path   => '/etc/nginx/conf.d',
           :ensure => 'directory',
           :owner => 'root',
           :group => 'root',
           :mode => '0644'
         )}
-        it { should contain_file("/etc/nginx/conf.mail.d").only_with(
+        it { is_expected.to contain_file("/etc/nginx/conf.mail.d").only_with(
           :path   => '/etc/nginx/conf.mail.d',
           :ensure => 'directory',
           :owner => 'root',
           :group => 'root',
           :mode => '0644'
         )}
-        it { should contain_file("/etc/nginx/conf.d/vhost_autogen.conf").with_ensure('absent') }
-        it { should contain_file("/etc/nginx/conf.mail.d/vhost_autogen.conf").with_ensure('absent') }
-        it { should contain_file("/var/nginx").with(
+        it { is_expected.to contain_file("/etc/nginx/conf.d/vhost_autogen.conf").with_ensure('absent') }
+        it { is_expected.to contain_file("/etc/nginx/conf.mail.d/vhost_autogen.conf").with_ensure('absent') }
+        it { is_expected.to contain_file("/var/nginx").with(
           :ensure => 'directory',
           :owner => 'root',
           :group => 'root',
           :mode => '0644'
         )}
-        it { should contain_file("/var/nginx/client_body_temp").with(
+        it { is_expected.to contain_file("/var/nginx/client_body_temp").with(
           :ensure => 'directory',
           :group => 'root',
           :mode => '0644'
         )}
-        it { should contain_file("/var/nginx/proxy_temp").with(
+        it { is_expected.to contain_file("/var/nginx/proxy_temp").with(
           :ensure => 'directory',
           :group => 'root',
           :mode => '0644'
         )}
-        it { should contain_file('/etc/nginx/sites-enabled/default').with_ensure('absent') }
-        it { should contain_file("/etc/nginx/nginx.conf").with(
+        it { is_expected.to contain_file('/etc/nginx/sites-enabled/default').with_ensure('absent') }
+        it { is_expected.to contain_file("/etc/nginx/nginx.conf").with(
           :ensure => 'file',
           :owner => 'root',
           :group => 'root',
           :mode => '0644'
         )}
-        it { should contain_file("/etc/nginx/conf.d/proxy.conf").with(
+        it { is_expected.to contain_file("/etc/nginx/conf.d/proxy.conf").with(
           :ensure => 'file',
           :owner => 'root',
           :group => 'root',
           :mode => '0644'
         )}
-        it { should contain_file("/tmp/nginx.d").with(
+        it { is_expected.to contain_file("/tmp/nginx.d").with(
           :ensure => 'absent',
           :purge => true,
           :recurse => true
         )}
-        it { should contain_file("/tmp/nginx.mail.d").with(
+        it { is_expected.to contain_file("/tmp/nginx.mail.d").with(
           :ensure => 'absent',
           :purge => true,
           :recurse => true
@@ -108,9 +108,9 @@ describe 'nginx::config' do
             :operatingsystem => facts[:operatingsystem],
           }
         end
-        it { should contain_file("/var/nginx/client_body_temp").with(:owner => 'www-data')}
-        it { should contain_file("/var/nginx/proxy_temp").with(:owner => 'www-data')}
-        it { should contain_file("/etc/nginx/nginx.conf").with_content %r{^user www-data;}}
+        it { is_expected.to contain_file("/var/nginx/client_body_temp").with(:owner => 'www-data')}
+        it { is_expected.to contain_file("/var/nginx/proxy_temp").with(:owner => 'www-data')}
+        it { is_expected.to contain_file("/etc/nginx/nginx.conf").with_content %r{^user www-data;}}
       end
     end
   end
@@ -137,9 +137,9 @@ describe 'nginx::config' do
             :operatingsystem => facts[:operatingsystem],
           }
         end
-        it { should contain_file("/var/nginx/client_body_temp").with(:owner => 'nginx')}
-        it { should contain_file("/var/nginx/proxy_temp").with(:owner => 'nginx')}
-        it { should contain_file("/etc/nginx/nginx.conf").with_content %r{^user nginx;}}
+        it { is_expected.to contain_file("/var/nginx/client_body_temp").with(:owner => 'nginx')}
+        it { is_expected.to contain_file("/var/nginx/proxy_temp").with(:owner => 'nginx')}
+        it { is_expected.to contain_file("/etc/nginx/nginx.conf").with_content %r{^user nginx;}}
       end
     end
   end
@@ -250,11 +250,11 @@ describe 'nginx::config' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do { param[:attr].to_sym => param[:value] } end
 
-          it { should contain_file("/etc/nginx/nginx.conf").with_mode('0644') }
+          it { is_expected.to contain_file("/etc/nginx/nginx.conf").with_mode('0644') }
           it param[:title] do
             verify_contents(subject, "/etc/nginx/nginx.conf", Array(param[:match]))
             Array(param[:notmatch]).each do |item|
-              should contain_file("/etc/nginx/nginx.conf").without_content(item)
+              is_expected.to contain_file("/etc/nginx/nginx.conf").without_content(item)
             end
           end
         end
@@ -306,11 +306,11 @@ describe 'nginx::config' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do { param[:attr].to_sym => param[:value] } end
 
-          it { should contain_file("/etc/nginx/conf.d/proxy.conf").with_mode('0644') }
+          it { is_expected.to contain_file("/etc/nginx/conf.d/proxy.conf").with_mode('0644') }
           it param[:title] do
             verify_contents(subject, "/etc/nginx/conf.d/proxy.conf", Array(param[:match]))
             Array(param[:notmatch]).each do |item|
-              should contain_file("/etc/nginx/conf.d/proxy.conf").without_content(item)
+              is_expected.to contain_file("/etc/nginx/conf.d/proxy.conf").without_content(item)
             end
           end
         end
@@ -319,7 +319,7 @@ describe 'nginx::config' do
 
     context "when confd_purge true" do
       let(:params) {{:confd_purge => true}}
-      it { should contain_file('/etc/nginx/conf.d').with(
+      it { is_expected.to contain_file('/etc/nginx/conf.d').with(
         :purge => true,
         :recurse => true
       )}
@@ -327,7 +327,7 @@ describe 'nginx::config' do
 
     context "when confd_purge false" do
       let(:params) {{:confd_purge => false}}
-      it { should contain_file('/etc/nginx/conf.d').without([
+      it { is_expected.to contain_file('/etc/nginx/conf.d').without([
         'ignore',
         'purge',
         'recurse'
@@ -336,11 +336,11 @@ describe 'nginx::config' do
 
     context "when vhost_purge true" do
       let(:params) {{:vhost_purge => true}}
-      it { should contain_file('/etc/nginx/sites-available').with(
+      it { is_expected.to contain_file('/etc/nginx/sites-available').with(
         :purge => true,
         :recurse => true
       )}
-      it { should contain_file('/etc/nginx/sites-enabled').with(
+      it { is_expected.to contain_file('/etc/nginx/sites-enabled').with(
         :purge => true,
         :recurse => true
       )}
@@ -348,12 +348,12 @@ describe 'nginx::config' do
 
     context "when vhost_purge false" do
       let(:params) {{:vhost_purge => false}}
-      it { should contain_file('/etc/nginx/sites-available').without([
+      it { is_expected.to contain_file('/etc/nginx/sites-available').without([
         'ignore',
         'purge',
         'recurse'
       ])}
-      it { should contain_file('/etc/nginx/sites-enabled').without([
+      it { is_expected.to contain_file('/etc/nginx/sites-enabled').without([
         'ignore',
         'purge',
         'recurse'

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -11,20 +11,20 @@ describe 'nginx' do
   end
 
   shared_examples "a Linux OS" do
-    it { should compile.with_all_deps }
-    it { should contain_class('nginx') }
-    it { should contain_anchor('nginx::begin') }
-    it { should contain_nginx__package.that_requires('Anchor[nginx::begin]') }
-    it { should contain_nginx__config.that_requires('Class[nginx::package]') }
-    it { should contain_nginx__service.that_subscribes_to('Anchor[nginx::begin]') }
-    it { should contain_nginx__service.that_subscribes_to('Class[nginx::package]') }
-    it { should contain_nginx__service.that_subscribes_to('Class[nginx::config]') }
-    it { should contain_anchor('nginx::end').that_requires('Class[nginx::service]') }
-    it { should contain_class("nginx::params") }
-    it { should contain_nginx__resource__upstream("upstream1") }
-    it { should contain_nginx__resource__vhost("test2.local") }
-    it { should contain_nginx__resource__location("test2.local") }
-    it { should contain_nginx__resource__mailhost("smtp.test2.local") }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to contain_class('nginx') }
+    it { is_expected.to contain_anchor('nginx::begin') }
+    it { is_expected.to contain_nginx__package.that_requires('Anchor[nginx::begin]') }
+    it { is_expected.to contain_nginx__config.that_requires('Class[nginx::package]') }
+    it { is_expected.to contain_nginx__service.that_subscribes_to('Anchor[nginx::begin]') }
+    it { is_expected.to contain_nginx__service.that_subscribes_to('Class[nginx::package]') }
+    it { is_expected.to contain_nginx__service.that_subscribes_to('Class[nginx::config]') }
+    it { is_expected.to contain_anchor('nginx::end').that_requires('Class[nginx::service]') }
+    it { is_expected.to contain_class("nginx::params") }
+    it { is_expected.to contain_nginx__resource__upstream("upstream1") }
+    it { is_expected.to contain_nginx__resource__vhost("test2.local") }
+    it { is_expected.to contain_nginx__resource__location("test2.local") }
+    it { is_expected.to contain_nginx__resource__mailhost("smtp.test2.local") }
   end
 
   context "Debian OS" do

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -6,8 +6,8 @@ describe 'nginx::package' do
     let(:facts) {{ :operatingsystem => operatingsystem, :osfamily => 'RedHat' }}
 
     context "using defaults" do
-      it { should contain_package('nginx') }
-      it { should contain_yumrepo('nginx-release').with(
+      it { is_expected.to contain_package('nginx') }
+      it { is_expected.to contain_yumrepo('nginx-release').with(
         'baseurl'  => 'http://nginx.org/packages/rhel/6/$basearch/',
         'descr'    => 'nginx repo',
         'enabled'  => '1',
@@ -15,25 +15,25 @@ describe 'nginx::package' do
         'priority' => '1',
         'gpgkey'   => 'http://nginx.org/keys/nginx_signing.key'
       )}
-      it { should contain_file('/etc/yum.repos.d/nginx-release.repo') }
-      it { should contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::redhat]') }
-      it { should contain_anchor('nginx::package::end').that_requires('Class[nginx::package::redhat]') }
+      it { is_expected.to contain_file('/etc/yum.repos.d/nginx-release.repo') }
+      it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::redhat]') }
+      it { is_expected.to contain_anchor('nginx::package::end').that_requires('Class[nginx::package::redhat]') }
     end
 
     context "manage_repo => false" do
       let(:params) {{ :manage_repo => false }}
-      it { should contain_package('nginx') }
-      it { should_not contain_yumrepo('nginx-release') }
-      it { should_not contain_file('/etc/yum.repos.d/nginx-release.repo') }
+      it { is_expected.to contain_package('nginx') }
+      it { is_expected.not_to contain_yumrepo('nginx-release') }
+      it { is_expected.not_to contain_file('/etc/yum.repos.d/nginx-release.repo') }
     end
 
     context "lsbmajdistrelease = 5" do
       let(:facts) {{ :operatingsystem => operatingsystem, :osfamily => 'RedHat', :lsbmajdistrelease => 5 }}
-      it { should contain_package('nginx') }
-      it { should contain_yumrepo('nginx-release').with(
+      it { is_expected.to contain_package('nginx') }
+      it { is_expected.to contain_yumrepo('nginx-release').with(
         'baseurl'  => 'http://nginx.org/packages/rhel/5/$basearch/'
       )}
-      it { should contain_file('/etc/yum.repos.d/nginx-release.repo') }
+      it { is_expected.to contain_file('/etc/yum.repos.d/nginx-release.repo') }
     end
 
     describe 'installs the requested package version' do
@@ -41,7 +41,7 @@ describe 'nginx::package' do
       let(:params) {{ :package_ensure => '3.0.0' }}
 
       it 'installs 3.0.0 exactly' do
-        should contain_package('nginx').with({
+        is_expected.to contain_package('nginx').with({
           'ensure' => '3.0.0'
         })
       end
@@ -52,23 +52,23 @@ describe 'nginx::package' do
     let(:facts) {{ :operatingsystem => operatingsystem, :osfamily => 'Debian', :lsbdistcodename => lsbdistcodename }}
 
     context "using defaults" do
-      it { should contain_package('nginx') }
-      it { should_not contain_package('passenger') }
-      it { should contain_apt__source('nginx').with(
+      it { is_expected.to contain_package('nginx') }
+      it { is_expected.not_to contain_package('passenger') }
+      it { is_expected.to contain_apt__source('nginx').with(
         'location'   => "http://nginx.org/packages/#{operatingsystem}",
         'repos'      => 'nginx',
         'key'        => '7BD9BF62',
         'key_source' => 'http://nginx.org/keys/nginx_signing.key'
       )}
-      it { should contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::debian]') }
-      it { should contain_anchor('nginx::package::end').that_requires('Class[nginx::package::debian]') }
+      it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::debian]') }
+      it { is_expected.to contain_anchor('nginx::package::end').that_requires('Class[nginx::package::debian]') }
     end
 
     context "package_source => 'passenger'" do
       let(:params) {{ :package_source => 'passenger' }}
-      it { should contain_package('nginx') }
-      it { should contain_package('passenger') }
-      it { should contain_apt__source('nginx').with(
+      it { is_expected.to contain_package('nginx') }
+      it { is_expected.to contain_package('passenger') }
+      it { is_expected.to contain_apt__source('nginx').with(
         'location'   => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
         'repos'      => "main",
         'key'        => '561F9B9CAC40B2F7',
@@ -78,9 +78,9 @@ describe 'nginx::package' do
 
     context "manage_repo => false" do
       let(:params) {{ :manage_repo => false }}
-      it { should contain_package('nginx') }
-      it { should_not contain_apt__source('nginx') }
-      it { should_not contain_package('passenger') }
+      it { is_expected.to contain_package('nginx') }
+      it { is_expected.not_to contain_apt__source('nginx') }
+      it { is_expected.not_to contain_package('passenger') }
     end
   end
 
@@ -89,10 +89,10 @@ describe 'nginx::package' do
     [
       'nginx',
     ].each do |package|
-      it { should contain_package("#{package}") }
+      it { is_expected.to contain_package("#{package}") }
     end
-    it { should contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::suse]') }
-    it { should contain_anchor('nginx::package::end').that_requires('Class[nginx::package::suse]') }
+    it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::suse]') }
+    it { is_expected.to contain_anchor('nginx::package::end').that_requires('Class[nginx::package::suse]') }
   end
 
 
@@ -116,8 +116,8 @@ describe 'nginx::package' do
 
   context 'amazon with facter < 1.7.2' do
     let(:facts) {{ :operatingsystem => 'Amazon', :osfamily => 'Linux' }}
-      it { should contain_package('nginx') }
-      it { should contain_yumrepo('nginx-release').with(
+      it { is_expected.to contain_package('nginx') }
+      it { is_expected.to contain_yumrepo('nginx-release').with(
         'baseurl'  => 'http://nginx.org/packages/rhel/6/$basearch/',
         'descr'    => 'nginx repo',
         'enabled'  => '1',
@@ -125,18 +125,18 @@ describe 'nginx::package' do
         'priority' => '1',
         'gpgkey'   => 'http://nginx.org/keys/nginx_signing.key'
       )}
-      it { should contain_file('/etc/yum.repos.d/nginx-release.repo') }
-      it { should contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::redhat]') }
-      it { should contain_anchor('nginx::package::end').that_requires('Class[nginx::package::redhat]') }
+      it { is_expected.to contain_file('/etc/yum.repos.d/nginx-release.repo') }
+      it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::redhat]') }
+      it { is_expected.to contain_anchor('nginx::package::end').that_requires('Class[nginx::package::redhat]') }
   end
 
   context 'fedora' do
     # fedora is identical to the rest of osfamily RedHat except for not
     # including nginx-release
     let(:facts) {{ :operatingsystem => 'Fedora', :osfamily => 'RedHat', :lsbmajdistrelease => 6 }}
-    it { should contain_package('nginx') }
-    it { should_not contain_yumrepo('nginx-release') }
-    it { should_not contain_file('/etc/yum.repos.d/nginx-release.repo') }
+    it { is_expected.to contain_package('nginx') }
+    it { is_expected.not_to contain_yumrepo('nginx-release') }
+    it { is_expected.not_to contain_file('/etc/yum.repos.d/nginx-release.repo') }
   end
 
   context 'other' do

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -7,9 +7,9 @@ describe 'nginx::params' do
       :operatingsystem => 'debian',
     } end
 
-    it { should contain_nginx__params }
-    it { should have_class_count(1) }    #only nginx::params itself
-    it { should have_resource_count(0) } #params class should never declare resources
+    it { is_expected.to contain_nginx__params }
+    it { is_expected.to have_class_count(1) }    #only nginx::params itself
+    it { is_expected.to have_resource_count(0) } #params class should never declare resources
 
   end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -14,24 +14,24 @@ describe 'nginx::service' do
 
   context "using default parameters" do
 
-    it { should contain_service('nginx').with(
+    it { is_expected.to contain_service('nginx').with(
       :ensure     => 'running',
       :enable     => true,
       :hasstatus  => true,
       :hasrestart => true
     )}
 
-    it { should contain_service('nginx').without_restart }
+    it { is_expected.to contain_service('nginx').without_restart }
 
   end
 
   describe "when configtest_enable => true" do
     let(:params) {{ :configtest_enable => true,  :service_restart => '/etc/init.d/nginx configtest && /etc/init.d/nginx restart'}}
-    it { should contain_service('nginx').with_restart('/etc/init.d/nginx configtest && /etc/init.d/nginx restart') }
+    it { is_expected.to contain_service('nginx').with_restart('/etc/init.d/nginx configtest && /etc/init.d/nginx restart') }
 
     context "when service_restart => 'a restart command'" do
       let(:params) {{ :configtest_enable => true, :service_restart => 'a restart command' }}
-      it { should contain_service('nginx').with_restart('a restart command') }
+      it { is_expected.to contain_service('nginx').with_restart('a restart command') }
     end
   end
 

--- a/spec/defines/resource_geo_spec.rb
+++ b/spec/defines/resource_geo_spec.rb
@@ -35,7 +35,7 @@ describe 'nginx::resource::geo' do
     describe 'basic assumptions' do
       let :params do default_params end
 
-      it { should contain_file("/etc/nginx/conf.d/#{title}-geo.conf").with(
+      it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-geo.conf").with(
         {
           'owner'   => 'root',
           'group'   => 'root',
@@ -105,11 +105,11 @@ describe 'nginx::resource::geo' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_file("/etc/nginx/conf.d/#{title}-geo.conf").with_mode('0644') }
+          it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-geo.conf").with_mode('0644') }
           it param[:title] do
             verify_contents(subject, "/etc/nginx/conf.d/#{title}-geo.conf", Array(param[:match]))
             Array(param[:notmatch]).each do |item|
-              should contain_file("/etc/nginx/conf.d/#{title}-geo.conf").without_content(item)
+              is_expected.to contain_file("/etc/nginx/conf.d/#{title}-geo.conf").without_content(item)
             end
           end
         end
@@ -122,7 +122,7 @@ describe 'nginx::resource::geo' do
           }
         ) end
 
-        it { should contain_file("/etc/nginx/conf.d/#{title}-geo.conf").with_ensure('absent') }
+        it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-geo.conf").with_ensure('absent') }
       end
     end
   end

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -26,12 +26,12 @@ describe 'nginx::resource::location' do
         :vhost    => 'vhost1',
       } end
 
-      it { should contain_class("nginx::params") }
-      it { should contain_class("nginx::config") }
-      it { should contain_concat__fragment("f25e14942fb58942ee13b1465a4e1719").with_content(/location rspec-test/) }
-      it { should_not contain_file('/etc/nginx/fastcgi_params') }
-      it { should_not contain_concat__fragment("vhost1-800-rspec-test-ssl") }
-      it { should_not contain_file("/etc/nginx/rspec-test_htpasswd") }
+      it { is_expected.to contain_class("nginx::params") }
+      it { is_expected.to contain_class("nginx::config") }
+      it { is_expected.to contain_concat__fragment("f25e14942fb58942ee13b1465a4e1719").with_content(/location rspec-test/) }
+      it { is_expected.not_to contain_file('/etc/nginx/fastcgi_params') }
+      it { is_expected.not_to contain_concat__fragment("vhost1-800-rspec-test-ssl") }
+      it { is_expected.not_to contain_file("/etc/nginx/rspec-test_htpasswd") }
     end
 
     describe "vhost/location_header template content" do
@@ -117,21 +117,21 @@ describe 'nginx::resource::location' do
           let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
 
           it param[:title] do
             fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
               lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
-              (lines & matches).should == matches
+              expect(lines & matches).to eq(matches)
             end
 
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -185,28 +185,28 @@ describe 'nginx::resource::location' do
           let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
 
           it param[:title] do
             fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
               lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
-              (lines & matches).should == matches
+              expect(lines & matches).to eq(matches)
             end
 
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
           end
 
           it "should end with a closing brace" do
             fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
             content = subject.resource('concat::fragment', fragment).send(:parameters)[:content]
-            (content.split("\n").reject {|l| l =~ /^(\s*#|$)/ }.last).strip.should == '}'
+            expect((content.split("\n").reject {|l| l =~ /^(\s*#|$)/ }.last).strip).to eq('}')
           end
         end
       end
@@ -219,27 +219,27 @@ describe 'nginx::resource::location' do
 
       context "when location_alias is 'value'" do
         let :params do default_params end
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
         it "should set alias" do
-          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
                   with_content(/^[ ]+alias\s+value;/)
         end
       end
 
       context "when autoindex is 'on'" do
         let :params do default_params.merge({ :autoindex => 'on' }) end
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
         it "should set autoindex" do
-          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
                   with_content(/^[ ]+autoindex\s+on;/)
         end
       end
 
       context "when autoindex is not set" do
         let :params do default_params end
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
         it "should not set autoindex" do
-          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
                   without_content(/^[ ]+autoindex[^;]+;/)
         end
       end
@@ -309,20 +309,20 @@ describe 'nginx::resource::location' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
           it param[:title] do
             fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
               lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
-              (lines & matches).should == matches
+              expect(lines & matches).to eq(matches)
             end
 
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -330,18 +330,18 @@ describe 'nginx::resource::location' do
 
       context "when autoindex is 'on'" do
         let :params do default_params.merge({ :autoindex => 'on' }) end
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
         it "should set autoindex" do
-          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
                   with_content(/^[ ]+autoindex\s+on;/)
         end
       end
 
       context "when autoindex is not set" do
         let :params do default_params end
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")) }
         it "should not set autoindex" do
-          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
+          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).
                   without_content(/^[ ]+autoindex[^;]+;/)
         end
       end
@@ -370,20 +370,20 @@ describe 'nginx::resource::location' do
           let :default_params do { :location => 'location', :location_custom_cfg => {'test1'=>'value1'}, :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
           it param[:title] do
             fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
               lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
-              (lines & matches).should == matches
+              expect(lines & matches).to eq(matches)
             end
 
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -434,20 +434,20 @@ describe 'nginx::resource::location' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
           it param[:title] do
             fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
               lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
-              (lines & matches).should == matches
+              expect(lines & matches).to eq(matches)
             end
 
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -455,18 +455,18 @@ describe 'nginx::resource::location' do
 
       context "when fastcgi_script is 'value'" do
         let :params do default_params.merge({ :fastcgi_script => 'value' }) end
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
         it "should set fastcgi_script" do
-          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
                   with_content(%r|^[ ]+fastcgi_param\s+SCRIPT_FILENAME\s+value;|)
         end
       end
 
       context "when fastcgi_script is not set" do
         let :params do default_params end
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
         it "should not set fastcgi_script" do
-          should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+          is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
                   without_content(/^[ ]+fastcgi_param\s+SCRIPT_FILENAME\s+.+?;/)
         end
       end
@@ -556,20 +556,20 @@ describe 'nginx::resource::location' do
           let :default_params do { :location => 'location', :proxy => 'proxy_value', :vhost => 'vhost1' } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
+          it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")) }
           it param[:title] do
             fragment = Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment(fragment).with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment(fragment).with_content(item) }
             else
               lines = subject.resource('concat::fragment', fragment).send(:parameters)[:content].split("\n")
-              (lines & matches).should == matches
+              expect(lines & matches).to eq(matches)
             end
 
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
+              is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).without_content(item)
             end
           end
         end
@@ -584,14 +584,14 @@ describe 'nginx::resource::location' do
           :proxy_cache_valid => '10m',
         } end
 
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).with_content(/proxy_cache_valid   10m;/) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-location")).with_content(/proxy_cache_valid   10m;/) }
       end
     end
 
     describe "vhost_location_stub_status template content" do
       let :params do { :location => 'location', :stub_status => true, :vhost => 'vhost1' }  end
       it do
-        should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+        is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
                  with_content(/stub_status\s+on/)
       end
     end
@@ -600,36 +600,36 @@ describe 'nginx::resource::location' do
       context 'when fastcgi => "localhost:9000"' do
         let :params do { :fastcgi => 'localhost:9000', :vhost => 'vhost1' } end
 
-        it { should contain_file('/etc/nginx/fastcgi_params').with_mode('0770') }
+        it { is_expected.to contain_file('/etc/nginx/fastcgi_params').with_mode('0770') }
       end
 
       context 'when ssl_only => true' do
         let :params do { :ssl_only => true, :vhost => 'vhost1', :www_root => '/', } end
-        it { should_not contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-rspec-test")) }
+        it { is_expected.not_to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-rspec-test")) }
       end
 
       context 'when ssl_only => false' do
         let :params do { :ssl_only => false, :vhost => 'vhost1', :www_root => '/', } end
 
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-rspec-test")) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-rspec-test")) }
       end
 
       context 'when ssl => true' do
         let :params do { :ssl => true, :vhost => 'vhost1', :www_root => '/', } end
 
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-800-rspec-test-ssl")) }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-800-rspec-test-ssl")) }
       end
 
       context 'when ssl => false' do
         let :params do { :ssl => false, :vhost => 'vhost1', :www_root => '/', } end
 
-        it { should_not contain_concat__fragment(Digest::MD5.hexdigest("vhost1-800-rspec-test-ssl")) }
+        it { is_expected.not_to contain_concat__fragment(Digest::MD5.hexdigest("vhost1-800-rspec-test-ssl")) }
       end
 
       context 'when auth_basic_user_file => true' do
         let :params do { :auth_basic_user_file => '/path/to/file', :vhost => 'vhost1', :www_root => '/', } end
 
-        it { should contain_file("/etc/nginx/rspec-test_htpasswd") }
+        it { is_expected.to contain_file("/etc/nginx/rspec-test_htpasswd") }
       end
 
       context 'when ensure => absent' do
@@ -641,7 +641,7 @@ describe 'nginx::resource::location' do
           :auth_basic_user_file => '/path/to/file',
         } end
 
-        it { should contain_file("/etc/nginx/rspec-test_htpasswd").with_ensure('absent') }
+        it { is_expected.to contain_file("/etc/nginx/rspec-test_htpasswd").with_ensure('absent') }
       end
 
       context "vhost missing" do
@@ -649,7 +649,7 @@ describe 'nginx::resource::location' do
           :www_root => '/',
         } end
 
-        it { expect { should contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, /Cannot create a location reference without attaching to a virtual host/) }
+        it { expect { is_expected.to contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, /Cannot create a location reference without attaching to a virtual host/) }
       end
 
       context "location type missing" do
@@ -657,7 +657,7 @@ describe 'nginx::resource::location' do
           :vhost => 'vhost1',
         } end
 
-        it { expect { should contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, /Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, stub_status, or location_custom_cfg defined/) }
+        it { expect { is_expected.to contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, /Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, stub_status, or location_custom_cfg defined/) }
       end
 
       context "www_root and proxy are set" do
@@ -667,7 +667,7 @@ describe 'nginx::resource::location' do
           :proxy    => 'http://localhost:8000/uri/',
         } end
 
-        it { expect { should contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, /Cannot define both directory and proxy in a virtual host/) }
+        it { expect { is_expected.to contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, /Cannot define both directory and proxy in a virtual host/) }
       end
 
       context 'when vhost name is sanitized' do
@@ -678,8 +678,8 @@ describe 'nginx::resource::location' do
           :ssl => true,
         } end
 
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("www_rspec-vhost_com-500-www.rspec-location.com")).with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
-        it { should contain_concat__fragment(Digest::MD5.hexdigest("www_rspec-vhost_com-800-www.rspec-location.com-ssl")).with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("www_rspec-vhost_com-500-www.rspec-location.com")).with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
+        it { is_expected.to contain_concat__fragment(Digest::MD5.hexdigest("www_rspec-vhost_com-800-www.rspec-location.com-ssl")).with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
       end
     end
   end

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -27,14 +27,14 @@ describe 'nginx::resource::mailhost' do
 
     describe 'basic assumptions' do
       let :params do default_params end
-      it { should contain_class("nginx::config") }
-      it { should contain_concat("/etc/nginx/conf.mail.d/#{title}.conf").with({
+      it { is_expected.to contain_class("nginx::config") }
+      it { is_expected.to contain_concat("/etc/nginx/conf.mail.d/#{title}.conf").with({
         'owner' => 'root',
         'group' => 'root',
         'mode'  => '0644',
       })}
-      it { should contain_concat__fragment("#{title}-header") }
-      it { should_not contain_concat__fragment("#{title}-ssl") }
+      it { is_expected.to contain_concat__fragment("#{title}-header") }
+      it { is_expected.not_to contain_concat__fragment("#{title}-ssl") }
     end
 
     describe "mailhost template content" do
@@ -139,12 +139,12 @@ describe 'nginx::resource::mailhost' do
           } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment("#{title}-header") }
+          it { is_expected.to contain_concat__fragment("#{title}-header") }
           it param[:title] do
             lines = subject.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment("#{title}-header").without_content(item)
+              is_expected.to contain_concat__fragment("#{title}-header").without_content(item)
             end
           end
         end
@@ -193,12 +193,12 @@ describe 'nginx::resource::mailhost' do
           } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment("#{title}-header") }
+          it { is_expected.to contain_concat__fragment("#{title}-header") }
           it param[:title] do
             lines = subject.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment("#{title}-header").without_content(item)
+              is_expected.to contain_concat__fragment("#{title}-header").without_content(item)
             end
           end
         end
@@ -290,12 +290,12 @@ describe 'nginx::resource::mailhost' do
           } end
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment("#{title}-ssl") }
+          it { is_expected.to contain_concat__fragment("#{title}-ssl") }
           it param[:title] do
             lines = subject.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment("#{title}-ssl").without_content(item)
+              is_expected.to contain_concat__fragment("#{title}-ssl").without_content(item)
             end
           end
         end
@@ -309,7 +309,7 @@ describe 'nginx::resource::mailhost' do
           :ssl_key => 'key',
         }) end
 
-        it { expect { should contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
+        it { expect { is_expected.to contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
       end
 
       context "SSL key missing and ssl => true" do
@@ -318,7 +318,7 @@ describe 'nginx::resource::mailhost' do
           :ssl_cert => 'cert',
         }) end
 
-        it { expect { should contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
+        it { expect { is_expected.to contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
       end
 
       context "SSL cert missing and starttls => 'on'" do
@@ -327,7 +327,7 @@ describe 'nginx::resource::mailhost' do
           :ssl_key  => 'key',
         }) end
 
-        it { expect { should contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
+        it { expect { is_expected.to contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
       end
 
       context "SSL key missing and starttls => 'on'" do
@@ -336,7 +336,7 @@ describe 'nginx::resource::mailhost' do
           :ssl_cert => 'cert',
         }) end
 
-        it { expect { should contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
+        it { expect { is_expected.to contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
       end
 
       context "SSL cert missing and starttls => 'only'" do
@@ -345,7 +345,7 @@ describe 'nginx::resource::mailhost' do
           :ssl_key  => 'key',
         }) end
 
-        it { expect { should contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
+        it { expect { is_expected.to contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
       end
 
       context "SSL key missing and starttls => 'only'" do
@@ -354,7 +354,7 @@ describe 'nginx::resource::mailhost' do
           :ssl_cert => 'cert',
         }) end
 
-        it { expect { should contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
+        it { expect { is_expected.to contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error, %r{nginx: SSL certificate/key \(ssl_cert/ssl_cert\) and/or SSL Private must be defined and exist on the target system\(s\)}) }
       end
 
       context 'when listen_port != ssl_port' do
@@ -363,7 +363,7 @@ describe 'nginx::resource::mailhost' do
           :ssl_port    => 443,
         }) end
 
-        it { should contain_concat__fragment("#{title}-header") }
+        it { is_expected.to contain_concat__fragment("#{title}-header") }
       end
 
       context 'when listen_port == ssl_port' do
@@ -372,7 +372,7 @@ describe 'nginx::resource::mailhost' do
           :ssl_port    => 80,
         }) end
 
-        it { should_not contain_concat__fragment("#{title}-header") }
+        it { is_expected.not_to contain_concat__fragment("#{title}-header") }
       end
 
       context 'when ssl => true' do
@@ -383,8 +383,8 @@ describe 'nginx::resource::mailhost' do
           :ssl_cert => 'dummy.cert',
         }) end
 
-        it { should contain_concat__fragment("#{title}-header") }
-        it { should contain_concat__fragment("#{title}-ssl") }
+        it { is_expected.to contain_concat__fragment("#{title}-header") }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl") }
       end
 
       context 'when ssl => false' do
@@ -393,8 +393,8 @@ describe 'nginx::resource::mailhost' do
           :ssl    => false,
         }) end
 
-        it { should contain_concat__fragment("#{title}-header") }
-        it { should_not contain_concat__fragment("#{title}-ssl") }
+        it { is_expected.to contain_concat__fragment("#{title}-header") }
+        it { is_expected.not_to contain_concat__fragment("#{title}-ssl") }
       end
     end
   end

--- a/spec/defines/resource_map_spec.rb
+++ b/spec/defines/resource_map_spec.rb
@@ -35,7 +35,7 @@ describe 'nginx::resource::map' do
     describe 'basic assumptions' do
       let :params do default_params end
 
-      it { should contain_file("/etc/nginx/conf.d/#{title}-map.conf").with(
+      it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-map.conf").with(
         {
           'owner'   => 'root',
           'group'   => 'root',
@@ -78,11 +78,11 @@ describe 'nginx::resource::map' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_file("/etc/nginx/conf.d/#{title}-map.conf").with_mode('0644') }
+          it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-map.conf").with_mode('0644') }
           it param[:title] do
             verify_contents(subject, "/etc/nginx/conf.d/#{title}-map.conf", Array(param[:match]))
             Array(param[:notmatch]).each do |item|
-              should contain_file("/etc/nginx/conf.d/#{title}-map.conf").without_content(item)
+              is_expected.to contain_file("/etc/nginx/conf.d/#{title}-map.conf").without_content(item)
             end
           end
         end
@@ -95,7 +95,7 @@ describe 'nginx::resource::map' do
           }
         ) end
 
-        it { should contain_file("/etc/nginx/conf.d/#{title}-map.conf").with_ensure('absent') }
+        it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-map.conf").with_ensure('absent') }
       end
     end
   end

--- a/spec/defines/resource_upstream_spec.rb
+++ b/spec/defines/resource_upstream_spec.rb
@@ -39,13 +39,13 @@ describe 'nginx::resource::upstream' do
     describe 'basic assumptions' do
       let :params do default_params end
 
-      it { should contain_class("nginx::params") }
-      it { should contain_class('concat::setup') }
-      it { should contain_file("/etc/nginx/conf.d/#{title}-upstream.conf") }
-      it { should contain_concat__fragment("#{title}_upstream_header").with_content(/upstream #{title}/) }
+      it { is_expected.to contain_class("nginx::params") }
+      it { is_expected.to contain_class('concat::setup') }
+      it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-upstream.conf") }
+      it { is_expected.to contain_concat__fragment("#{title}_upstream_header").with_content(/upstream #{title}/) }
 
       it {
-        should contain_concat__fragment("#{title}_upstream_header").with(
+        is_expected.to contain_concat__fragment("#{title}_upstream_header").with(
         {
           'target' => "/etc/nginx/conf.d/#{title}-upstream.conf",
           'order'  => 10,
@@ -53,7 +53,7 @@ describe 'nginx::resource::upstream' do
       )}
 
       it {
-        should contain_concat__fragment("#{title}_upstream_members").with(
+        is_expected.to contain_concat__fragment("#{title}_upstream_members").with(
         {
           'target' => "/etc/nginx/conf.d/#{title}-upstream.conf",
           'order'  => 50,
@@ -61,7 +61,7 @@ describe 'nginx::resource::upstream' do
       )}
 
       it {
-        should contain_concat__fragment("#{title}_upstream_footer").with(
+        is_expected.to contain_concat__fragment("#{title}_upstream_footer").with(
         {
           'target' => "/etc/nginx/conf.d/#{title}-upstream.conf",
           'order'  => 90,
@@ -110,13 +110,13 @@ describe 'nginx::resource::upstream' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_file("/etc/nginx/conf.d/#{title}-upstream.conf").with_mode('0644') }
-          it { should contain_concat__fragment("#{title}_upstream_#{param[:fragment]}") }
+          it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-upstream.conf").with_mode('0644') }
+          it { is_expected.to contain_concat__fragment("#{title}_upstream_#{param[:fragment]}") }
           it param[:title] do
             lines = subject.resource('concat::fragment', "#{title}_upstream_#{param[:fragment]}").send(:parameters)[:content].split("\n")
-            (lines & Array(param[:match])).should == Array(param[:match])
+            expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment("#{title}_upstream_#{param[:fragment]}").without_content(item)
+              is_expected.to contain_concat__fragment("#{title}_upstream_#{param[:fragment]}").without_content(item)
             end
           end
         end
@@ -129,7 +129,7 @@ describe 'nginx::resource::upstream' do
           }
         ) end
 
-        it { should contain_file("/etc/nginx/conf.d/#{title}-upstream.conf").with_ensure('absent') }
+        it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-upstream.conf").with_ensure('absent') }
       end
     end
   end

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -28,19 +28,19 @@ describe 'nginx::resource::vhost' do
 
     describe 'basic assumptions' do
       let :params do default_params end
-      it { should contain_class("nginx::params") }
-      it { should contain_class("nginx::config") }
-      it { should contain_concat("/etc/nginx/sites-available/#{title}.conf").with({
+      it { is_expected.to contain_class("nginx::params") }
+      it { is_expected.to contain_class("nginx::config") }
+      it { is_expected.to contain_concat("/etc/nginx/sites-available/#{title}.conf").with({
         'owner' => 'root',
         'group' => 'root',
         'mode'  => '0644',
       })}
-      it { should contain_concat__fragment("#{title}-header").with_content(%r{access_log[ ]+/var/log/nginx/www\.rspec\.example\.com\.access\.log}) }
-      it { should contain_concat__fragment("#{title}-header").with_content(%r{error_log[ ]+/var/log/nginx/www\.rspec\.example\.com\.error\.log}) }
-      it { should contain_concat__fragment("#{title}-footer") }
-      it { should contain_nginx__resource__location("#{title}-default") }
-      it { should_not contain_file("/etc/nginx/fastcgi_params") }
-      it { should contain_file("#{title}.conf symlink").with({
+      it { is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{access_log[ ]+/var/log/nginx/www\.rspec\.example\.com\.access\.log}) }
+      it { is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{error_log[ ]+/var/log/nginx/www\.rspec\.example\.com\.error\.log}) }
+      it { is_expected.to contain_concat__fragment("#{title}-footer") }
+      it { is_expected.to contain_nginx__resource__location("#{title}-default") }
+      it { is_expected.not_to contain_file("/etc/nginx/fastcgi_params") }
+      it { is_expected.to contain_file("#{title}.conf symlink").with({
         'ensure' => 'link',
         'path'   => "/etc/nginx/sites-enabled/#{title}.conf",
         'target' => "/etc/nginx/sites-available/#{title}.conf"
@@ -242,18 +242,18 @@ describe 'nginx::resource::vhost' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment("#{title}-header") }
+          it { is_expected.to contain_concat__fragment("#{title}-header") }
           it param[:title] do
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment("#{title}-header").with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment("#{title}-header").with_content(item) }
             else
               lines = subject.resource('concat::fragment', "#{title}-header").send(:parameters)[:content].split("\n")
-              (lines & Array(param[:match])).should == Array(param[:match])
+              expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment("#{title}-header").without_content(item)
+              is_expected.to contain_concat__fragment("#{title}-header").without_content(item)
             end
           end
         end
@@ -307,18 +307,18 @@ describe 'nginx::resource::vhost' do
         context "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end
 
-          it { should contain_concat__fragment("#{title}-footer") }
+          it { is_expected.to contain_concat__fragment("#{title}-footer") }
           it param[:title] do
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment("#{title}-footer").with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment("#{title}-footer").with_content(item) }
             else
               lines  = subject.resource('concat::fragment', "#{title}-footer").send(:parameters)[:content].split("\n")
-              (lines & Array(param[:match])).should == Array(param[:match])
+              expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment("#{title}-footer").without_content(item)
+              is_expected.to contain_concat__fragment("#{title}-footer").without_content(item)
             end
           end
         end
@@ -538,18 +538,18 @@ describe 'nginx::resource::vhost' do
             :ssl_key            => 'dummy.key',
             :ssl_cert           => 'dummy.crt',
           }) end
-          it { should contain_concat__fragment("#{title}-ssl-header") }
+          it { is_expected.to contain_concat__fragment("#{title}-ssl-header") }
           it param[:title] do
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment("#{title}-ssl-header").with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(item) }
             else
               lines = subject.resource('concat::fragment', "#{title}-ssl-header").send(:parameters)[:content].split("\n")
-              (lines & Array(param[:match])).should == Array(param[:match])
+              expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment("#{title}-ssl-header").without_content(item)
+              is_expected.to contain_concat__fragment("#{title}-ssl-header").without_content(item)
             end
           end
         end
@@ -618,18 +618,18 @@ describe 'nginx::resource::vhost' do
             :ssl_cert           => 'dummy.crt',
           }) end
 
-          it { should contain_concat__fragment("#{title}-ssl-footer") }
+          it { is_expected.to contain_concat__fragment("#{title}-ssl-footer") }
           it param[:title] do
             matches  = Array(param[:match])
 
             if matches.all? { |m| m.is_a? Regexp }
-              matches.each { |item| should contain_concat__fragment("#{title}-ssl-footer").with_content(item) }
+              matches.each { |item| is_expected.to contain_concat__fragment("#{title}-ssl-footer").with_content(item) }
             else
               lines = subject.resource('concat::fragment', "#{title}-ssl-footer").send(:parameters)[:content].split("\n")
-              (lines & Array(param[:match])).should == Array(param[:match])
+              expect(lines & Array(param[:match])).to eq(Array(param[:match]))
             end
             Array(param[:notmatch]).each do |item|
-              should contain_concat__fragment("#{title}-ssl-footer").without_content(item)
+              is_expected.to contain_concat__fragment("#{title}-ssl-footer").without_content(item)
             end
           end
         end
@@ -651,7 +651,7 @@ describe 'nginx::resource::vhost' do
         end
 
         it "should set the server_name of the rewrite server stanza to the first server_name with 'www.' stripped" do
-          should contain_concat__fragment("#{title}-ssl-header").with_content(/^[ ]+server_name\s+foo.com;/)
+          is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(/^[ ]+server_name\s+foo.com;/)
         end
       end
 
@@ -666,20 +666,20 @@ describe 'nginx::resource::vhost' do
         end
 
         it "should set the server_name of the rewrite server stanza to the first server_name with 'www.' stripped" do
-          should contain_concat__fragment("#{title}-header").with_content(/^[ ]+server_name\s+foo.com;/)
+          is_expected.to contain_concat__fragment("#{title}-header").with_content(/^[ ]+server_name\s+foo.com;/)
         end
       end
 
       context "SSL cert missing" do
         let(:params) {{ :ssl => true, :ssl_key => 'key' }}
 
-        it { expect { should contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error) }
+        it { expect { is_expected.to contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error) }
       end
 
       context "SSL key missing" do
         let(:params) {{ :ssl => true, :ssl_cert => 'cert' }}
 
-        it { expect { should contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error) }
+        it { expect { is_expected.to contain_class('nginx::resource::vhost') }.to raise_error(Puppet::Error) }
       end
 
       context 'when use_default_location => true' do
@@ -687,7 +687,7 @@ describe 'nginx::resource::vhost' do
           :use_default_location => true,
         }) end
 
-        it { should contain_nginx__resource__location("#{title}-default") }
+        it { is_expected.to contain_nginx__resource__location("#{title}-default") }
       end
 
       context 'when use_default_location => false' do
@@ -695,7 +695,7 @@ describe 'nginx::resource::vhost' do
           :use_default_location => false,
         }) end
 
-        it { should_not contain_nginx__resource__location("#{title}-default") }
+        it { is_expected.not_to contain_nginx__resource__location("#{title}-default") }
       end
 
       context 'when location_cfg_prepend => { key => value }' do
@@ -703,7 +703,7 @@ describe 'nginx::resource::vhost' do
           :location_cfg_prepend => { 'key' => 'value' },
         }) end
 
-        it { should contain_nginx__resource__location("#{title}-default").with_location_cfg_prepend({ 'key' => 'value' }) }
+        it { is_expected.to contain_nginx__resource__location("#{title}-default").with_location_cfg_prepend({ 'key' => 'value' }) }
       end
 
       context "when location_raw_prepend => [ 'foo;' ]" do
@@ -711,7 +711,7 @@ describe 'nginx::resource::vhost' do
           :location_raw_prepend => [ 'foo;' ],
         }) end
 
-        it { should contain_nginx__resource__location("#{title}-default").with_raw_prepend([ 'foo;' ]) }
+        it { is_expected.to contain_nginx__resource__location("#{title}-default").with_raw_prepend([ 'foo;' ]) }
       end
 
       context "when location_raw_append => [ 'foo;' ]" do
@@ -719,7 +719,7 @@ describe 'nginx::resource::vhost' do
           :location_raw_append => [ 'foo;' ],
         }) end
 
-        it { should contain_nginx__resource__location("#{title}-default").with_raw_append([ 'foo;' ]) }
+        it { is_expected.to contain_nginx__resource__location("#{title}-default").with_raw_append([ 'foo;' ]) }
       end
 
       context 'when location_cfg_append => { key => value }' do
@@ -727,7 +727,7 @@ describe 'nginx::resource::vhost' do
           :location_cfg_append => { 'key' => 'value' },
         }) end
 
-        it { should contain_nginx__resource__location("#{title}-default").with_location_cfg_append({ 'key' => 'value' }) }
+        it { is_expected.to contain_nginx__resource__location("#{title}-default").with_location_cfg_append({ 'key' => 'value' }) }
       end
 
       context 'when fastcgi => "localhost:9000"' do
@@ -735,7 +735,7 @@ describe 'nginx::resource::vhost' do
           :fastcgi => 'localhost:9000',
         }) end
 
-        it { should contain_file('/etc/nginx/fastcgi_params').with_mode('0770') }
+        it { is_expected.to contain_file('/etc/nginx/fastcgi_params').with_mode('0770') }
       end
 
       context 'when listen_port == ssl_port' do
@@ -744,8 +744,8 @@ describe 'nginx::resource::vhost' do
           :ssl_port    => 80,
         }) end
 
-        it { should_not contain_concat__fragment("#{title}-header") }
-        it { should_not contain_concat__fragment("#{title}-footer") }
+        it { is_expected.not_to contain_concat__fragment("#{title}-header") }
+        it { is_expected.not_to contain_concat__fragment("#{title}-footer") }
       end
 
       context 'when listen_port != ssl_port' do
@@ -754,8 +754,8 @@ describe 'nginx::resource::vhost' do
           :ssl_port    => 443,
         }) end
 
-        it { should contain_concat__fragment("#{title}-header") }
-        it { should contain_concat__fragment("#{title}-footer") }
+        it { is_expected.to contain_concat__fragment("#{title}-header") }
+        it { is_expected.to contain_concat__fragment("#{title}-footer") }
       end
 
       context 'when ensure => absent' do
@@ -766,8 +766,8 @@ describe 'nginx::resource::vhost' do
           :ssl_cert => 'dummy.cert',
         }) end
 
-        it { should contain_nginx__resource__location("#{title}-default").with_ensure('absent') }
-        it { should contain_file("#{title}.conf symlink").with_ensure('absent') }
+        it { is_expected.to contain_nginx__resource__location("#{title}-default").with_ensure('absent') }
+        it { is_expected.to contain_file("#{title}.conf symlink").with_ensure('absent') }
       end
 
       context 'when ssl => true and ssl_port == listen_port' do
@@ -779,12 +779,12 @@ describe 'nginx::resource::vhost' do
           :ssl_cert    => 'dummy.cert',
         }) end
 
-        it { should contain_nginx__resource__location("#{title}-default").with_ssl_only(true) }
-        it { should contain_concat__fragment("#{title}-ssl-header").with_content(%r{access_log[ ]+/var/log/nginx/ssl-www\.rspec\.example\.com\.access\.log}) }
-        it { should contain_concat__fragment("#{title}-ssl-header").with_content(%r{error_log[ ]+/var/log/nginx/ssl-www\.rspec\.example\.com\.error\.log}) }
-        it { should contain_concat__fragment("#{title}-ssl-footer") }
-        it { should contain_file("/etc/nginx/#{title}.crt") }
-        it { should contain_file("/etc/nginx/#{title}.key") }
+        it { is_expected.to contain_nginx__resource__location("#{title}-default").with_ssl_only(true) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{access_log[ ]+/var/log/nginx/ssl-www\.rspec\.example\.com\.access\.log}) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{error_log[ ]+/var/log/nginx/ssl-www\.rspec\.example\.com\.error\.log}) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-footer") }
+        it { is_expected.to contain_file("/etc/nginx/#{title}.crt") }
+        it { is_expected.to contain_file("/etc/nginx/#{title}.key") }
       end
 
       context 'when passenger_cgi_param is set' do
@@ -792,9 +792,9 @@ describe 'nginx::resource::vhost' do
           :passenger_cgi_param => { 'test1' => 'test value 1', 'test2' => 'test value 2', 'test3' => 'test value 3' }
         }) end
 
-        it { should contain_concat__fragment("#{title}-header").with_content( /passenger_set_cgi_param  test1 test value 1;/ ) }
-        it { should contain_concat__fragment("#{title}-header").with_content( /passenger_set_cgi_param  test2 test value 2;/ ) }
-        it { should contain_concat__fragment("#{title}-header").with_content( /passenger_set_cgi_param  test3 test value 3;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_cgi_param  test1 test value 1;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_cgi_param  test2 test value 2;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-header").with_content( /passenger_set_cgi_param  test3 test value 3;/ ) }
       end
 
       context 'when passenger_cgi_param is set and ssl => true' do
@@ -805,16 +805,16 @@ describe 'nginx::resource::vhost' do
           :ssl_cert            => 'dummy.cert',
         }) end
 
-        it { should contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_cgi_param  test1 test value 1;/ ) }
-        it { should contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_cgi_param  test2 test value 2;/ ) }
-        it { should contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_cgi_param  test3 test value 3;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_cgi_param  test1 test value 1;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_cgi_param  test2 test value 2;/ ) }
+        it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content( /passenger_set_cgi_param  test3 test value 3;/ ) }
       end
 
       context 'when vhost name is sanitized' do
         let :title do 'www rspec-vhost com' end
         let :params do default_params end
 
-        it { should contain_concat('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
+        it { is_expected.to contain_concat('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
       end
     end
   end


### PR DESCRIPTION
This conversion is done by Transpec 2.3.4 with the following command:
    transpec -c "rake spec" spec/classes/ spec/defines/ spec/spec_helper.rb
- 210 conversions
  from: it { should ... }
    to: it { is_expected.to ... }
- 19 conversions
  from: it { should_not ... }
    to: it { is_expected.not_to ... }
- 15 conversions
  from: == expected
    to: eq(expected)
- 15 conversions
  from: obj.should
    to: expect(obj).to

For more details: https://github.com/yujinakayama/transpec#supported-conversions
