### PR TITLE
Correct validation of {proxy,fastcgi}_cache_levels

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,9 +131,7 @@ class nginx (
   if ($proxy_cache_path != false) {
     validate_string($proxy_cache_path)
   }
-  if (!is_integer($proxy_cache_levels)) {
-    fail('$proxy_cache_levels must be an integer.')
-  }
+  validate_re($proxy_cache_levels, '^[12](:[12])*$')
   validate_string($proxy_cache_keys_zone)
   validate_string($proxy_cache_max_size)
   validate_string($proxy_cache_inactive)
@@ -141,9 +139,7 @@ class nginx (
   if ($fastcgi_cache_path != false) {
         validate_string($fastcgi_cache_path)
   }
-  if (!is_integer($fastcgi_cache_levels)) {
-    fail('$fastcgi_cache_levels must be an integer.')
-  }
+  validate_re($fastcgi_cache_levels, '^[12](:[12])*$')
   validate_string($fastcgi_cache_keys_zone)
   validate_string($fastcgi_cache_max_size)
   validate_string($fastcgi_cache_inactive)


### PR DESCRIPTION
Allow any combination of 1 and 2 in these formats: X, X:X, and X:X:X, e.g.: "2", "2:2", "1:1:2". The old validation failed if it wasn't an integer which didn't allow these formats.

Fixes #294
