### PR TITLE
Add X-Forwarded-Proto to the headers

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,6 +47,7 @@ class nginx::params {
     'Host $host',
     'X-Real-IP $remote_addr',
     'X-Forwarded-For $proxy_add_x_forwarded_for',
+    'X-Forwarded-Proto $scheme',
   ]
   $nx_proxy_cache_path               = false
   $nx_proxy_cache_levels             = 1


### PR DESCRIPTION
Latest version of Jenkins complains without it, due to https://github.com/jenkinsci/jenkins/pull/1265
