### PR TITLE
Added configuration of custom fastcgi_params [fixes #389]

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -245,7 +245,7 @@ nginx::resource::location { "some_root":
   ensure         => present,
   location       => '/some/url',
   fastcgi        => "127.0.0.1:9000",
-  params         => {
+  fastcgi_param  => {
     'APP_ENV' => 'local',
   },
 }

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -471,26 +471,28 @@ describe 'nginx::resource::location' do
         end
       end
 
-      context "when params is {'CUSTOM_PARAM' => 'value'}" do
-        let :params do default_params.merge({ :params => {'CUSTOM_PARAM' => 'value'} }) end
-        it "should set custom fastcgi_params" do
-        should contain_file('/etc/nginx/fastcgi_params').
-                  with_content(%r|fastcgi_param\s+CUSTOM_PARAM\s+value;|)
+      context "when fastcgi_param is {'CUSTOM_PARAM' => 'value'}" do
+        let :params do default_params.merge({ :fastcgi_param => {'CUSTOM_PARAM' => 'value', 'CUSTOM_PARAM2' => 'value2'} }) end
+        it "should set fastcgi_param" do
+        should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+                  with_content(%r|fastcgi_param\s+CUSTOM_PARAM\s+value;|).
+                  with_content(%r|fastcgi_param\s+CUSTOM_PARAM2\s+value2;|)
         end
         it "should add comment # Enable custom fastcgi_params" do
-        should contain_file('/etc/nginx/fastcgi_params').
+        should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
                   with_content(%r|# Enable custom fastcgi_params\s+|)
         end
       end
 
-      context "when params is not set" do
+      context "when fastcgi_param is not set" do
         let :params do default_params end
-        it "should not set custom fastcgi_params" do
-        should contain_file('/etc/nginx/fastcgi_params').
-                  without_content(/fastcgi_param\s+CUSTOM_PARAM\s+.+?;/)
+        it "should not set fastcgi_param" do
+        should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
+                  without_content(/fastcgi_param\s+CUSTOM_PARAM\s+.+?;/).
+                  without_content(/fastcgi_param\s+CUSTOM_PARAM2\s+.+?;/)
         end
         it "should not add comment # Enable custom fastcgi_params" do
-        should contain_file('/etc/nginx/fastcgi_params').
+        should contain_concat__fragment(Digest::MD5.hexdigest("vhost1-500-#{params[:location]}")).
                   without_content(/# Enable custom fastcgi_params\s+/)
         end
       end

--- a/templates/vhost/fastcgi_params.erb
+++ b/templates/vhost/fastcgi_params.erb
@@ -25,10 +25,3 @@ fastcgi_param	HTTPS			    $https;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param	REDIRECT_STATUS		200;
-
-<% if @params %>
-# Enable custom fastcgi_params
-	<% params.each_pair do |key, val| -%>
-fastcgi_param	<%= key %>			<%= val %>;
-	<% end -%>
-<% end %>

--- a/templates/vhost/locations/fastcgi.erb
+++ b/templates/vhost/locations/fastcgi.erb
@@ -12,3 +12,9 @@
 <% if defined? @fastcgi_script %>
     fastcgi_param SCRIPT_FILENAME <%= @fastcgi_script %>;
 <% end -%>
+<% if defined? @fastcgi_param %>
+    # Enable custom fastcgi_params
+	<% fastcgi_param.each_pair do |key, val| -%>
+    fastcgi_param <%= key %> <%= val %>;
+	<% end -%>
+<% end %>

--- a/tests/location_params.pp
+++ b/tests/location_params.pp
@@ -4,7 +4,7 @@ nginx::resource::location { 'www.test.com-params':
     ensure         => present,
     location       => '/some/url',
     vhost          => 'www.test.com',
-    params  	   => {
+    fastcgi_param  => {
     	'APP_ENV'  		=> 'production',
     	'APP_VERSION' 	=> '0.1.10',
     	'APP_SECRET'	=> 'hisfaihicasagfkjsa',


### PR DESCRIPTION
I created a PR for [Fastcgi Params #389](https://github.com/jfryman/puppet-nginx/issues/389) and proposed the key "params" for adding custom fastcgi_params in the puppet configuration.

``` puppet
nginx::resource::location { "root":
    ...
    ensure          => present,
    fastcgi         => "127.0.0.1:9000",
    params          => {
        'APP_ENV' => 'local',
    },
}
```
