### PR TITLE
Fix deprecated variable access warning

### DIFF
--- a/templates/vhost/locations/fastcgi.erb
+++ b/templates/vhost/locations/fastcgi.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <% if defined? @fastcgi_param %>
     # Enable custom fastcgi_params
-	<% fastcgi_param.each_pair do |key, val| -%>
+	<% @fastcgi_param.each_pair do |key, val| -%>
     fastcgi_param <%= key %> <%= val %>;
 	<% end -%>
 <% end %>


### PR DESCRIPTION
Fix to remove the following warning:

```
Warning: Variable access via 'fastcgi_param' is deprecated. Use '@fastcgi_param' instead. template[/etc/puppet/modules/nginx/templates/vhost/locations/fastcgi.erb]:17 (at /etc/puppet/modules/nginx/templates/vhost/locations/fastcgi.erb:17:in `block in result')
```
