### PR TITLE
Remove hardcoded ssl_session_timeout

### DIFF
--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -21,7 +21,6 @@ server {
   ssl_dhparam               <%= scope.lookupvar('nginx::config::conf_dir') %>/<%= @name.gsub(' ', '_') %>.dh.pem;
 <% end -%>
   ssl_session_cache         <%= @ssl_cache %>;
-  ssl_session_timeout       5m;
   ssl_protocols             <%= @ssl_protocols %>;
   ssl_ciphers               <%= @ssl_ciphers %>;
   ssl_prefer_server_ciphers on;


### PR DESCRIPTION
It's hard coded to 5 minutes, which is already nginx default.

http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout
