### PR TITLE
Don't hard code 'ssl on' in ssl template

### DIFF
--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -13,8 +13,6 @@ server {
   <%- end %>
   server_name  <%= @rewrite_www_to_non_www ? @server_name[0].gsub(/^www\./, '') : @server_name.join(" ") %>;
 
-  ssl on;
-
   ssl_certificate           <%= scope.lookupvar('nginx::config::conf_dir') %>/<%= @name.gsub(' ', '_') %>.crt;
   ssl_certificate_key       <%= scope.lookupvar('nginx::config::conf_dir') %>/<%= @name.gsub(' ', '_') %>.key;
 <% if defined? @ssl_dhparam -%>


### PR DESCRIPTION
The 'ssl' option is set on the listen directives already, so this is redundant.

It may also conflict with the `ssl_listen_option` parameter added in #330, since the hard coded directive may override `ssl_listen_option`.
