### PR TITLE
Remove redundant $cert from ssl config

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -593,36 +593,34 @@ define nginx::resource::vhost (
     }
 
     #Generate ssl key/cert with provided file-locations
-    $cert = regsubst($name,' ','_', 'G')
-
     # Check if the file has been defined before creating the file to
     # avoid the error when using wildcard cert on the multiple vhosts
-    ensure_resource('file', "${nginx::config::conf_dir}/${cert}.crt", {
+    ensure_resource('file', "${nginx::config::conf_dir}/${name_sanitized}.crt", {
       owner  => $nginx::config::daemon_user,
       mode   => '0444',
       source => $ssl_cert,
     })
-    ensure_resource('file', "${nginx::config::conf_dir}/${cert}.key", {
+    ensure_resource('file', "${nginx::config::conf_dir}/${name_sanitized}.key", {
       owner  => $nginx::config::daemon_user,
       mode   => '0440',
       source => $ssl_key,
     })
     if ($ssl_dhparam != undef) {
-      ensure_resource('file', "${nginx::config::conf_dir}/${cert}.dh.pem", {
+      ensure_resource('file', "${nginx::config::conf_dir}/${name_sanitized}.dh.pem", {
         owner  => $nginx::config::daemon_user,
         mode   => '0440',
         source => $ssl_dhparam,
       })
     }
     if ($ssl_stapling_file != undef) {
-      ensure_resource('file', "${nginx::config::conf_dir}/${cert}.ocsp.resp", {
+      ensure_resource('file', "${nginx::config::conf_dir}/${name_sanitized}.ocsp.resp", {
         owner  => $nginx::config::daemon_user,
         mode   => '0440',
         source => $ssl_stapling_file,
       })
     }
     if ($ssl_trusted_cert != undef) {
-      ensure_resource('file', "${nginx::config::conf_dir}/${cert}.trusted.crt", {
+      ensure_resource('file', "${nginx::config::conf_dir}/${name_sanitized}.trusted.crt", {
         owner  => $nginx::config::daemon_user,
         mode   => '0440',
         source => $ssl_trusted_cert,


### PR DESCRIPTION
It's set to the same value as $name_sanitized so no need to have two equivalent variables in the manifest.
