### PR TITLE
Removed proxy_cache_valid as default when using proxy_cache option

### DIFF
--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -531,12 +531,24 @@ describe 'nginx::resource::location' do
           :match => /^[ ]+proxy_cache\s+value;/,
         },
         {
+          :title    => 'should not set proxy_cache_valid',
+          :attr     => 'proxy_cache_valid',
+          :value    => false,
+          :notmatch => /proxy_cache_valid\b/
+        },
+        {
+          :title => 'should set proxy_cache_valid',
+          :attr  => 'proxy_cache_valid',
+          :value => 'value',
+          :match => /^[ ]+proxy_cache_valid\s+value;/,
+        },
+        {
           :title    => 'should not set proxy_cache',
           :attr     => 'proxy_cache',
           :value    => false,
           :notmatch => /proxy_cache\b/
         },
-        {
+	{
           :title => 'should set proxy_pass',
           :attr  => 'proxy',
           :value => 'value',

--- a/templates/vhost/locations/proxy.erb
+++ b/templates/vhost/locations/proxy.erb
@@ -1,5 +1,7 @@
 <% if @proxy_cache -%>
     proxy_cache         <%= @proxy_cache %>;
+<% end -%>
+<% if @proxy_cache_valid -%>
     proxy_cache_valid   <%= @proxy_cache_valid %>;
 <% end -%>
     proxy_pass          <%= @proxy %>;


### PR DESCRIPTION
Hello

If you specify the option proxy_cache, the module automatically add proxy_cache_valid with "false" as an argument, this fails. And this option is not mandatory when using proxy_cache, so I made it optional.

Hope is OK
