### PR TITLE
Fix to detect the major release version for redhat/centos 7

### DIFF
--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -19,6 +19,13 @@ class nginx::package::redhat (
   $package_name   = 'nginx',
 ) {
 
+  if $::lsbmajdistrelease {
+    $major_dist_release = $::lsbmajdistrelease
+  }
+  else {
+    $major_dist_release = $::operatingsystemmajrelease
+  }
+
   case $::operatingsystem {
     'fedora': {
       # nginx.org does not supply RPMs for fedora
@@ -31,9 +38,9 @@ class nginx::package::redhat (
       }
     }
     default: {
-      case $::lsbmajdistrelease {
+      case $major_dist_release {
         5, 6, 7: {
-          $os_rel = $::lsbmajdistrelease
+          $os_rel = $major_dist_release
         }
         default: {
           # Amazon uses the year as the $::lsbmajdistrelease


### PR DESCRIPTION
In Redhat/CentOS 7, `lsbmajdistrelease` was not being set due to a minimal install not having all the required dependencies for `lsbmajdistrelease` and falling back to the default `$os_rel = 6`. This caused the puppet install to fail due to the wrong yum repo being set. As you can see below the differences in the facter output: 

```
[vagrant@localhost ~]$ facter kernel lsbmajdistrelease
kernel => Linux
lsbmajdistrelease => nil
```

compared to:

```
[vagrant@localhost ~]$ facter kernel operatingsystemmajrelease
kernel => Linux
operatingsystemmajrelease => 7
```

Puppet version: 3.7
CentOS version: `CentOS Linux release 7.0.1406 (Core)`

After these changes were made, I tested on CentOS 5.10, 6.5, and 7.0

This may be related to issue #445 

I am fairly new to Puppet and apologize for any guidelines that weren't followed while submitting this pull request. 
