### PR TITLE
add configurable service name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -135,6 +135,7 @@ class nginx::params {
   $nx_configtest_enable = false
   $nx_service_restart = '/etc/init.d/nginx configtest && /etc/init.d/nginx restart'
   $nx_service_ensure = running
+  $nx_service_name = 'nginx'
 
   $nx_mail = false
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,6 +17,7 @@ class nginx::service(
   $configtest_enable = $nginx::configtest_enable,
   $service_restart   = $nginx::service_restart,
   $service_ensure    = $nginx::service_ensure,
+  $service_name      = 'nginx',
 ) {
 
   $service_enable = $service_ensure ? {
@@ -34,6 +35,7 @@ class nginx::service(
   }
 
   service { 'nginx':
+    name       => $service_name,
     ensure     => $service_ensure_real,
     enable     => $service_enable,
     hasstatus  => true,

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -10,15 +10,16 @@ describe 'nginx::service' do
       :configtest_enable => false,
       :service_restart => '/etc/init.d/nginx configtest && /etc/init.d/nginx restart',
       :service_ensure => 'running',
+      :service_name => 'nginx',
   } end   
 
   context "using default parameters" do
 
     it { is_expected.to contain_service('nginx').with(
-      :ensure     => 'running',
-      :enable     => true,
-      :hasstatus  => true,
-      :hasrestart => true
+      :ensure       => 'running',
+      :enable       => true,
+      :hasstatus    => true,
+      :hasrestart   => true,
     )}
 
     it { is_expected.to contain_service('nginx').without_restart }
@@ -30,6 +31,7 @@ describe 'nginx::service' do
       :configtest_enable => true,
       :service_restart   => '/etc/init.d/nginx configtest && /etc/init.d/nginx restart',
       :service_ensure    => 'running',
+      :service_name      => 'nginx',
     } end
     it { is_expected.to contain_service('nginx').with_restart('/etc/init.d/nginx configtest && /etc/init.d/nginx restart') }
 
@@ -38,9 +40,16 @@ describe 'nginx::service' do
         :configtest_enable => true,
         :service_restart   => 'a restart command',
         :service_ensure    => 'running',
+        :service_name      => 'nginx',
       } end
       it { is_expected.to contain_service('nginx').with_restart('a restart command') }
     end
   end
 
+  describe "when service_name => 'nginx14" do
+    let :params do {
+      :service_name => 'nginx14',
+    } end
+    it { is_expected.to contain_service('nginx').with_name('nginx14') }
+  end
 end


### PR DESCRIPTION
This module works very well with the SCL packaged version of NGINX, but needs just one additional point of change.  I've added a few lines to allow for adjustment of the service name.
