### PR TITLE
Add support for using mainline nginx packages on RHEL/CentOS/Debian

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,6 +105,7 @@ class nginx (
   $sites_available_mode           = $nginx::params::sites_available_mode,
   $geo_mappings                   = {},
   $string_mappings                = {},
+  $use_mainline                   = $nginx::params::use_mainline,
 ) inherits nginx::params {
 
   include stdlib
@@ -180,6 +181,7 @@ class nginx (
   validate_bool($manage_repo)
   validate_string($proxy_headers_hash_bucket_size)
   validate_bool($super_user)
+  validate_bool($use_mainline)
 
   validate_hash($string_mappings)
   validate_hash($geo_mappings)
@@ -190,6 +192,7 @@ class nginx (
     package_ensure => $package_ensure,
     notify         => Class['nginx::service'],
     manage_repo    => $manage_repo,
+    use_mainline   => $use_mainline,
   }
 
   class { 'nginx::config':

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -18,6 +18,7 @@ class nginx::package(
   $package_source = 'nginx',
   $package_ensure = 'present',
   $manage_repo    = true,
+  $use_mainline   = false,
 ) {
 
   anchor { 'nginx::package::begin': }
@@ -29,6 +30,7 @@ class nginx::package(
         manage_repo    => $manage_repo,
         package_ensure => $package_ensure,
         package_name   => $package_name,
+        use_mainline   => $use_mainline,
         require        => Anchor['nginx::package::begin'],
         before         => Anchor['nginx::package::end'],
       }
@@ -39,6 +41,7 @@ class nginx::package(
         package_source => $package_source,
         package_ensure => $package_ensure,
         manage_repo    => $manage_repo,
+        use_mainline   => $use_mainline,
         require        => Anchor['nginx::package::begin'],
         before         => Anchor['nginx::package::end'],
       }

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -17,7 +17,8 @@ class nginx::package::debian(
     $manage_repo    = true,
     $package_name   = 'nginx',
     $package_source = 'nginx',
-    $package_ensure = 'present'
+    $package_ensure = 'present',
+    $use_mainline   = false,
   ) {
 
   $distro = downcase($::operatingsystem)
@@ -34,8 +35,17 @@ class nginx::package::debian(
 
     case $package_source {
       'nginx': {
+        case $use_mainline {
+          true: {
+            $location = "http://nginx.org/packages/mainline/${distro}"
+          }
+          default: {
+            $location = "http://nginx.org/packages/${distro}"
+          }
+        }
+
         apt::source { 'nginx':
-          location   => "http://nginx.org/packages/${distro}",
+          location   => $location,
           repos      => 'nginx',
           key        => '7BD9BF62',
           key_source => 'http://nginx.org/keys/nginx_signing.key',

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -17,6 +17,7 @@ class nginx::package::redhat (
   $manage_repo    = true,
   $package_ensure = 'present',
   $package_name   = 'nginx',
+  $use_mainline   = false,
 ) {
 
   if $::lsbmajdistrelease {
@@ -48,13 +49,22 @@ class nginx::package::redhat (
         }
       }
 
+      case $use_mainline {
+        true: {
+          $baseurl = "http://nginx.org/packages/mainline/rhel/${os_rel}/\$basearch/"
+        }
+        default: {
+          $baseurl = "http://nginx.org/packages/rhel/${os_rel}/\$basearch/"
+        }
+      }
+
       # as of 2013-07-28
       # http://nginx.org/packages/centos appears to be identical to
       # http://nginx.org/packages/rhel
       # no other dedicated dirs exist for platforms under $::osfamily == redhat
       if $manage_repo {
         yumrepo { 'nginx-release':
-          baseurl  => "http://nginx.org/packages/rhel/${os_rel}/\$basearch/",
+          baseurl  => $baseurl,
           descr    => 'nginx repo',
           enabled  => '1',
           gpgcheck => '1',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -148,6 +148,7 @@ class nginx::params {
   $package_ensure = 'present'
   $package_source = 'nginx'
   $manage_repo    = true
+  $use_mainline   = false
 
   # Specific owner for sites-available directory
   $sites_available_owner = 'root'


### PR DESCRIPTION
Add support for using mainline nginx packages on RHEL/CentOS/Debian

http://nginx.org/en/linux_packages.html#mainline

Fixes #450 
