### PR TITLE
Add instructions on bootstrapping puppet-module-data

### DIFF
--- a/docs/hiera.md
+++ b/docs/hiera.md
@@ -5,6 +5,35 @@ by R.I. Pinnear to allow for a significant amount of flexibility with base
 configuration of the module. This is to reduce the amount of clutter starting
 to gather in `params.pp`, and provide a foundation for future enhancements.
 
+## Installation
+
+In order to leverage `puppet-module-data`, you must add an additional
+configuration item to your `hiera.yaml` file to load the new backend. Simply
+add the following code block.
+
+```
+:backends:
+...
+  - module_data
+```
+
+### Vagrant
+
+In order to use this module with Vagrant, you will need to also configure
+Vagrant to load up Hiera. This can be done with the following directives
+in your Vagrantfile.
+
+```
+  config.vm.provision "puppet" do |puppet|
+    ...
+    puppet.hiera_config_path = "hiera.yaml"
+    puppet.options           = "--pluginsync"
+  end
+```
+
+For a full example, please take a look at https://gist.github.com/jfryman/e9f08affec54307e5198
+to get additional information to bootstrap this module.
+
 ## Upgrading
 
 If you happen to be here because of some silly deprecation notice, it is


### PR DESCRIPTION
After releasing https://github.com/jfryman/puppet-nginx/pull/453, a bug was filed that showed a problem with loading module data. It seems that the new backend does in fact need to be loaded to parse data contained within the module.

Fixes https://github.com/jfryman/puppet-nginx/issues/460
