### PR TITLE
Impossible to set proxy_set_header for default location

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -493,6 +493,7 @@ define nginx::resource::vhost (
       proxy_cache           => $proxy_cache,
       proxy_cache_valid     => $proxy_cache_valid,
       proxy_method          => $proxy_method,
+      proxy_set_header      => $proxy_set_header,
       proxy_set_body        => $proxy_set_body,
       fastcgi               => $fastcgi,
       fastcgi_params        => $fastcgi_params,

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -199,15 +199,6 @@ describe 'nginx::resource::vhost' do
           :notmatch => /  root \/;/,
         },
         {
-          :title => 'should set proxy_set_header',
-          :attr  => 'proxy_set_header',
-          :value => ['header1','header2'],
-          :match => [
-            '  proxy_set_header        header1;',
-            '  proxy_set_header        header2;',
-          ],
-        },
-        {
           :title => 'should rewrite to HTTPS',
           :attr  => 'rewrite_to_https',
           :value => true,

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -69,9 +69,6 @@ server {
 <% if Array(@resolver).count > 0 -%>
   resolver                  <% Array(@resolver).each do |r| %> <%= r %><% end %>;
 <% end -%>
-<% @proxy_set_header.each do |header| -%>
-  proxy_set_header        <%= header %>;
-<% end -%>
 <% if @add_header -%>
   <%- @add_header.each do |key,value| -%>
   add_header              <%= key %> <%= value %>;

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -116,9 +116,6 @@ server {
 <% Array(@passenger_cgi_param).each do |key,value| -%>
   passenger_set_cgi_param  <%= key %> <%= value %>;
 <% end -%>
-<% Array(@proxy_set_header).each do |header| -%>
-  proxy_set_header        <%= header %>;
-<% end -%>
 <% Array(@add_header).each do |key,value| -%>
   add_header              <%= key %> <%= value %>;
 <% end -%>


### PR DESCRIPTION
When setting `proxy_set_header` in a vhost, it will add those entries directly to the `server` although the documentation says it will be added to the default location. Since the headers are not passed on to the location, the location will be generated with the fault set, even if the given `proxy_set_header` does not include those.

This PR fixes both issues.

Travis fails because of unrelated issues.
