### PR TITLE
Disable SSLv3 by default

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -72,7 +72,7 @@ define nginx::resource::vhost (
   $ssl_cert               = undef,
   $ssl_key                = undef,
   $ssl_port               = '443',
-  $ssl_protocols          = 'SSLv3 TLSv1 TLSv1.1 TLSv1.2',
+  $ssl_protocols          = 'TLSv1 TLSv1.1 TLSv1.2',
   $ssl_ciphers            = 'HIGH:!aNULL:!MD5',
   $spdy                   = $nginx::params::nx_spdy,
   $proxy                  = undef,


### PR DESCRIPTION
This disables SSLv3 by default on all vhosts we create using this module. We should disable SSLv3 support as it is fundamentally flawed, in that the design allows for MitM attacks when invoked in certain ways, per the POODLE vulnerability. In testing, this does as expected.
