### PR TITLE
Allow multiple proxy_cache_paths and allow users to be more specific.

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -27,11 +27,7 @@ nginx::config::proxy_set_header:
   - 'Host $host'
   - 'X-Real-IP $remote_addr'
   - 'X-Forwarded-For $proxy_add_x_forwarded_for'
-nginx::config::proxy_cache_path: false
-nginx::config::proxy_cache_levels: '1'
-nginx::config::proxy_cache_keys_zone: 'd2:100m'
-nginx::config::proxy_cache_max_size: 500m
-nginx::config::proxy_cache_inactive: 20m
+nginx::config::proxy_cache: false
 nginx::config::fastcgi_cache_path: false
 nginx::config::fastcgi_cache_levels: '1'
 nginx::config::fastcgi_cache_keys_zone: 'd3:100m'

--- a/docs/hiera.md
+++ b/docs/hiera.md
@@ -72,7 +72,7 @@ In the event that you are unable to leverage Hiera for your attribute configurat
 
 ```ruby
 Class<| title == 'nginx::class' |> {
-  proxy_cache_levels => '2',
+  proxy_cache => {'/tmp/www/cache' => 'keys_zone=my-cache:8m'},
 }
 ```
 The recommended path is to use Hiera, but this pattern should give you an intermediate step during the upgrade process.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,11 +44,7 @@ class nginx::config(
   $pid                            = undef,
   $proxy_buffers                  = undef,
   $proxy_buffer_size              = undef,
-  $proxy_cache_inactive           = undef,
-  $proxy_cache_keys_zone          = undef,
-  $proxy_cache_levels             = undef,
-  $proxy_cache_max_size           = undef,
-  $proxy_cache_path               = undef,
+  $proxy_cache                    = undef,
   $proxy_conf_template            = undef,
   $proxy_connect_timeout          = undef,
   $proxy_headers_hash_bucket_size = undef,
@@ -97,13 +93,11 @@ class nginx::config(
   validate_string($proxy_http_version)
   validate_bool($confd_purge)
   validate_bool($vhost_purge)
-  if ($proxy_cache_path != false) {
-    validate_string($proxy_cache_path)
+  if ($proxy_cache != false) {
+    if !(is_hash($proxy_cache) or is_array($proxy_cache)) {
+      fail('$proxy_cache must be either a hash or array')
+    }
   }
-  validate_re($proxy_cache_levels, '^[12](:[12])*$')
-  validate_string($proxy_cache_keys_zone)
-  validate_string($proxy_cache_max_size)
-  validate_string($proxy_cache_inactive)
 
   if ($fastcgi_cache_path != false) {
         validate_string($fastcgi_cache_path)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,11 +69,7 @@ class nginx (
   $pid                            = undef,
   $proxy_buffers                  = undef,
   $proxy_buffer_size              = undef,
-  $proxy_cache_inactive           = undef,
-  $proxy_cache_keys_zone          = undef,
-  $proxy_cache_levels             = undef,
-  $proxy_cache_max_size           = undef,
-  $proxy_cache_path               = undef,
+  $proxy_cache                    = undef,
   $proxy_conf_template            = undef,
   $proxy_connect_timeout          = undef,
   $proxy_headers_hash_bucket_size = undef,
@@ -152,11 +148,7 @@ class nginx (
 	 $pid or
 	 $proxy_buffers or
 	 $proxy_buffer_size or
-	 $proxy_cache_inactive or
-	 $proxy_cache_keys_zone or
-	 $proxy_cache_levels or
-	 $proxy_cache_max_size or
-	 $proxy_cache_path or
+	 $proxy_cache or
 	 $proxy_conf_template or
 	 $proxy_connect_timeout or
 	 $proxy_headers_hash_bucket_size or
@@ -229,11 +221,7 @@ class nginx (
     pid                            => $pid,
     proxy_buffers                  => $proxy_buffers,
     proxy_buffer_size              => $proxy_buffer_size,
-    proxy_cache_inactive           => $proxy_cache_inactive,
-    proxy_cache_keys_zone          => $proxy_cache_keys_zone,
-    proxy_cache_levels             => $proxy_cache_levels,
-    proxy_cache_max_size           => $proxy_cache_max_size,
-    proxy_cache_path               => $proxy_cache_path,
+    proxy_cache                    => $proxy_cache,
     proxy_conf_template            => $proxy_conf_template,
     proxy_connect_timeout          => $proxy_connect_timeout,
     proxy_headers_hash_bucket_size => $proxy_headers_hash_bucket_size,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -191,15 +191,15 @@ describe 'nginx::config' do
         },
         {
           :title => 'should set proxy_cache_path',
-          :attr  => 'proxy_cache_path',
-          :value => '/path/to/proxy.cache',
-          :match => %r'\s+proxy_cache_path\s+/path/to/proxy.cache levels=1 keys_zone=d2:100m max_size=500m inactive=20m;',
+          :attr  => 'proxy_cache',
+          :value => {'/path/to/proxy.cache' => 'keys_zone=d2:100m'},
+          :match => %r'\s+proxy_cache_path\s+/path/to/proxy.cache keys_zone=d2:100m;',
         },
         {
           :title    => 'should not set proxy_cache_path',
-          :attr     => 'proxy_cache_path',
+          :attr     => 'proxy_cache',
           :value    => false,
-          :notmatch => %r'\s+proxy_cache_path\s+/path/to/proxy\.cache levels=1 keys_zone=d2:100m max_size=500m inactive=20m;',
+          :notmatch => %r'\s+proxy_cache_path\s+/path/to/proxy\.cache keys_zone=d2:100m;',
         },
         {
           :title => 'should contain ordered appended directives from hash',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -50,8 +50,10 @@ http {
   gzip_disable "MSIE [1-6]\.(?!.*SV1)";
 
 <% end -%>
-<% if @proxy_cache_path -%>
-  proxy_cache_path        <%= @proxy_cache_path %> levels=<%= @proxy_cache_levels %> keys_zone=<%= @proxy_cache_keys_zone %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive %>;
+<% if @proxy_cache -%>
+  <%- @proxy_cache.each do |key,value| -%>
+  proxy_cache_path        <%= key %> <%= value %>;
+  <%- end -%>
 
 <% end -%>
 <% if @fastcgi_cache_path -%>


### PR DESCRIPTION
In the past the module has only allowed for one proxy_cache_path to be
set. I might have a use case coming up where I will need a few caches
with different requirements so I wanted to be able to define both of
those within puppet. Another thing about breaking this into a hash
instead of using settings for each option is that now the user can
define the minimum options which are path and keys_zone as defined in
the docs [1].

The only thing I can think that this is missing is if we'd want the
option to be called proxy_cache_path still as then its a 1 to 1 matching
to the option within nginx. I only changed it because it does allow a
hash now and is a collection of proxy_caches. I can easily change this
back and make a new PR if that's what we want to go with.

[1] http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_path