### PR TITLE
vhost: add a blank line at the end of the header template

### DIFF
--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -94,3 +94,4 @@ server {
 
   access_log            <%= @access_log_real %>;
   error_log             <%= @error_log_real %>;
+


### PR DESCRIPTION
Without it, we get something like this:

```
  error_log             /var/log/nginx/my_error.log;  location / {
    root      /var/www/html;
  }
```

With this commit, we get this:

```
  error_log             /var/log/nginx/my_error.log;

  location / {
    root      /var/www/html;
  }
```
