### PR TITLE
fastcgi: sync fastcgi_params with upstream fastcgi.conf

### DIFF
--- a/templates/vhost/fastcgi_params.erb
+++ b/templates/vhost/fastcgi_params.erb
@@ -1,27 +1,26 @@
 # This file managed by puppet on host <%= @fqdn %>
 
-fastcgi_param	QUERY_STRING		$query_string;
-fastcgi_param	REQUEST_METHOD	  	$request_method;
-fastcgi_param	CONTENT_TYPE		$content_type;
-fastcgi_param	CONTENT_LENGTH	  	$content_length;
+fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
+fastcgi_param  QUERY_STRING       $query_string;
+fastcgi_param  REQUEST_METHOD     $request_method;
+fastcgi_param  CONTENT_TYPE       $content_type;
+fastcgi_param  CONTENT_LENGTH     $content_length;
 
-fastcgi_param	SCRIPT_FILENAME	  	$request_filename;
-fastcgi_param	SCRIPT_NAME		    $fastcgi_script_name;
-fastcgi_param	REQUEST_URI		    $request_uri;
-fastcgi_param	DOCUMENT_URI		$document_uri;
-fastcgi_param	DOCUMENT_ROOT		$document_root;
-fastcgi_param	SERVER_PROTOCOL	  	$server_protocol;
+fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+fastcgi_param  REQUEST_URI        $request_uri;
+fastcgi_param  DOCUMENT_URI       $document_uri;
+fastcgi_param  DOCUMENT_ROOT      $document_root;
+fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+fastcgi_param  HTTPS              $https if_not_empty;
 
-fastcgi_param	GATEWAY_INTERFACE	CGI/1.1;
-fastcgi_param	SERVER_SOFTWARE		nginx/$nginx_version;
+fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
 
-fastcgi_param	REMOTE_ADDR		    $remote_addr;
-fastcgi_param	REMOTE_PORT		    $remote_port;
-fastcgi_param	SERVER_ADDR		    $server_addr;
-fastcgi_param	SERVER_PORT		    $server_port;
-fastcgi_param	SERVER_NAME		    $server_name;
-
-fastcgi_param	HTTPS			    $https;
+fastcgi_param  REMOTE_ADDR        $remote_addr;
+fastcgi_param  REMOTE_PORT        $remote_port;
+fastcgi_param  SERVER_ADDR        $server_addr;
+fastcgi_param  SERVER_PORT        $server_port;
+fastcgi_param  SERVER_NAME        $server_name;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
-fastcgi_param	REDIRECT_STATUS		200;
+fastcgi_param  REDIRECT_STATUS    200;


### PR DESCRIPTION
This is a risky change for `SCRIPT_FILENAME` but it handles more
situation than fastcgi_params. Upstream still ships the previous
fastcgi_params file.

Fixes #499 

As explained in #499, the change is disruptive. I am doing the pull request for comments only. Only `SCRIPT_FILENAME` is changed (and `HTTPS` a bit).
