### PR TITLE
Deprecated comment.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,9 +4,6 @@
 #
 # Parameters:
 #
-# There are no default parameters for this class. All module parameters
-# are managed via puppet-module-data (see data/ dir)
-#
 # Actions:
 #
 # Requires:


### PR DESCRIPTION
I believe the hiera backend `module_data` has been introduced in 0.1 and then dropped again in 0.2 (I don't know why exactly).

Is this correct ?

Anyhow, there is no `data` directory anymore. Please update the docs. I am not sure I can really trust any comment now ;-)
