### PR TITLE
package: support the nginx mainline repo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,6 +102,7 @@ class nginx (
   $package_ensure                 = present,
   $package_name                   = 'nginx',
   $package_source                 = 'nginx',
+  $package_mainline               = false,
   $manage_repo                    = true,
   ### END Package Configuration ###
 
@@ -206,11 +207,12 @@ class nginx (
   ### END DEPRECATION WARNING ###
 
   class { '::nginx::package':
-    package_name   => $package_name,
-    package_source => $package_source,
-    package_ensure => $package_ensure,
-    notify         => Class['::nginx::service'],
-    manage_repo    => $manage_repo,
+    package_name     => $package_name,
+    package_source   => $package_source,
+    package_ensure   => $package_ensure,
+    package_mainline => $package_mainline,
+    notify           => Class['::nginx::service'],
+    manage_repo      => $manage_repo,
   }
 
   ## This `if` statement is here in the event a user cannot use

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -14,11 +14,13 @@
 #
 # This class file is not called directly
 class nginx::package(
-  $package_name   = 'nginx',
-  $package_source = 'nginx',
-  $package_ensure = 'present',
-  $manage_repo    = true,
+  $package_name     = 'nginx',
+  $package_source   = 'nginx',
+  $package_ensure   = 'present',
+  $package_mainline = false,
+  $manage_repo      = true,
 ) {
+  $mainline = $package_mainline ? { true => "mainline/", false => "" }
 
   anchor { 'nginx::package::begin': }
   anchor { 'nginx::package::end': }
@@ -29,6 +31,7 @@ class nginx::package(
         manage_repo    => $manage_repo,
         package_ensure => $package_ensure,
         package_name   => $package_name,
+        mainline       => $mainline,
         require        => Anchor['nginx::package::begin'],
         before         => Anchor['nginx::package::end'],
       }
@@ -38,6 +41,7 @@ class nginx::package(
         package_name   => $package_name,
         package_source => $package_source,
         package_ensure => $package_ensure,
+        mainline       => $mainline,
         manage_repo    => $manage_repo,
         require        => Anchor['nginx::package::begin'],
         before         => Anchor['nginx::package::end'],

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -15,6 +15,7 @@
 # This class file is not called directly
 class nginx::package::debian(
     $manage_repo    = true,
+    $mainline       = '',
     $package_name   = 'nginx',
     $package_source = 'nginx',
     $package_ensure = 'present'
@@ -35,7 +36,7 @@ class nginx::package::debian(
     case $package_source {
       'nginx': {
         apt::source { 'nginx':
-          location   => "http://nginx.org/packages/${distro}",
+          location   => "http://nginx.org/packages/${mainline}${distro}",
           repos      => 'nginx',
           key        => '7BD9BF62',
           key_source => 'http://nginx.org/keys/nginx_signing.key',

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -15,6 +15,7 @@
 # This class file is not called directly
 class nginx::package::redhat (
   $manage_repo    = true,
+  $mainline       = '',
   $package_ensure = 'present',
   $package_name   = 'nginx',
 ) {
@@ -54,7 +55,7 @@ class nginx::package::redhat (
       # no other dedicated dirs exist for platforms under $::osfamily == redhat
       if $manage_repo {
         yumrepo { 'nginx-release':
-          baseurl  => "http://nginx.org/packages/rhel/${os_rel}/\$basearch/",
+          baseurl  => "http://nginx.org/packages/${mainline}rhel/${os_rel}/\$basearch/",
           descr    => 'nginx repo',
           enabled  => '1',
           gpgcheck => '1',


### PR DESCRIPTION
The stable nginx repo is at:

```
http://http://nginx.org/packages/
```

while the mainline is at:

```
http://nginx.org/packages/mainline/
```
