### PR TITLE
don't ignore lint errors

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -355,7 +355,7 @@ define nginx::resource::location (
         $content_real,
         template('nginx/vhost/location_footer.erb')
       ], ''),
-      order   => "${priority}", #lint:ignore:only_variable_string waiting on https://github.com/puppetlabs/puppetlabs-concat/commit/f70881fbfd01c404616e9e4139d98dad78d5a918
+      order   => $priority,
     }
   }
 
@@ -372,7 +372,7 @@ define nginx::resource::location (
         $content_real,
         template('nginx/vhost/location_footer.erb')
       ], ''),
-      order   => "${ssl_priority}", #lint:ignore:only_variable_string waiting on https://github.com/puppetlabs/puppetlabs-concat/commit/f70881fbfd01c404616e9e4139d98dad78d5a918
+      order   => $ssl_priority,
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,6 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 3.0.0 <5.0.0"},
     {"name":"puppetlabs/apt","version_requirement":">= 1.0.0 <2.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.0 <2.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 <2.0.0"}
   ]
 }


### PR DESCRIPTION
This is no longer necessary, and will improve the code quality score on Puppet Forge.
