### PR TITLE
travis: enable container-based builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ branches:
   except:
   - refactor
   - gh-pages
+sudo: false
 language: ruby
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 bundler_args: --without rake


### PR DESCRIPTION
Jobs running on container-based infrastructure:
1. start up faster
2. allow the use of caches for public repositories
3. disallow the use of sudo, setuid and setgid executables

http://docs.travis-ci.com/user/workers/container-based-infrastructure/
