### PR TITLE
Gemfile: pin rspec-puppet to 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :rake, :test do
 end
 
 group :rake do
-  gem 'rspec-puppet', '>=1.0.1'
+  gem 'rspec-puppet', '~>1.0'
   gem 'rake',         '>=0.9.2.2'
   gem 'puppet-lint',  '>=1.0.1'
   gem 'rspec-system-serverspec', :require => false


### PR DESCRIPTION
rspec-puppet 2.0.0 will cause test failures when it's released until this module's test code is updated
