### PR TITLE
Handle array in custom prepend/append configuration.

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -12,10 +12,16 @@ pid        <%= @pid %>;
 error_log  <%= @nginx_error_log %>;
 
 <% if @nginx_cfg_prepend -%>
+<% if @nginx_cfg_prepend.is_a?(Hash) -%>
 <%- field_width = @nginx_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
 <%- @nginx_cfg_prepend.sort_by{|k,v| k}.each do |key,value| -%>
 <%- Array(value).each do |asubvalue| -%>
 <%= sprintf("%-*s", field_width, key) %> <%= asubvalue %>;
+<%- end -%>
+<%- end -%>
+<%- else -%>
+<%- @nginx_cfg_prepend.each do |value| -%>
+<%= value %>
 <%- end -%>
 <%- end -%>
 <% end -%>
@@ -118,12 +124,18 @@ http {
 <% end -%>
 <% if @http_cfg_append -%>
 
+<% if @http_cfg_append.is_a?(Hash) -%>
   <%- field_width = @http_cfg_append.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
   <%- @http_cfg_append.sort_by{|k,v| k}.each do |key,value| -%>
   <%- Array(value).each do |asubvalue| -%>
   <%= sprintf("%-*s", field_width, key) %> <%= asubvalue %>;
   <%- end -%>
   <%- end -%>
+<% else -%>
+  <%- @http_cfg_append.each do |value| -%>
+  <%= value %>
+  <%- end -%>
+<% end -%>
 <% end -%>
 
   include <%= @conf_dir %>/conf.d/*.conf;


### PR DESCRIPTION
Improved handling of hashes prevented arrays being processed correctly, resulting in no configuration being rendered for array values.
