### PR TITLE
Adding more configuration variables with default values

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,6 +44,9 @@ class nginx::config(
   ### START Nginx Configuration ###
   $client_body_buffer_size        = '128k',
   $client_max_body_size           = '10m',
+  $client_body_timeout            = '60',
+  $send_timeout                   = '60',
+  $lingering_timeout              = '5',
   $events_use                     = false,
   $fastcgi_cache_inactive         = '20m',
   $fastcgi_cache_key              = false,
@@ -65,6 +68,7 @@ class nginx::config(
   $http_tcp_nodelay               = 'on',
   $http_tcp_nopush                = 'off',
   $keepalive_timeout              = '65',
+  $keepalive_requests             = '100',
   $log_format                     = {},
   $mail                           = false,
   $multi_accept                   = 'off',

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -78,6 +78,7 @@
 #     different replies.
 #   [*proxy_method*]         - If defined, overrides the HTTP method of the
 #     request to be passed to the backend.
+#   [*proxy_http_version*]      - Sets the proxy http version
 #   [*proxy_set_body*]       - If defined, sets the body passed to the backend.
 #   [*auth_basic*]            - This directive includes testing name and password
 #     with HTTP Basic Authentication.
@@ -174,6 +175,7 @@ define nginx::resource::location (
   $proxy_cache_use_stale = undef,
   $proxy_cache_valid    = false,
   $proxy_method         = undef,
+  $proxy_http_version   = undef,
   $proxy_set_body       = undef,
   $auth_basic           = undef,
   $auth_basic_user_file = undef,
@@ -294,6 +296,9 @@ define nginx::resource::location (
   }
   if ($proxy_method != undef) {
     validate_string($proxy_method)
+  }
+  if ($proxy_http_version != undef) {
+    validate_string($proxy_http_version)
   }
   if ($proxy_set_body != undef) {
     validate_string($proxy_set_body)

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -150,6 +150,8 @@
 #   [*maintenance*]             - A boolean value to set a vhost in maintenance
 #   [*maintenance_value*]       - Value to return when maintenance is on.
 #                                 Default to return 503
+#   [*error_pages*]             - Hash: setup errors pages, hash key is the http
+#                                 code and hash value the page
 # Actions:
 #
 # Requires:
@@ -256,7 +258,8 @@ define nginx::resource::vhost (
   $group                        = $::nginx::config::global_group,
   $mode                         = $::nginx::config::global_mode,
   $maintenance                  = false,
-  $maintenance_value            = 'return 503'
+  $maintenance_value            = 'return 503',
+  $error_pages                  = {},
 ) {
 
   validate_re($ensure, '^(present|absent)$',

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -94,6 +94,7 @@
 #     different replies.
 #   [*proxy_method*]            - If defined, overrides the HTTP method of the
 #     request to be passed to the backend.
+#   [*proxy_http_version*]      - Sets the proxy http version
 #   [*proxy_set_body*]          - If defined, sets the body passed to the backend.
 #   [*auth_basic*]              - This directive includes testing name and
 #      password with HTTP Basic Authentication.
@@ -205,6 +206,7 @@ define nginx::resource::vhost (
   $proxy_cache_use_stale        = undef,
   $proxy_cache_valid            = false,
   $proxy_method                 = undef,
+  $proxy_http_version           = undef,
   $proxy_set_body               = undef,
   $resolver                     = [],
   $fastcgi                      = undef,
@@ -344,6 +346,9 @@ define nginx::resource::vhost (
   }
   if ($proxy_method != undef) {
     validate_string($proxy_method)
+  }
+  if ($proxy_http_version != undef) {
+    validate_string($proxy_http_version)
   }
   if ($proxy_set_body != undef) {
     validate_string($proxy_set_body)
@@ -550,6 +555,7 @@ define nginx::resource::vhost (
       proxy_cache_use_stale       => $proxy_cache_use_stale,
       proxy_cache_valid           => $proxy_cache_valid,
       proxy_method                => $proxy_method,
+      proxy_http_version          => $proxy_http_version,
       proxy_set_header            => $proxy_set_header,
       proxy_set_body              => $proxy_set_body,
       fastcgi                     => $fastcgi,

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -41,6 +41,10 @@ http {
 
   access_log  <%= @http_access_log %>;
 
+  client_body_timeout   <%= @client_body_timeout %>;
+  send_timeout   <%= @send_timeout %>;
+  lingering_timeout   <%= @lingering_timeout %>;
+
 <% if @sendfile == 'on' -%>
   sendfile    on;
   <%- if @http_tcp_nopush == 'on' -%>
@@ -57,6 +61,8 @@ http {
   server_names_hash_max_size <%= @names_hash_max_size %>;
 
   keepalive_timeout  <%= @keepalive_timeout %>;
+  keepalive_requests <%= @keepalive_requests %>;
+
   tcp_nodelay        <%= @http_tcp_nodelay %>;
 
 <% if @gzip == 'on' -%>

--- a/templates/vhost/locations/proxy.erb
+++ b/templates/vhost/locations/proxy.erb
@@ -2,6 +2,9 @@
     proxy_read_timeout    <%= @proxy_read_timeout %>;
     proxy_connect_timeout <%= @proxy_connect_timeout %>;
     proxy_redirect        <%= @proxy_redirect %>;
+<% if @proxy_http_version -%>
+    proxy_http_version    <%= @proxy_http_version %>;
+<% end -%>
 <% if @proxy_method -%>
     proxy_method          <%= @proxy_method %>;
 <% end -%>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -134,3 +134,9 @@ server {
 
   access_log            <%= @access_log_real %>;
   error_log             <%= @error_log_real %>;
+
+<% if @error_pages -%>
+  <%- @error_pages.keys.sort.each do |key| -%>
+  error_page  <%= key %> <%= @error_pages[key] %>;
+  <%- end -%>
+<% end -%>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -88,6 +88,13 @@ server {
   access_log            <%= @ssl_access_log_real %>;
   error_log             <%= @ssl_error_log_real %>;
 
+<% if @error_pages -%>
+  <%- @error_pages.keys.sort.each do |key| -%>
+  error_page  <%= key %> <%= @error_pages[key] %>;
+  <%- end -%>
+<% end -%>
+
+
 <% if @vhost_cfg_prepend -%>
   <%- @vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
     <%- if value.is_a?(Hash) -%>


### PR DESCRIPTION
Some of this variables already existed in "server" section, but according to Nginx docs they are also allowed in "http" section, so adding them with the default values.

Also, supporting error_page that was missing