### PR TITLE
fix (fastcgi_params): add support for not including predefined values…

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -358,7 +358,7 @@ define nginx::resource::location (
     $content_real = template('nginx/vhost/locations/empty.erb')
   }
 
-  if $ensure == present and $fastcgi != undef and !defined(File[$fastcgi_params]) {
+  if $ensure == present and $fastcgi != undef and ! empty($fastcgi_params) and !defined(File[$fastcgi_params]) {
     file { $fastcgi_params:
       ensure  => present,
       mode    => '0770',

--- a/templates/vhost/locations/fastcgi.erb
+++ b/templates/vhost/locations/fastcgi.erb
@@ -1,7 +1,9 @@
 <% if defined? @www_root -%>
     root          <%= @www_root %>;
 <% end -%>
+<% unless @fastcgi_params.nil? or @fastcgi_params.empty? -%>
     include       <%= @fastcgi_params %>;
+<% end -%>
 <% if @try_files -%>
     try_files    <% @try_files.each do |try| -%> <%= try %><% end -%>;
 <% end -%>


### PR DESCRIPTION
It it not possible to pass undef with hiera, so support for empty string is necessary when declaring locations via create_resources() with data coming from hiera
