### PR TITLE
Added missing uwsgi_params HTTPS

### DIFF
--- a/templates/vhost/uwsgi_params.erb
+++ b/templates/vhost/uwsgi_params.erb
@@ -13,3 +13,4 @@ uwsgi_param REMOTE_PORT $remote_port;
 uwsgi_param SERVER_ADDR $server_addr;
 uwsgi_param SERVER_PORT $server_port;
 uwsgi_param SERVER_NAME $server_name;
+uwsgi_param HTTPS $https if_not_empty;


### PR DESCRIPTION
This is in the default uwsgi_params file but is missing from the template. I see #767 will add custom params, but I think this should be in the defaults