### PR TITLE
Fixing Streamhost implementation support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -86,11 +86,12 @@ class nginx::config(
   $proxy_read_timeout             = '90',
   $proxy_redirect                 = 'off',
   $proxy_send_timeout             = '90',
-  $proxy_set_header               = [
-    'Host $host',
-    'X-Real-IP $remote_addr',
-    'X-Forwarded-For $proxy_add_x_forwarded_for',
-  ],
+  #$proxy_set_header               = [
+  #  'Host $host',
+  #  'X-Real-IP $remote_addr',
+  #  'X-Forwarded-For $proxy_add_x_forwarded_for',
+  #],
+  $proxy_set_header                = undef,
   $sendfile                       = 'on',
   $server_tokens                  = 'on',
   $spdy                           = 'off',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -91,7 +91,7 @@ class nginx::config(
   #  'X-Real-IP $remote_addr',
   #  'X-Forwarded-For $proxy_add_x_forwarded_for',
   #],
-  $proxy_set_header                = undef,
+  $proxy_set_header               = [],
   $sendfile                       = 'on',
   $server_tokens                  = 'on',
   $spdy                           = 'off',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -206,16 +206,14 @@ class nginx::config(
     ensure => directory,
   }
 
-  $_streamhost_avail_dir = "${conf_dir}/streams-available"
-  $_streamhost_enable_dir = "${conf_dir}/streams-enabled"
-
-  file { [$_streamhost_avail_dir, $streamhost_enable_dir]:
+  file { "${conf_dir}/streams-available":
     ensure => directory,
-    owner  => $owner,
-    group  => $group,
-    mode   => $mode,
   }
-  
+
+  file {"${conf_dir}/streams-enabled":
+    ensure => directory,
+  }
+
   if $confd_purge == true {
     File["${conf_dir}/conf.stream.d"] {
       purge   => true,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -205,6 +205,17 @@ class nginx::config(
   file { "${conf_dir}/conf.stream.d":
     ensure => directory,
   }
+
+  $_streamhost_avail_dir = "${conf_dir}/streams-available"
+  $_streamhost_enable_dir = "${conf_dir}/streams-enabled"
+
+  file { [$_streamhost_avail_dir, $streamhost_enable_dir]:
+    ensure => directory,
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
+  }
+  
   if $confd_purge == true {
     File["${conf_dir}/conf.stream.d"] {
       purge   => true,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -63,6 +63,7 @@ class nginx::config(
   $gzip_types                     = undef,
   $gzip_vary                      = 'off',
   $http_cfg_append                = false,
+  $http_raw_append                = false,
   $http_tcp_nodelay               = 'on',
   $http_tcp_nopush                = 'off',
   $keepalive_timeout              = '65',
@@ -167,6 +168,12 @@ class nginx::config(
   if ($http_cfg_append != false) {
     if !(is_hash($http_cfg_append) or is_array($http_cfg_append)) {
       fail('$http_cfg_append must be either a hash or array')
+    }
+  }
+
+  if ($http_raw_append != false) {
+    if !(is_array($http_raw_append)) {
+      fail('$http_raw_append must be an array')
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@ class nginx (
   $fastcgi_cache_use_stale        = undef,
   $gzip                           = undef,
   $http_cfg_append                = undef,
+  $http_raw_append                = undef,
   $http_tcp_nodelay               = undef,
   $http_tcp_nopush                = undef,
   $keepalive_timeout              = undef,
@@ -158,6 +159,7 @@ class nginx (
         $gzip or
         $http_access_log or
         $http_cfg_append or
+        $http_raw_append or
         $http_tcp_nodelay or
         $http_tcp_nopush or
         $keepalive_timeout or
@@ -239,6 +241,7 @@ class nginx (
       gzip                           => $gzip,
       http_access_log                => $http_access_log,
       http_cfg_append                => $http_cfg_append,
+      http_raw_append                => $http_raw_append,
       http_tcp_nodelay               => $http_tcp_nodelay,
       http_tcp_nopush                => $http_tcp_nopush,
       keepalive_timeout              => $keepalive_timeout,

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -138,10 +138,7 @@ define nginx::resource::location (
   $vhost                = undef,
   $www_root             = undef,
   $autoindex            = undef,
-  $index_files          = [
-    'index.html',
-    'index.htm',
-    'index.php'],
+  $index_files          = undef,
   $proxy                = undef,
   $proxy_redirect       = $::nginx::config::proxy_redirect,
   $proxy_read_timeout   = $::nginx::config::proxy_read_timeout,
@@ -206,7 +203,11 @@ define nginx::resource::location (
   if ($autoindex != undef) {
     validate_string($autoindex)
   }
-  validate_array($index_files)
+  
+  if ($index_files != undef){
+    validate_array($index_files)
+  }
+  
   if ($proxy != undef) {
     validate_string($proxy)
   }

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -204,7 +204,7 @@ define nginx::resource::location (
     validate_string($autoindex)
   }
   
-  if ($index_files != undef){
+  if ($index_files != undef) {
     validate_array($index_files)
   }
   

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -112,6 +112,17 @@ define nginx::resource::streamhost (
     'absent' => absent,
     default  => 'link',
   }
+  
+  file {
+    default:
+      ensure  => directory,
+      mode    => '0755',
+    ; 
+    "${streamhost_dir}":
+    ;
+    "${streamhost_enable_dir}":
+    ;
+  }
 
   $name_sanitized = regsubst($name, ' ', '_', 'G')
   $config_file = "${streamhost_dir}/${name_sanitized}.conf"

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -113,15 +113,11 @@ define nginx::resource::streamhost (
     default  => 'link',
   }
   
-  file {
-    default:
+  file {[$streamhost_dir, $streamhost_enable_dir]:
       ensure  => directory,
-      mode    => '0755',
-    ; 
-    "${streamhost_dir}":
-    ;
-    "${streamhost_enable_dir}":
-    ;
+      owner   => $owner,
+      group   => $group,
+      mode    => $mode,
   }
 
   $name_sanitized = regsubst($name, ' ', '_', 'G')
@@ -132,8 +128,8 @@ define nginx::resource::streamhost (
       'absent' => absent,
       default  => 'file',
       require  => [
-        File["${streamhost_dir}"],
-        File["${streamhost_enable_dir}"],
+        File[$streamhost_dir],
+        File[$streamhost_enable_dir],
       ],
     },
     notify => Class['::nginx::service'],

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -113,12 +113,6 @@ define nginx::resource::streamhost (
     default  => 'link',
   }
   
-  file {[$streamhost_dir, $streamhost_enable_dir]:
-    ensure => directory,
-    owner  => $owner,
-    group  => $group,
-    mode   => $mode,
-  }
 
   $name_sanitized = regsubst($name, ' ', '_', 'G')
   $config_file = "${streamhost_dir}/${name_sanitized}.conf"

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -131,6 +131,10 @@ define nginx::resource::streamhost (
     ensure => $ensure ? {
       'absent' => absent,
       default  => 'file',
+      require  => [
+        File["${streamhost_dir}"],
+        File["${streamhost_enable_dir}"],
+      ],
     },
     notify => Class['::nginx::service'],
     owner  => $owner,

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -114,10 +114,10 @@ define nginx::resource::streamhost (
   }
   
   file {[$streamhost_dir, $streamhost_enable_dir]:
-      ensure  => directory,
-      owner   => $owner,
-      group   => $group,
-      mode    => $mode,
+    ensure  => directory,
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
   }
 
   $name_sanitized = regsubst($name, ' ', '_', 'G')

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -114,10 +114,10 @@ define nginx::resource::streamhost (
   }
   
   file {[$streamhost_dir, $streamhost_enable_dir]:
-    ensure  => directory,
-    owner   => $owner,
-    group   => $group,
-    mode    => $mode,
+    ensure => directory,
+    owner  => $owner,
+    group  => $group,
+    mode   => $mode,
   }
 
   $name_sanitized = regsubst($name, ' ', '_', 'G')

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -224,10 +224,7 @@ define nginx::resource::vhost (
   $fastcgi_script               = undef,
   $uwsgi                        = undef,
   $uwsgi_params                 = "${nginx::config::conf_dir}/uwsgi_params",
-  $index_files                  = [
-    'index.html',
-    'index.htm',
-    'index.php'],
+  $index_files                  = undef,
   $autoindex                    = undef,
   $server_name                  = [$name],
   $www_root                     = undef,
@@ -392,7 +389,11 @@ define nginx::resource::vhost (
     validate_string($uwsgi)
   }
   validate_string($uwsgi_params)
-  validate_array($index_files)
+  
+  if ($index_files != undef) {
+    validate_array($index_files)
+  }
+
   if ($autoindex != undef) {
     validate_string($autoindex)
   }

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -144,6 +144,11 @@ http {
   <%- end -%>
   <%- end -%>
 <% end -%>
+<% if @http_raw_append && Array(@http_raw_append).size > 0 -%>
+  <%- Array(@http_raw_append).each do |line| -%>
+  <%= line %>
+  <%- end -%>
+<% end -%>
 
   include <%= @conf_dir %>/conf.d/*.conf;
   include <%= @conf_dir %>/sites-enabled/*;

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -51,14 +51,29 @@ http {
 
   server_tokens <%= @server_tokens %>;
 
+<%- if @types_hash_max_size -%>
   types_hash_max_size <%= @types_hash_max_size %>;
+<%- end -%>
+
+<%- if @types_hash_bucket_size -%>
   types_hash_bucket_size <%= @types_hash_bucket_size %>;
+<%- end -%>
 
+<%- if @names_hash_bucket_size -%>
   server_names_hash_bucket_size <%= @names_hash_bucket_size %>;
-  server_names_hash_max_size <%= @names_hash_max_size %>;
+<%- end -%>
 
+<%- if @names_hash_max_size -%>
+  server_names_hash_max_size <%= @names_hash_max_size %>;
+<%- end -%>
+
+<%- if @keepalive_timeout -%>
   keepalive_timeout  <%= @keepalive_timeout %>;
+<%- end -%>
+
+<%- if @htttp_tcp_nodelay -%>
   tcp_nodelay        <%= @http_tcp_nodelay %>;
+<%- end -%>
 
 <% if @gzip == 'on' -%>
   gzip              on;

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -156,5 +156,6 @@ mail {
 <% if @stream -%>
 stream {
   include <%= @conf_dir %>/conf.stream.d/*.conf;
+  include <%= @conf_dir %>/streams-enabled/*.conf;
 }
 <% end -%>

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -51,29 +51,14 @@ http {
 
   server_tokens <%= @server_tokens %>;
 
-<%- if @types_hash_max_size -%>
   types_hash_max_size <%= @types_hash_max_size %>;
-<%- end -%>
-
-<%- if @types_hash_bucket_size -%>
   types_hash_bucket_size <%= @types_hash_bucket_size %>;
-<%- end -%>
 
-<%- if @names_hash_bucket_size -%>
   server_names_hash_bucket_size <%= @names_hash_bucket_size %>;
-<%- end -%>
-
-<%- if @names_hash_max_size -%>
   server_names_hash_max_size <%= @names_hash_max_size %>;
-<%- end -%>
 
-<%- if @keepalive_timeout -%>
   keepalive_timeout  <%= @keepalive_timeout %>;
-<%- end -%>
-
-<%- if @htttp_tcp_nodelay -%>
   tcp_nodelay        <%= @http_tcp_nodelay %>;
-<%- end -%>
 
 <% if @gzip == 'on' -%>
   gzip              on;

--- a/templates/streamhost/streamhost.erb
+++ b/templates/streamhost/streamhost.erb
@@ -17,7 +17,6 @@ server {
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
   <%- end -%>
 <%- end -%>
-  server_name           <%= @server_name.join(" ") %>;
 
   <% Array(@raw_prepend).each do |line| -%>
     <%= line %>

--- a/templates/vhost/locations/directory.erb
+++ b/templates/vhost/locations/directory.erb
@@ -5,9 +5,13 @@
 
     autoindex <%= @autoindex %>;
 <% end -%>
-<% if @index_files.count > 0 -%>
-    index    <% Array(@index_files).each do |i| %> <%= i %><% end %>;
+
+<% if defined? @index_files -%>
+  <%- if @index_files.count > 0 -%>
+      index    <% Array(@index_files).each do |i| %> <%= i %><% end %>;
+  <%- end -%>
 <% end -%>
+
 <% if @try_files -%>
     try_files<% @try_files.each do |try| -%> <%= try %><% end -%>;
 <% end -%>

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -139,9 +139,13 @@ server {
        return 301 https://$host<% if @ssl_port.to_i != 443 %>:<%= @ssl_port %><% end %>$request_uri;
   }
 <% end -%>
-<% if @index_files.count > 0 -%>
-  index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
+
+<% if defined? @index_files -%>
+  <%- if @index_files.count > 0 -%>
+    index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
+  <%- end -%>
 <% end -%>
+
 <% if defined? @log_by_lua -%>
   log_by_lua '<%= @log_by_lua %>';
 <% end -%>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -77,8 +77,11 @@ server {
 <% if defined? @gzip_types -%>
   gzip_types <%= @gzip_types %>;
 <% end -%>
-<% if @index_files.count > 0 -%>
-  index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
+
+<% if defined? @index_files -%>
+  <%- if @index_files.count > 0 -%>
+    index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
+  <%- end -%>
 <% end -%>
 
   access_log            <%= @ssl_access_log_real %>;


### PR DESCRIPTION
There were issues with the streamhosts implementation for TCP load balancing. Changes made to support successful implementation of a stream host within NGINX configurations:

1) added "include <%= @conf_dir %>/streams-enabled/.conf;" to stream {} section of nginx.conf.erb. In order to enable nginx to listen on the defined TCP port, the stream{} configuration needs to include the /etc/nginx/streams-enabled/.conf files.

2) Removed 'server_name' from streamhost.erb template. The 'server_name' parameter is not valid for a stream host implementation. Removed line 20: server_name <%= @server_name.join(" ") %>;

3) nginx::resource::streamhost.pp does not ensure that the /etc/nginx/streams-enabled and /etc/nginx/streams-available directories exist before creating the stream host files. Added a file resource to ensure these directories are created, and adjusted the file creation resource to require this resource when creating the files.