### PR TITLE
Add support for 'default' vhosts

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,6 +49,14 @@ nginx::resource::vhost { 'www.puppetlabs.com':
   www_root => '/var/www/www.puppetlabs.com',
 }
 ```
+### Creating a landing page if no other vhost matches:
+
+```puppet
+nginx::resource::vhost { 'fallback-host':
+  server_name => [],
+  www_root => '/var/www/www.puppetlabs.com',
+}
+```
 
 ### A more complex proxy example
 

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -61,7 +61,9 @@ server {
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
   <%- end -%>
 <%- end -%>
+<%- if @server_name.size > 0 -%>
   server_name           <%= @rewrite_www_to_non_www ? @server_name.join("  ").gsub(/(^| )(www\.)?(?=[a-z0-9])/, '') : @server_name.join(" ") %>;
+<%- end -%>
 <%- if instance_variables.any? { |iv| iv.to_s.include? 'auth_basic' } -%>
   <%- if defined? @auth_basic -%>
   auth_basic           "<%= @auth_basic %>";


### PR DESCRIPTION
Allow a user to specify an empty server_name array. This allows you to configure a 'fallback' vhost if no host header matches, which is useful if NGINX is an ssl termination point for something like varnish.