### PR TITLE
Add rewrite_to_https_port setting support

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -135,6 +135,8 @@
 #     put before everything else inside vhost ssl
 #   [*rewrite_to_https*]        - Adds a server directive and rewrite rule to
 #     rewrite to ssl
+#   [*rewrite_to_https_port*]   - Add https port to rewrite. Useful, when nginx
+#     SSL is behind port multiplexer. Default to 8443
 #   [*include_files*]           - Adds include files to vhost
 #   [*access_log*]              - Where to write access log. May add additional
 #     options like log format to the end.
@@ -235,6 +237,7 @@ define nginx::resource::vhost (
   $www_root                     = undef,
   $rewrite_www_to_non_www       = false,
   $rewrite_to_https             = undef,
+  $rewrite_to_https_port        = 8443,
   $location_custom_cfg          = undef,
   $location_cfg_prepend         = undef,
   $location_cfg_append          = undef,
@@ -410,6 +413,12 @@ define nginx::resource::vhost (
   validate_bool($rewrite_www_to_non_www)
   if ($rewrite_to_https != undef) {
     validate_bool($rewrite_to_https)
+  }
+  if is_string($rewrite_to_https_port) {
+    warning('DEPRECATION: String $rewrite_to_https_port must be converted to an integer. Integer string support will be removed in a future release.')
+  }
+  elsif !is_integer($rewrite_to_https_port) {
+    fail('$rewrite_to_https_port must be an integer.')
   }
   if ($raw_prepend != undef) {
     if (is_array($raw_prepend)) {

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -136,7 +136,7 @@ server {
 <% end -%>
 <% if @rewrite_to_https -%>
   if ($ssl_protocol = "") {
-       return 301 https://$host<% if @ssl_port.to_i != 443 %>:<%= @ssl_port %><% end %>$request_uri;
+       return 301 https://$host<% if @rewrite_to_https_port %><% if @rewrite_to_https_port.to_i != 443 %>:<%= @rewrite_to_https_port %><% end %><% elsif @ssl_port.to_i != 443 %>:<%= @ssl_port %><% end %>$request_uri;
   }
 <% end -%>
 <% if @index_files.count > 0 -%>


### PR DESCRIPTION
In situation, when nginx is behind port multiplexer, ex. [sslh](https://github.com/yrutschle/sslh), so nginx ssl is listening on `8443` and multiplexer on `443`, I was unable to set proper redirect to SSL. With this patch, we can set on which port we want to be redirected to SSL.

First if in template is to prevent using `@ssl_port` when `@rewrite_to_https_port` is defined. Second if is the same as for `@ssl_port`
