### PR TITLE
No reasons to manage separate files since confd_purge is available

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -227,14 +227,6 @@ class nginx::config(
     }
   }
 
-  file { "${conf_dir}/conf.d/vhost_autogen.conf":
-    ensure => absent,
-  }
-
-  file { "${conf_dir}/conf.mail.d/vhost_autogen.conf":
-    ensure => absent,
-  }
-
   file {$run_dir:
     ensure => directory,
   }
@@ -278,25 +270,9 @@ class nginx::config(
     }
   }
 
-  file { "${conf_dir}/sites-enabled/default":
-    ensure => absent,
-  }
-
   file { "${conf_dir}/nginx.conf":
     ensure  => file,
     content => template($conf_template),
-  }
-
-  file { "${conf_dir}/conf.d/proxy.conf":
-    ensure  => absent,
-  }
-
-  file { "${conf_dir}/conf.d/default.conf":
-    ensure => absent,
-  }
-
-  file { "${conf_dir}/conf.d/example_ssl.conf":
-    ensure => absent,
   }
 
   file { "${temp_dir}/nginx.d":


### PR DESCRIPTION
Module also prevents managing content of default files
if configuration files installed by rpm just removed, without supplying a sanitized safe content, they will be re-installed during rpm update,
this will leave site broken until next puppet run