### PR TITLE
Don't generate http locations if rewrite_to_https

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -569,7 +569,7 @@ define nginx::resource::vhost (
     notify => Class['::nginx::service'],
   }
 
-  $ssl_only = ($ssl == true) and (($ssl_port + 0) == ($listen_port + 0))
+  $ssl_only = ($ssl == true) and (($ssl_port + 0) == ($listen_port + 0) or $rewrite_to_https)
 
   if $use_default_location == true {
     # Create the default location reference for the vHost


### PR DESCRIPTION
The configuration I'm trying to produce being:

```
server {
  listen 80;
  server_name  host;
  return 301 https://$host$request_uri;
}

server {
  listen 443 ssl;
  server_name host;

  ssl on;

  location /foo {
  }
  location /bar {
  }
  # ...
```

Locations don't need to be present in both http and ssl servers.
