### PR TITLE
Allow locations with try_files only

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -333,7 +333,7 @@ define nginx::resource::location (
   if ($vhost == undef) {
     fail('Cannot create a location reference without attaching to a virtual host')
   }
-  if (($www_root == undef) and ($proxy == undef) and ($location_alias == undef) and ($stub_status == undef) and ($fastcgi == undef) and ($uwsgi == undef) and ($location_custom_cfg == undef) and ($internal == false)) {
+  if (($www_root == undef) and ($proxy == undef) and ($location_alias == undef) and ($stub_status == undef) and ($fastcgi == undef) and ($uwsgi == undef) and ($location_custom_cfg == undef) and ($internal == false) and ($try_files == undef)) {
     fail('Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, uwsgi, stub_status, internal, or location_custom_cfg defined')
   }
   if (($www_root != undef) and ($proxy != undef)) {
@@ -365,6 +365,8 @@ define nginx::resource::location (
     $content_real = template('nginx/vhost/locations/uwsgi.erb')
   } elsif ($www_root != undef) {
     $content_real = template('nginx/vhost/locations/directory.erb')
+  } elsif ($try_files != undef) {
+    $content_real = template('nginx/vhost/locations/try_files.erb')
   } else {
     $content_real = template('nginx/vhost/locations/empty.erb')
   }

--- a/templates/vhost/locations/try_files.erb
+++ b/templates/vhost/locations/try_files.erb
@@ -1,0 +1,3 @@
+<% if @try_files -%>
+    try_files<% @try_files.each do |try| -%> <%= try %><% end -%>;
+<% end -%>


### PR DESCRIPTION
This is already possible through location_custom_cfg with a manifest
that looks like:

nginx::resource::location { 'location name':
  location  => '/',
  vhost     => 'any vhost',
  location_custom_cfg => {
    'try_files' => '$uri $uri/ @rewrite',
  }
}

This change simplifies the part by allowing to use the try_files
directive on its own (without only in combination with, e.g., www_root):

nginx::resource::location { 'location name':
  location  => '/',
  vhost     => 'any vhost',
  try_files' => [ '$uri', '$uri/', '@rewrite' ],
}

That looks a bit better as know the user doesn't need to think about,
if he can use try_files or need to use location_custom_cfg in the current
context, anymore.

fixes #470