### PR TITLE
[keepalive_requests] added keepalive_requests parameter in nginx.conf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -68,6 +68,7 @@ class nginx::config(
   $http_tcp_nodelay               = 'on',
   $http_tcp_nopush                = 'off',
   $keepalive_timeout              = '65',
+  $keepalive_requests             = '100',
   $log_format                     = {},
   $mail                           = false,
   $stream                         = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,7 @@ class nginx (
   $http_tcp_nodelay               = undef,
   $http_tcp_nopush                = undef,
   $keepalive_timeout              = undef,
+  $keepalive_requests             = undef,
   $mail                           = undef,
   $multi_accept                   = undef,
   $names_hash_bucket_size         = undef,
@@ -164,6 +165,7 @@ class nginx (
         $http_tcp_nodelay or
         $http_tcp_nopush or
         $keepalive_timeout or
+        $keepalive_requests or
         $logdir or
         $log_format or
         $mail or
@@ -247,6 +249,7 @@ class nginx (
       http_tcp_nodelay               => $http_tcp_nodelay,
       http_tcp_nopush                => $http_tcp_nopush,
       keepalive_timeout              => $keepalive_timeout,
+      keepalive_requests             => $keepalive_requests,
       log_dir                        => $logdir,
       log_format                     => $log_format,
       mail                           => $mail,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -264,6 +264,12 @@ describe 'nginx::config' do
           match: '  keepalive_timeout  123;'
         },
         {
+          title: 'should set keepalive_requests',
+          attr: 'keepalive_requests',
+          value: '345',
+          match: '  keepalive_requests  345;'
+        },
+        {
           title: 'should set tcp_nodelay',
           attr: 'http_tcp_nodelay',
           value: 'on',
@@ -457,6 +463,12 @@ describe 'nginx::config' do
           attr: 'keepalive_timeout',
           value: '123',
           match: '  keepalive_timeout  123;'
+        },
+        {
+          title: 'should set keepalive_requests',
+          attr: 'keepalive_requests',
+          value: '345',
+          match: '  keepalive_requests  345;'
         },
         {
           title: 'should set mail',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -62,6 +62,7 @@ http {
   server_names_hash_max_size <%= @names_hash_max_size %>;
 
   keepalive_timeout  <%= @keepalive_timeout %>;
+  keepalive_requests  <%= @keepalive_requests %>;
   tcp_nodelay        <%= @http_tcp_nodelay %>;
 
 <% if @gzip == 'on' -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

set it to default value of 100 as shown in nginx config
Require this parameter as default value results in a huge number of TIME_WAIT connections with high QPS applications hitting nginx
The check has been copied from the keepalive_timeout parameter