### PR TITLE
add support for passenger on CentOS/RHEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,7 @@ nginx::nginx_mailhosts:
 
 ## Nginx with precompiled Passenger
 
-Currently this works only for Debian family and OpenBSD.
-
-On Debian it might look like:
+On Debian and CentOS it might look like:
 ```puppet
 class { 'nginx':
   package_source  => 'passenger',

--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ nginx::nginx_mailhosts:
 
 ## Nginx with precompiled Passenger
 
-On Debian and CentOS it might look like:
+Example configuration for Debian and RHEL / CentOS (pulling the Nginx and
+Passenger packages from the Phusion repo)
 ```puppet
 class { 'nginx':
   package_source  => 'passenger',

--- a/README.md
+++ b/README.md
@@ -146,8 +146,7 @@ nginx::nginx_mailhosts:
 
 ## Nginx with precompiled Passenger
 
-Example configuration for Debian and RHEL / CentOS (pulling the Nginx and
-Passenger packages from the Phusion repo)
+Example configuration for Debian and RHEL / CentOS (>6), pulling the Nginx and Passenger packages from the Phusion repo. See additional notes in [https://github.com/voxpupuli/puppet-nginx/blob/master/docs/quickstart.md](https://github.com/voxpupuli/puppet-nginx/blob/master/docs/quickstart.md)
 ```puppet
 class { 'nginx':
   package_source  => 'passenger',

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ class{'nginx':
     package_source => 'nginx-mainline'
 }
 ```
-The choices here are `nginx-stable` (the current 'production' level release) and `nginx-mainline` (where active development is occuring) - you can read a full explanation of the differences [here][nginxpackages].  
+The choices here are `nginx-stable` (the current 'production' level release), `nginx-mainline` (where active development is occuring), as well as `passenger` - you can read a full explanation of the differences [here][nginxpackages]. `passenger` will install Phusion Passenger, as well as their version of nginx built with Passenger support. Keep in mind that changing `package_source` may require some manual intervention if you change this setting after initial configuration. On CentOS 6 / RHEL 6, there is a soft dependency on EPEL (GeoIP package won't install without it).
 
 ### Creating Your First Virtual Host
 

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -41,6 +41,11 @@ class nginx::package::redhat (
           gpgkey   => 'http://nginx.org/keys/nginx_signing.key',
           before   => Package['nginx'],
         }
+
+        yumrepo { 'passenger':
+          ensure => absent,
+        }
+
       }
       'nginx-mainline': {
         yumrepo { 'nginx-release':
@@ -52,22 +57,36 @@ class nginx::package::redhat (
           gpgkey   => 'http://nginx.org/keys/nginx_signing.key',
           before   => Package['nginx'],
         }
-      }
-      'passenger': {
+
         yumrepo { 'passenger':
-          baseurl  => "https://oss-binaries.phusionpassenger.com/yum/passenger/el/${::operatingsystemmajrelease}/\$basearch",
-          descr    => 'passenger repo',
-          enabled  => '1',
-          gpgcheck => '0',
-          repo_gpgcheck => '1',
-          priority => '1',
-          gpgkey   => 'https://packagecloud.io/gpg.key',
-          before   => Package['nginx'],
+          ensure => absent,
         }
 
-        package { 'passenger':
-          ensure  => 'present',
-          require => Yumrepo['passenger'],
+      }
+      'passenger': {
+        if ($::operatingsystem in ['RedHat', 'CentOS']) and ($::operatingsystemmajrelease in ['6', '7']) {
+          yumrepo { 'passenger':
+            baseurl       => "https://oss-binaries.phusionpassenger.com/yum/passenger/el/${::operatingsystemmajrelease}/\$basearch",
+            descr         => 'passenger repo',
+            enabled       => '1',
+            gpgcheck      => '0',
+            repo_gpgcheck => '1',
+            priority      => '1',
+            gpgkey        => 'https://packagecloud.io/gpg.key',
+            before        => Package['nginx'],
+          }
+
+          yumrepo { 'nginx-release':
+            ensure => absent,
+          }
+
+          package { 'passenger':
+            ensure  => present,
+            require => Yumrepo['passenger'],
+          }
+
+        } else {
+          fail("${::operatingsystem} version ${::operatingsystemmajrelease} is unsupported with \$package_source 'passenger'")
         }
       }
       default: {

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -53,8 +53,25 @@ class nginx::package::redhat (
           before   => Package['nginx'],
         }
       }
+      'passenger': {
+        yumrepo { 'passenger':
+          baseurl  => "https://oss-binaries.phusionpassenger.com/yum/passenger/el/${::operatingsystemmajrelease}/\$basearch",
+          descr    => 'passenger repo',
+          enabled  => '1',
+          gpgcheck => '0',
+          repo_gpgcheck => '1',
+          priority => '1',
+          gpgkey   => 'https://packagecloud.io/gpg.key',
+          before   => Package['nginx'],
+        }
+
+        package { 'passenger':
+          ensure  => 'present',
+          require => Yumrepo['passenger'],
+        }
+      }
       default: {
-        fail("\$package_source must be 'nginx-stable' or 'nginx-mainline'. It was set to '${package_source}'")
+        fail("\$package_source must be 'nginx-stable', 'nginx-mainline', or 'passenger'. It was set to '${package_source}'")
       }
     }
   }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -1,22 +1,79 @@
 require 'spec_helper_acceptance'
 
 describe 'nginx class:' do
+  case fact('osfamily')
+  when 'RedHat'
+    pkg_cmd = 'yum info nginx | grep "^From repo"'
+    pkg_remove_cmd = 'yum -y remove nginx nginx-filesystem passenger'
+    pkg_match = %r{passenger}
+  when 'Debian'
+    pkg_cmd = 'dpkg -s nginx | grep ^Maintainer'
+    pkg_remove_cmd = 'apt-get -y remove nginx nginx-common'
+    pkg_match = %r{Phusion}
+  end
+
   context 'default parameters' do
     it 'runs successfully' do
       pp = "class { 'nginx': }"
-
       # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)
       expect(apply_manifest(pp, catch_failures: true).exit_code).to be_zero
     end
+
+    describe package('nginx') do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('nginx') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
   end
 
-  describe package('nginx') do
-    it { is_expected.to be_installed }
+  context 'nginx with package_source passenger' do
+    # TODO: also test for (expected) failure on 5
+    unless fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') == '5'
+      it 'runs successfully' do
+        shell(pkg_remove_cmd)
+        pp = <<-EOS
+          class { 'nginx':
+            package_source => 'passenger'
+          }
+        EOS
+
+        apply_manifest(pp, catch_failures: true)
+      end
+
+      describe package('nginx') do
+        it { is_expected.to be_installed }
+        it 'comes from the expected source' do
+          pkg_output = shell(pkg_cmd)
+          expect(pkg_output.stdout).to match pkg_match
+        end
+      end
+
+      if fact('osfamily') == 'Debian'
+        describe package('nginx-extras') do
+          it { is_expected.to be_installed }
+        end
+      end
+
+      describe package('passenger') do
+        it { is_expected.to be_installed }
+      end
+
+      describe service('nginx') do
+        it { is_expected.to be_running }
+        it { is_expected.to be_enabled }
+      end
+    end
   end
 
-  describe service('nginx') do
-    it { is_expected.to be_running }
-    it { is_expected.to be_enabled }
+  context 'reset to default parameters' do
+    it 'runs successfully' do
+      shell(pkg_remove_cmd)
+      pp = "class { 'nginx': }"
+      apply_manifest(pp, catch_failures: true)
+    end
   end
 end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -28,6 +28,14 @@ describe 'nginx::package' do
       end
     end
 
+    context "package_source => passenger" do
+      let(:params) {{ :package_source => 'passenger' }}
+      it { is_expected.to contain_yumrepo('passenger').with(
+        'baseurl'  => 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/6/$basearch',
+      )}
+      it { is_expected.to contain_package('passenger') }
+    end
+
     context 'manage_repo => false' do
       let(:facts) { { operatingsystem: operatingsystem, osfamily: 'RedHat', operatingsystemmajrelease: '7' } }
       let(:params) { { manage_repo: false } }

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -15,6 +15,11 @@ describe 'nginx::package' do
           'gpgkey'   => 'http://nginx.org/keys/nginx_signing.key'
         )
       end
+      it do
+        is_expected.to contain_yumrepo('passenger').with(
+          'ensure' => 'absent'
+        )
+      end
       it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::redhat]') }
       it { is_expected.to contain_anchor('nginx::package::end').that_requires('Class[nginx::package::redhat]') }
     end
@@ -26,13 +31,28 @@ describe 'nginx::package' do
           'baseurl' => "http://nginx.org/packages/mainline/#{operatingsystem == 'CentOS' ? 'centos' : 'rhel'}/6/$basearch/"
         )
       end
+      it do
+        is_expected.to contain_yumrepo('passenger').with(
+          'ensure' => 'absent'
+        )
+      end
     end
 
-    context "package_source => passenger" do
-      let(:params) {{ :package_source => 'passenger' }}
-      it { is_expected.to contain_yumrepo('passenger').with(
-        'baseurl'  => 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/6/$basearch',
-      )}
+    context 'package_source => passenger' do
+      let(:params) { { package_source: 'passenger' } }
+      it do
+        is_expected.to contain_yumrepo('passenger').with(
+          'baseurl'       => 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/6/$basearch',
+          'gpgcheck'      => '0',
+          'repo_gpgcheck' => '1',
+          'gpgkey'        => 'https://packagecloud.io/gpg.key'
+        )
+      end
+      it do
+        is_expected.to contain_yumrepo('nginx-release').with(
+          'ensure' => 'absent'
+        )
+      end
       it { is_expected.to contain_package('passenger') }
     end
 
@@ -50,6 +70,14 @@ describe 'nginx::package' do
         is_expected.to contain_yumrepo('nginx-release').with(
           'baseurl' => "http://nginx.org/packages/#{operatingsystem == 'CentOS' ? 'centos' : 'rhel'}/5/$basearch/"
         )
+      end
+    end
+
+    context 'RedHat / CentOS 5 with package_source => passenger' do
+      let(:facts) { { operatingsystem: operatingsystem, osfamily: 'RedHat', operatingsystemmajrelease: '5' } }
+      let(:params) { { package_source: 'passenger' } }
+      it 'we fail' do
+        expect { catalogue }.to raise_error(Puppet::Error, %r{is unsupported with \$package_source})
       end
     end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -16,6 +16,11 @@ RSpec.configure do |c|
       copy_module_to(host, source: proj_root, module_name: 'nginx')
       if fact('osfamily') == 'Debian'
         on host, puppet('module', 'install', 'puppetlabs-apt'), acceptable_exit_codes: [0, 1]
+      elsif fact('osfamily') == 'RedHat'
+        # Cheat to work around soft dep on EPEL for CentOS / EL 6
+        if fact_on(host, 'operatingsystemmajrelease') == '6'
+          install_package(host, 'epel-release')
+        end
       end
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
       on host, puppet('module', 'install', 'puppetlabs-concat'), acceptable_exit_codes: [0, 1]


### PR DESCRIPTION
This contains elements of @jlambert121's #786, but addresses @3flex's feedback from back in June, as well as improving test coverage slightly. It's also based against current upstream, so shouldn't need a rebase.

If preferred, I can submit on top of #786, but wasn't sure how to do that.