### PR TITLE
Add confd_only option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,7 @@ class nginx (
   ### END Nginx Configuration
 
   ### START Module/App Configuration ###
+  $confd_only                     = undef,
   $confd_purge                    = undef,
   $conf_dir                       = undef,
   $daemon_user                    = undef,
@@ -234,6 +235,7 @@ class nginx (
       client_body_temp_path          => $client_body_temp_path,
       client_max_body_size           => $client_max_body_size,
       confd_purge                    => $confd_purge,
+      confd_only                     => $confd_only,
       conf_dir                       => $conf_dir,
       conf_template                  => $conf_template,
       daemon_user                    => $daemon_user,

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -363,7 +363,13 @@ define nginx::resource::location (
   }
 
   $vhost_sanitized = regsubst($vhost, ' ', '_', 'G')
-  $config_file = "${::nginx::config::conf_dir}/sites-available/${vhost_sanitized}.conf"
+  if $::nginx::config::confd_only {
+    $vhost_dir = "${::nginx::config::conf_dir}/conf.d"
+  } else {
+    $vhost_dir = "${::nginx::config::conf_dir}/sites-available"
+  }
+
+  $config_file = "${vhost_dir}/${vhost_sanitized}.conf"
 
   $location_sanitized_tmp = regsubst($location, '\/', '_', 'G')
   $location_sanitized = regsubst($location_sanitized_tmp, '\\\\', '_', 'G')

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -20,6 +20,15 @@ describe 'nginx::config' do
       )
     end
     it do
+      is_expected.to contain_file('/etc/nginx/conf.stream.d').only_with(
+        path: '/etc/nginx/conf.stream.d',
+        ensure: 'directory',
+        owner: 'root',
+        group: 'root',
+        mode: '0644'
+      )
+    end
+    it do
       is_expected.to contain_file('/etc/nginx/conf.mail.d').only_with(
         path: '/etc/nginx/conf.mail.d',
         ensure: 'directory',
@@ -632,6 +641,24 @@ describe 'nginx::config' do
       end
     end
 
+    context 'when confd_only true' do
+      let(:params) { { confd_only: true } }
+      it do
+        is_expected.to contain_file('/etc/nginx/conf.d').without(
+          %w(
+            ignore
+            purge
+            recurse
+          )
+        )
+        is_expected.not_to contain_file('/etc/nginx/sites-available')
+        is_expected.not_to contain_file('/etc/nginx/sites-enabled')
+        is_expected.to contain_file('/etc/nginx/nginx.conf').without_content(%r{include /path/to/nginx/sites-enabled/\*;})
+        is_expected.not_to contain_file('/etc/nginx/streams-available')
+        is_expected.not_to contain_file('/etc/nginx/streams-enabled')
+      end
+    end
+
     context 'when vhost_purge true' do
       let(:params) { { vhost_purge: true } }
       it do
@@ -644,6 +671,51 @@ describe 'nginx::config' do
         is_expected.to contain_file('/etc/nginx/sites-enabled').with(
           purge: true,
           recurse: true
+        )
+      end
+    end
+
+    context 'when confd_purge true, vhost_purge true, and confd_only true' do
+      let(:params) do
+        {
+          confd_purge: true,
+          confd_only: true,
+          vhost_purge: true
+        }
+      end
+      it do
+        is_expected.to contain_file('/etc/nginx/conf.d').with(
+          purge: true,
+          recurse: true
+        )
+      end
+      it do
+        is_expected.to contain_file('/etc/nginx/conf.stream.d').with(
+          purge: true,
+          recurse: true
+        )
+      end
+    end
+
+    context 'when confd_purge true, vhost_purge default (false), confd_only true' do
+      let(:params) do
+        {
+          confd_purge: true,
+          confd_only: true
+        }
+      end
+      it do
+        is_expected.to contain_file('/etc/nginx/conf.d').without(
+          %w(
+            purge
+          )
+        )
+      end
+      it do
+        is_expected.to contain_file('/etc/nginx/conf.stream.d').without(
+          %w(
+            purge
+          )
         )
       end
     end
@@ -677,12 +749,42 @@ describe 'nginx::config' do
           )
         )
       end
-    end
-
-    context 'when stream true' do
-      let(:params) { { stream: true } }
-      it { is_expected.to contain_file('/etc/nginx/streams-available') }
-      it { is_expected.to contain_file('/etc/nginx/streams-enabled') }
+      it do
+        is_expected.to contain_file('/etc/nginx/streams-available').without(
+          %w(
+            ignore
+            purge
+            recurse
+          )
+        )
+      end
+      it do
+        is_expected.to contain_file('/etc/nginx/streams-enabled').without(
+          %w(
+            ignore
+            purge
+            recurse
+          )
+        )
+      end
+      it do
+        is_expected.to contain_file('/etc/nginx/streams-available').without(
+          %w(
+            ignore
+            purge
+            recurse
+          )
+        )
+      end
+      it do
+        is_expected.to contain_file('/etc/nginx/streams-enabled').without(
+          %w(
+            ignore
+            purge
+            recurse
+          )
+        )
+      end
     end
 
     context 'when daemon_user = www-data' do

--- a/spec/defines/resource_stream_spec.rb
+++ b/spec/defines/resource_stream_spec.rb
@@ -36,6 +36,17 @@ describe 'nginx::resource::streamhost' do
       end
     end
 
+    describe 'when confd_only true' do
+      let(:pre_condition) { 'class { "nginx": confd_only => true }' }
+      let(:params) { default_params }
+      it { is_expected.to contain_class('nginx::config') }
+      it do
+        is_expected.to contain_concat("/etc/nginx/conf.stream.d/#{title}.conf").with('owner' => 'root',
+                                                                                     'group' => 'root',
+                                                                                     'mode'  => '0644')
+      end
+    end
+
     describe 'vhost_header template content' do
       [
         {

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -43,6 +43,19 @@ describe 'nginx::resource::vhost' do
       end
     end
 
+    describe 'with $confd_only enabled' do
+      let(:pre_condition) { 'class { "nginx": confd_only => true }' }
+      let(:params) { default_params }
+      it { is_expected.to contain_class('nginx::config') }
+      it do
+        is_expected.to contain_concat("/etc/nginx/conf.d/#{title}.conf").with('owner' => 'root',
+                                                                              'group' => 'root',
+                                                                              'mode'  => '0644')
+        is_expected.not_to contain_file('/etc/nginx/sites-enabled')
+        is_expected.not_to contain_file('/etc/nginx/sites-available')
+      end
+    end
+
     describe 'vhost_header template content' do
       [
         {

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -176,7 +176,9 @@ http {
 <% end -%>
 
   include <%= @conf_dir %>/conf.d/*.conf;
+<% unless @confd_only -%>
   include <%= @conf_dir %>/sites-enabled/*;
+<% end -%>
 }
 <% if @mail -%>
 mail {


### PR DESCRIPTION
This PR adds an option `$confd_only` (defaulting to false), that avoids using the Ubuntu style `$conf_dir/sites-{available,enabled}` mechanism with symlinks. Obviously, the current way works, but I don't personally prefer it; also, presumably one is using Puppet to manage configs in a lot of scenarios, so on platforms where this convention isn't used, or when managing all of the nginx configs through Puppet, the symlinks don't really gain you much advantage.

A couple notes:
1) It just doesn't force the resource if the param is set, so `$conf_dir/sites-{available,enabled}` won't be forced to be present or absent
2) To purge, with `$confd_only` set, both `$vhost_purge` and `$confd_purge` must be set, otherwise, it will silently not purge (I can make it fail in that case if folks think it's cleaner).
3) With the option set, the `sites-enabled` dir will also not be included in the main nginx.conf

I can't tell where the main configurable params of the module are documented; the resources have their parameters documented, but init.pp and config.pp don't seem to have the main params documented. But the caveat above should probably be documented somewhere.

Happy for suggestions of improvements, or about making the style more consistent (I purposely didn't use the `if $foo == true`style used elsewhere in the module for things that are already verified as booleans, though I didn't change existing cases) or improve test coverage further.