### PR TITLE
Add missing stream dirs and create streams from hiera

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -264,6 +264,33 @@ class nginx::config(
     owner  => $daemon_user,
   }
 
+  if $stream {
+    file { "${conf_dir}/streams-available":
+      ensure => directory,
+      owner  => $sites_available_owner,
+      group  => $sites_available_group,
+      mode   => $sites_available_mode,
+    }
+
+    if $vhost_purge == true {
+      File["${conf_dir}/streams-available"] {
+        purge   => true,
+        recurse => true,
+      }
+    }
+
+    file { "${conf_dir}/streams-enabled":
+      ensure => directory,
+    }
+
+    if $vhost_purge == true {
+      File["${conf_dir}/streams-enabled"] {
+        purge   => true,
+        recurse => true,
+      }
+    }
+  }
+
   file { "${conf_dir}/sites-available":
     ensure => directory,
     owner  => $sites_available_owner,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,6 +123,7 @@ class nginx (
   $string_mappings                = {},
   $nginx_locations                = {},
   $nginx_mailhosts                = {},
+  $nginx_streamhosts              = {},
   $nginx_upstreams                = {},
   $nginx_vhosts                   = {},
   $nginx_vhosts_defaults          = {},
@@ -311,6 +312,7 @@ class nginx (
   create_resources('nginx::resource::vhost', $nginx_vhosts, $nginx_vhosts_defaults)
   create_resources('nginx::resource::location', $nginx_locations)
   create_resources('nginx::resource::mailhost', $nginx_mailhosts)
+  create_resources('nginx::resource::streamhost', $nginx_streamhosts)
   create_resources('nginx::resource::map', $string_mappings)
   create_resources('nginx::resource::geo', $geo_mappings)
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -636,6 +636,12 @@ describe 'nginx::config' do
       end
     end
 
+    context 'when stream true' do
+      let(:params) { { stream: true } }
+      it { is_expected.to contain_file('/etc/nginx/streams-available') }
+      it { is_expected.to contain_file('/etc/nginx/streams-enabled') }
+    end
+
     context 'when daemon_user = www-data' do
       let(:params) { { daemon_user: 'www-data' } }
       it { is_expected.to contain_file('/var/nginx/client_body_temp').with(owner: 'www-data') }

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -13,7 +13,8 @@ describe 'nginx' do
       nginx_vhosts: { 'test2.local' => { 'www_root' => '/' } },
       nginx_vhosts_defaults: { 'listen_options' => 'default_server' },
       nginx_locations: { 'test2.local' => { 'vhost' => 'test2.local', 'www_root' => '/' } },
-      nginx_mailhosts: { 'smtp.test2.local' => { 'auth_http' => 'server2.example/cgi-bin/auth', 'protocol' => 'smtp', 'listen_port' => 587 } }
+      nginx_mailhosts: { 'smtp.test2.local' => { 'auth_http' => 'server2.example/cgi-bin/auth', 'protocol' => 'smtp', 'listen_port' => 587 } },
+      nginx_streamhosts: { 'streamhost1' => { 'proxy' => 'streamproxy' } }
     }
   end
 
@@ -32,5 +33,6 @@ describe 'nginx' do
     it { is_expected.to contain_nginx__resource__vhost('test2.local').with_listen_options('default_server') }
     it { is_expected.to contain_nginx__resource__location('test2.local') }
     it { is_expected.to contain_nginx__resource__mailhost('smtp.test2.local') }
+    it { is_expected.to contain_nginx__resource__streamhost('streamhost1').with_proxy('streamproxy') }
   end
 end


### PR DESCRIPTION
This creates the missing streams-available and streams-enabled
directories if stream is true and allow the streamhost resources
to be created from hiera.

Some simple tests are included.

This commit might replace PRs:
 - Fix streams support #790
 - Fixing Streamhost implementation support #784
