### PR TITLE
add $passenger_pre_start variable

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -152,6 +152,9 @@
 #     backend application (Passenger 5.0+)
 #   [*passenger_env_var*]       - Allows one to set environemnt variables to pass
 #     to the backend application (Passenger 5.0+)
+#   [*passenger_pre_start*]     - Allows setting a URL to pre-warm the host. Per
+#     Passenger docs, the "domain part of the URL" must match a value of
+#     server_name
 #   [*log_by_lua*]              - Run the Lua source code inlined as the
 #     <lua-script-str> at the log request processing phase.
 #     This does not replace the current access logs, but runs after.
@@ -272,6 +275,7 @@ define nginx::resource::vhost (
   $passenger_cgi_param          = undef,
   $passenger_set_header         = undef,
   $passenger_env_var            = undef,
+  $passenger_pre_start          = undef,
   $log_by_lua                   = undef,
   $log_by_lua_file              = undef,
   $use_default_location         = true,
@@ -510,6 +514,9 @@ define nginx::resource::vhost (
   }
   if ($passenger_env_var != undef) {
     validate_hash($passenger_env_var)
+  }
+  if ($passenger_pre_start != undef) {
+    validate_string($passenger_pre_start)
   }
   if ($log_by_lua != undef) {
     validate_string($log_by_lua)

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -997,6 +997,14 @@ describe 'nginx::resource::vhost' do
         it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{passenger_env_var  test3 test value 3;}) }
       end
 
+      context 'when passenger_pre_start is set' do
+        let :params do
+          default_params.merge(passenger_pre_start: 'http://example.com:80/test/me')
+        end
+
+        it { is_expected.to contain_concat__fragment("#{title}-footer").with_content(%r{passenger_pre_start http://example.com:80/test/me;}) }
+      end
+
       context 'when vhost name is sanitized' do
         let(:title) { 'www rspec-vhost com' }
         let(:params) { default_params }

--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -25,3 +25,6 @@
   <%= line %>
 <% end -%>
 }
+<% if @passenger_pre_start -%>
+passenger_pre_start <%= @passenger_pre_start %>;
+<% end -%>


### PR DESCRIPTION
passenger_pre_start (unlike other passenger settings that are not directly in the module, and can be easily added with an 'append' directive inside the vhost) has to be outside the scope of the `server {}` block. If this is too specific, I could alternatively make a different append variable that appends in the vhost file but outside that block.

I believe it might be possible to put it in `http {}` also, but most examples show it following the `server {}` block, but outside of its scope. 
https://www.phusionpassenger.com/library/config/nginx/reference/#passenger_pre_start

Since the required stdlib version still doesn't seem to have a validate_url function, I just validated that it was a string, rather than trying to come up with a regex that would validate all possible valid URLs.

I added a test, but didn't add a test for the actual validation of parameters (most other params don't seem to have this at present).