### PR TITLE
Fix acceptance test failures with newer Beaker versions

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,9 +1,7 @@
 require 'beaker-rspec'
+require 'pry'
 
-hosts.each do |host|
-  # Install Puppet
-  on host, install_puppet
-end
+install_puppet_on(hosts)
 
 RSpec.configure do |c|
   # Project root
@@ -25,7 +23,7 @@ RSpec.configure do |c|
       # Fake keys.
       # Valid self-signed SSL key with 10 year expiry.
       # Required for nginx to start when SSL enabled
-      on host, shell('echo "-----BEGIN PRIVATE KEY-----
+      on host, 'echo "-----BEGIN PRIVATE KEY-----
 MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAOPchwRZRF4KmU6E
 g7C6Pq9zhdLiQt9owdcLZNiZS+UVRQjeDHSy3titzh5YwSoQonlnSqd0g/PJ6kNA
 O3CNOMVuzAddnAaHzW1J4Rt6sZwOuidtJC4t/hFCgz5NqOMgYOOfratQx00A7ZXK
@@ -40,8 +38,8 @@ KElopJlrX2ZFZwiM2m2yIjbDPMb6DwJAbNoiUbzZHOInVTA0316fzGEu7kKeZZYv
 J9lmX7GV9nUCM7lKVD2ckFOQNlMwCURs8ukJh7H/MfQ8Dt5xoQAMjQJBAOWpK6k6
 b0fTREZFZRGZBJcSu959YyMzhpSFA+lXkLNTWX8j1/D88H731oMSImoQNWcYx2dH
 sCwOCDqu1nZ2LJ8=
------END PRIVATE KEY-----" > /tmp/blah.key')
-      on host, shell('echo "-----BEGIN CERTIFICATE-----
+-----END PRIVATE KEY-----" > /tmp/blah.key'
+      on host, 'echo "-----BEGIN CERTIFICATE-----
 MIIDRjCCAq+gAwIBAgIJAL9m0V4sHW2tMA0GCSqGSIb3DQEBBQUAMIG7MQswCQYD
 VQQGEwItLTESMBAGA1UECAwJU29tZVN0YXRlMREwDwYDVQQHDAhTb21lQ2l0eTEZ
 MBcGA1UECgwQU29tZU9yZ2FuaXphdGlvbjEfMB0GA1UECwwWU29tZU9yZ2FuaXph
@@ -60,7 +58,7 @@ tT+vngE0v6N8MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAwYYQKVRN
 HaHIWGMBuXApE7t4PNdYWZ5Y56tI+HT59yVoDjc1YSnuzkKlWUPibVYoLpX/ROKr
 aIZ8kxsBjLvpi9KQTHi7Wl6Sw3ecoYdKy+2P8S5xOIpWjs8XVmOWf7Tq1+9KPv3z
 HLw/FDCzntkdq3G4em15CdFlO9BTY4HXiHU=
------END CERTIFICATE-----" > /tmp/blah.cert')
+-----END CERTIFICATE-----" > /tmp/blah.cert'
     end
   end
 end


### PR DESCRIPTION
(re #882): Still getting a failure, but putting in this PR for when we get acceptance tests working with newer Beaker version. Presumably we should also require a specific version more explicitly?