### PR TITLE
more test and docs fixes for acceptance tests for CentOS / Passenger

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -15,7 +15,7 @@ class{'nginx':
     package_source => 'nginx-mainline'
 }
 ```
-The choices here are `nginx-stable` (the current 'production' level release), `nginx-mainline` (where active development is occuring), as well as `passenger` - you can read a full explanation of the differences [here][nginxpackages]. `passenger` will install Phusion Passenger, as well as their version of nginx built with Passenger support. Keep in mind that changing `package_source` may require some manual intervention if you change this setting after initial configuration. On CentOS 6 / RHEL 6, there is a soft dependency on EPEL (GeoIP package won't install without it).
+The choices here are `nginx-stable` (the current 'production' level release), `nginx-mainline` (where active development is occuring), as well as `passenger` - you can read a full explanation of the differences [here][nginxpackages]. `passenger` will install Phusion Passenger, as well as their version of nginx built with Passenger support. Keep in mind that changing `package_source` may require some manual intervention if you change this setting after initial configuration. On CentOS / RHEL, there is a soft dependency on EPEL for this (i.e., the module doesn't configure EPEL for you, but will fail if you don't have it).
 
 ### Creating Your First Virtual Host
 

--- a/spec/acceptance/nginx_vhost_spec.rb
+++ b/spec/acceptance/nginx_vhost_spec.rb
@@ -41,7 +41,7 @@ describe 'nginx::resource::vhost define:' do
     end
 
     it 'answers to www.puppetlabs.com without error' do
-      shell('/usr/bin/curl http://www.puppetlabs.com:80') do |r|
+      shell('/usr/bin/curl --fail http://www.puppetlabs.com:80') do |r|
         expect(r.exit_code).to be_zero
       end
     end
@@ -90,7 +90,7 @@ describe 'nginx::resource::vhost define:' do
     end
 
     it 'answers to http://www.puppetlabs.com without error' do
-      shell('/usr/bin/curl http://www.puppetlabs.com:80') do |r|
+      shell('/usr/bin/curl --fail http://www.puppetlabs.com:80') do |r|
         expect(r.exit_code).to eq(0)
       end
     end
@@ -104,7 +104,7 @@ describe 'nginx::resource::vhost define:' do
 
     it 'answers to https://www.puppetlabs.com without error' do
       # use --insecure because it's a self-signed cert
-      shell('/usr/bin/curl --insecure https://www.puppetlabs.com:443') do |r|
+      shell('/usr/bin/curl --fail --insecure https://www.puppetlabs.com:443') do |r|
         expect(r.exit_code).to eq(0)
       end
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -17,10 +17,8 @@ RSpec.configure do |c|
       if fact('osfamily') == 'Debian'
         on host, puppet('module', 'install', 'puppetlabs-apt'), acceptable_exit_codes: [0, 1]
       elsif fact('osfamily') == 'RedHat'
-        # Cheat to work around soft dep on EPEL for CentOS / EL 6
-        if fact_on(host, 'operatingsystemmajrelease') == '6'
-          install_package(host, 'epel-release')
-        end
+        # Soft dep on epel for Passenger
+        install_package(host, 'epel-release')
       end
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
       on host, puppet('module', 'install', 'puppetlabs-concat'), acceptable_exit_codes: [0, 1]


### PR DESCRIPTION
@3flex @ffrank 
Here's one more related to the now-merged #876 
@3flex says that #885 should address the other test failure (though there will probably be a conflict if one isn't rebased after the other is merged).

I also added the `--fail` (`-f`) option to curl for the vhost test calls that rely on exit status, which should return a non-zero exit code if there's a non-2XX response. Normally, curl will exit non-zero if there's a failure to connect in the first place, but if it connects and gets a 4XX or 5XX response, it will display the error but exit 0.
```
[root@centos-7-x64 tmp]# curl localhost
<html>
<head><title>502 Bad Gateway</title></head>
<body bgcolor="white">
<center><h1>502 Bad Gateway</h1></center>
<hr><center>nginx/1.10.1</center>
</body>
</html>
[root@centos-7-x64 tmp]# echo $?
0
[root@centos-7-x64 tmp]# curl -f localhost
curl: (22) The requested URL returned error: 502 Bad Gateway
[root@centos-7-x64 tmp]# echo $?
22
```

Should figure out if we want to explicitly add some kind of dependency on epel or just document it as I've done in the README.