### PR TITLE
Allow multiple access / error logs in main config and vhosts, other logging changes

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,6 +24,7 @@ class nginx::config(
   $global_mode                    = $::nginx::params::global_mode,
   $log_dir                        = $::nginx::params::log_dir,
   $http_access_log                = $::nginx::params::http_access_log,
+  $http_format_log                = undef,
   $nginx_error_log                = $::nginx::params::nginx_error_log,
   $nginx_error_log_severity       = 'error',
   $pid                            = $::nginx::params::pid,
@@ -198,9 +199,15 @@ class nginx::config(
     }
   }
 
-  validate_string($nginx_error_log)
+  if !(is_string($http_access_log) or is_array($http_access_log)) {
+    fail('$http_access_log must be either a string or array')
+  }
+
+  if !(is_string($nginx_error_log) or is_array($nginx_error_log)) {
+    fail('$nginx_error_log must be either a string or array')
+  }
+
   validate_re($nginx_error_log_severity,['debug','info','notice','warn','error','crit','alert','emerg'],'$nginx_error_log_severity must be debug, info, notice, warn, error, crit, alert or emerg')
-  validate_string($http_access_log)
   validate_string($proxy_headers_hash_bucket_size)
   validate_bool($super_user)
   ### END VALIDATIONS ###

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -126,6 +126,15 @@ describe 'nginx::config' do
           match: 'error_log  /path/to/error.log error;'
         },
         {
+          title: 'should set multiple error_logs',
+          attr: 'nginx_error_log',
+          value: ['/path/to/error.log', 'syslog:server=localhost'],
+          match: [
+            'error_log  /path/to/error.log error;',
+            'error_log  syslog:server=localhost error;'
+          ]
+        },
+        {
           title: 'should set error_log severity level',
           attr: 'nginx_error_log_severity',
           value: 'warn',
@@ -214,6 +223,21 @@ describe 'nginx::config' do
           attr: 'http_access_log',
           value: '/path/to/access.log',
           match: '  access_log  /path/to/access.log;'
+        },
+        {
+          title: 'should set multiple access_logs',
+          attr: 'http_access_log',
+          value: ['/path/to/access.log', 'syslog:server=localhost'],
+          match: [
+            '  access_log  /path/to/access.log;',
+            '  access_log  syslog:server=localhost;'
+          ]
+        },
+        {
+          title: 'should set custom log format',
+          attr: 'http_format_log',
+          value: 'mycustomformat',
+          match: '  access_log  /var/log/nginx/access.log mycustomformat;'
         },
         {
           title: 'should set sendfile',

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -243,6 +243,15 @@ describe 'nginx::resource::vhost' do
           match: '  access_log            /path/to/access.log combined;'
         },
         {
+          title: 'should set multiple access_log directives',
+          attr: 'access_log',
+          value: ['/path/to/log/1', 'syslog:server=localhost'],
+          match: [
+            '  access_log            /path/to/log/1 combined;',
+            '  access_log            syslog:server=localhost combined;'
+          ]
+        },
+        {
           title: 'should set access_log off',
           attr: 'access_log',
           value: 'off',
@@ -261,10 +270,31 @@ describe 'nginx::resource::vhost' do
           match: '  access_log            /var/log/nginx/www.rspec.example.com.access.log custom;'
         },
         {
+          title: 'should not include access_log in vhost when set to absent',
+          attr: 'access_log',
+          value: 'absent',
+          notmatch: 'access_log'
+        },
+        {
           title: 'should set error_log',
           attr: 'error_log',
           value: '/path/to/error.log',
           match: '  error_log             /path/to/error.log;'
+        },
+        {
+          title: 'should allow multiple error_log directives',
+          attr: 'error_log',
+          value: ['/path/to/error.log', 'syslog:server=localhost'],
+          match: [
+            '  error_log             /path/to/error.log;',
+            '  error_log             syslog:server=localhost;'
+          ]
+        },
+        {
+          title: 'should not include error_log in vhost when set to absent',
+          attr: 'error_log',
+          value: 'absent',
+          notmatch: 'error_log'
         },
         {
           title: 'should set error_pages',
@@ -567,10 +597,25 @@ describe 'nginx::resource::vhost' do
           match: '  access_log            /path/to/access.log combined;'
         },
         {
+          title: 'should set multiple access_log directives',
+          attr: 'access_log',
+          value: ['/path/to/log/1', 'syslog:server=localhost'],
+          match: [
+            '  access_log            /path/to/log/1 combined;',
+            '  access_log            syslog:server=localhost combined;'
+          ]
+        },
+        {
           title: 'should set access_log off',
           attr: 'access_log',
           value: 'off',
           match: '  access_log            off;'
+        },
+        {
+          title: 'should not include access_log in vhost when set to absent',
+          attr: 'access_log',
+          value: 'absent',
+          notmatch: 'access_log'
         },
         {
           title: 'should set access_log to syslog',
@@ -589,6 +634,21 @@ describe 'nginx::resource::vhost' do
           attr: 'error_log',
           value: '/path/to/error.log',
           match: '  error_log             /path/to/error.log;'
+        },
+        {
+          title: 'should allow multiple error_log directives',
+          attr: 'error_log',
+          value: ['/path/to/error.log', 'syslog:server=localhost'],
+          match: [
+            '  error_log             /path/to/error.log;',
+            '  error_log             syslog:server=localhost;'
+          ]
+        },
+        {
+          title: 'should not include error_log in vhost when set to absent',
+          attr: 'error_log',
+          value: 'absent',
+          notmatch: 'error_log'
         },
         {
           title: 'should set error_pages',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -10,7 +10,13 @@ worker_rlimit_nofile <%= @worker_rlimit_nofile %>;
 <% if @pid -%>
 pid        <%= @pid %>;
 <% end -%>
+<% if @nginx_error_log.is_a?(Array) -%>
+  <%- @nginx_error_log.each do |log_item| -%>
+error_log  <%= log_item %> <%= @nginx_error_log_severity %>;
+  <%- end -%>
+<% else -%>
 error_log  <%= @nginx_error_log %> <%= @nginx_error_log_severity %>;
+<% end -%>
 <% if @nginx_cfg_prepend -%>
 
 <%- field_width = @nginx_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
@@ -52,7 +58,13 @@ http {
 <% end -%>
 <% end -%>
 
-  access_log  <%= @http_access_log %>;
+<% if @http_access_log.is_a?(Array) -%>
+  <%- @http_access_log.each do |log_item| -%>
+  access_log  <%= log_item %><% if @http_format_log %> <%= @http_format_log%><% end %>;
+  <%- end -%>
+<% else -%>
+  access_log  <%= @http_access_log %><% if @http_format_log %> <%= @http_format_log%><% end %>;
+<% end -%>
 
 <% if @sendfile == 'on' -%>
   sendfile    on;

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -141,6 +141,7 @@ server {
 <% end -%>
 <% if @index_files.count > 0 -%>
   index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
+
 <% end -%>
 <% if defined? @log_by_lua -%>
   log_by_lua '<%= @log_by_lua %>';
@@ -148,10 +149,30 @@ server {
 <% if defined? @log_by_lua_file -%>
   log_by_lua_file "<%= @log_by_lua_file %>";
 <% end -%>
-
-  access_log            <%= @access_log_real %>;
-  error_log             <%= @error_log_real %>;
+<% if @access_log.is_a?(Array) -%>
+  <%- @access_log.each do |log_item| -%>
+  access_log            <%= log_item %> <%= @format_log %>;
+  <%- end -%>
+<% elsif @access_log == 'absent' -%>
+<% elsif @access_log == 'off' -%>
+  access_log            off;
+<% elsif not @access_log -%>
+  access_log            <%= scope['::nginx::config::log_dir'] %>/<%= @name_sanitized %>.access.log <%= @format_log %>;
+<% else -%>
+  access_log            <%= @access_log %> <%= @format_log %>;
+<% end -%>
+<% if @error_log.is_a?(Array) -%>
+  <%- @error_log.each do |log_item| -%>
+  error_log             <%= log_item %>;
+  <%- end -%>
+<% elsif @error_log == 'absent' -%>
+<% elsif not @error_log -%>
+  error_log             <%= scope['::nginx::config::log_dir'] %>/<%= @name_sanitized %>.error.log;
+<% else -%>
+  error_log             <%= @error_log %>;
+<% end -%>
 <% if @error_pages -%>
+
   <%- @error_pages.keys.sort.each do |key| -%>
   error_page  <%= key %> <%= @error_pages[key] %>;
   <%- end -%>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -79,11 +79,32 @@ server {
 <% end -%>
 <% if @index_files.count > 0 -%>
   index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
-<% end -%>
 
-  access_log            <%= @ssl_access_log_real %>;
-  error_log             <%= @ssl_error_log_real %>;
+<% end -%>
+<% if @access_log.is_a?(Array) -%>
+  <%- @access_log.each do |log_item| -%>
+  access_log            <%= log_item %> <%= @format_log %>;
+  <%- end -%>
+<% elsif @access_log == 'absent' -%>
+<% elsif @access_log == 'off' -%>
+  access_log            off;
+<% elsif not @access_log -%>
+  access_log            <%= scope['::nginx::config::log_dir'] %>/ssl-<%= @name_sanitized %>.access.log <%= @format_log %>;
+<% else -%>
+  access_log            <%= @access_log %> <%= @format_log %>;
+<% end -%>
+<% if @error_log.is_a?(Array) -%>
+  <%- @error_log.each do |log_item| -%>
+  error_log             <%= log_item %>;
+  <%- end -%>
+<% elsif @error_log == 'absent' -%>
+<% elsif not @error_log -%>
+  error_log             <%= scope['::nginx::config::log_dir'] %>/ssl-<%= @name_sanitized %>.error.log;
+<% else -%>
+  error_log             <%= @error_log %>;
+<% end -%>
 <% if @error_pages -%>
+
   <%- @error_pages.keys.sort.each do |key| -%>
   error_page  <%= key %> <%= @error_pages[key] %>;
   <%- end -%>


### PR DESCRIPTION
This PR should preserve backwards compatibility, but allows to specify multiple access and error log directives by passing in an array, resulting in something like the following:

```
  access_log            /var/log/nginx/test.log combined;
  access_log            syslog:server=localhost combined;
  error_log             /var/log/nginx/test-error.log;
  error_log             syslog:server=localhost;
```
This allows more complex configurations, admittedly at the cost of doing more work in the template, something that it seems was intentionally avoided before. Note that the severity (for main error log) or access log format (in http or vhost scope) can't be set separately per logfile, though I think this could still be done if necessary using raw config appends (or I could change it to take a hash instead of an array when it's not a string).

Some other changes:

- Support disabling the logs in vhost context by setting to the string 'absent'. This is different from setting them to 'off', since it should just default to the logfiles specified in nginx.conf. I am not sure that using 'absent' is the best way to do this, but because of the way the module works, doing undef doesn't seem practical (nor ideal when hiera is the data source); I'm open to suggestions for how to improve this (maybe just an empty string?)
- I don't think the bit about having the format specified in `nginx::vhost::access_log` freeform actually worked as documented, since even before, it followed `$format_log`.
- Adds the `$http_format_log` parameter in `nginx::config` (didn't add the passthrough for the deprecated way of setting since it's new). I left it out if it's set to default (undef); this will still give default ('combined') format, but will let you easily set 'off' there too if it's legal.