### PR TITLE
Custom fact fails when using openresty

### DIFF
--- a/lib/facter/nginx_version.rb
+++ b/lib/facter/nginx_version.rb
@@ -2,7 +2,7 @@ Facter.add(:nginx_version) do
   setcode do
     if Facter.value('kernel') != 'windows' && Facter::Util::Resolution.which('nginx')
       nginx_version = Facter::Util::Resolution.exec('nginx -v 2>&1')
-      %r{nginx version: nginx\/([\w\.]+)}.match(nginx_version)[1]
+      %r{nginx version: (nginx|openresty)\/([\w\.]+)}.match(nginx_version)[2]
     end
   end
 end

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -152,6 +152,9 @@
 #     backend application (Passenger 5.0+)
 #   [*passenger_env_var*]       - Allows one to set environemnt variables to pass
 #     to the backend application (Passenger 5.0+)
+#   [*passenger_pre_start*]     - Allows setting a URL to pre-warm the host. Per
+#     Passenger docs, the "domain part of the URL" must match a value of
+#     server_name
 #   [*log_by_lua*]              - Run the Lua source code inlined as the
 #     <lua-script-str> at the log request processing phase.
 #     This does not replace the current access logs, but runs after.
@@ -272,6 +275,7 @@ define nginx::resource::vhost (
   $passenger_cgi_param          = undef,
   $passenger_set_header         = undef,
   $passenger_env_var            = undef,
+  $passenger_pre_start          = undef,
   $log_by_lua                   = undef,
   $log_by_lua_file              = undef,
   $use_default_location         = true,
@@ -510,6 +514,9 @@ define nginx::resource::vhost (
   }
   if ($passenger_env_var != undef) {
     validate_hash($passenger_env_var)
+  }
+  if ($passenger_pre_start != undef) {
+    validate_string($passenger_pre_start)
   }
   if ($log_by_lua != undef) {
     validate_string($log_by_lua)

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -997,6 +997,14 @@ describe 'nginx::resource::vhost' do
         it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{passenger_env_var  test3 test value 3;}) }
       end
 
+      context 'when passenger_pre_start is set' do
+        let :params do
+          default_params.merge(passenger_pre_start: 'http://example.com:80/test/me')
+        end
+
+        it { is_expected.to contain_concat__fragment("#{title}-footer").with_content(%r{passenger_pre_start http://example.com:80/test/me;}) }
+      end
+
       context 'when vhost name is sanitized' do
         let(:title) { 'www rspec-vhost com' }
         let(:params) { default_params }

--- a/templates/vhost/vhost_footer.erb
+++ b/templates/vhost/vhost_footer.erb
@@ -25,3 +25,6 @@
   <%= line %>
 <% end -%>
 }
+<% if @passenger_pre_start -%>
+passenger_pre_start <%= @passenger_pre_start %>;
+<% end -%>


### PR DESCRIPTION
When a modified Nginx (for instance Openresty: http://openresty.org/en/) is installed, the custom fact fails, regardless of the puppet code for that host actually uses any code of the module.

The regular Nginx responds to -v: 'nginx version: nginx/1.6.3'. The Nginx in Openresty responds: 'nginx version: openresty/1.11.2.1'.