### PR TITLE
try to improve spacing in generated configs (Issue #742)

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -11,8 +11,8 @@ worker_rlimit_nofile <%= @worker_rlimit_nofile %>;
 pid        <%= @pid %>;
 <% end -%>
 error_log  <%= @nginx_error_log %> <%= @nginx_error_log_severity %>;
-
 <% if @nginx_cfg_prepend -%>
+
 <%- field_width = @nginx_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
 <%- @nginx_cfg_prepend.sort_by{|k,v| k}.each do |key,value| -%>
 <%- Array(value).each do |asubvalue| -%>
@@ -60,7 +60,6 @@ http {
   tcp_nopush on;
   <%- end -%>
 <% end -%>
-
   server_tokens <%= @server_tokens %>;
 
   types_hash_max_size <%= @types_hash_max_size %>;

--- a/templates/vhost/vhost_header.erb
+++ b/templates/vhost/vhost_header.erb
@@ -151,7 +151,6 @@ server {
 
   access_log            <%= @access_log_real %>;
   error_log             <%= @error_log_real %>;
-
 <% if @error_pages -%>
   <%- @error_pages.keys.sort.each do |key| -%>
   error_page  <%= key %> <%= @error_pages[key] %>;

--- a/templates/vhost/vhost_ssl_footer.erb
+++ b/templates/vhost/vhost_ssl_footer.erb
@@ -1,4 +1,4 @@
-<% if @include_files %>
+<% if @include_files -%>
   <%- @include_files.each do |file| -%>
   include <%= file %>;
   <%- end -%>

--- a/templates/vhost/vhost_ssl_header.erb
+++ b/templates/vhost/vhost_ssl_header.erb
@@ -83,15 +83,13 @@ server {
 
   access_log            <%= @ssl_access_log_real %>;
   error_log             <%= @ssl_error_log_real %>;
-
 <% if @error_pages -%>
   <%- @error_pages.keys.sort.each do |key| -%>
   error_page  <%= key %> <%= @error_pages[key] %>;
   <%- end -%>
 <% end -%>
-
-
 <% if @vhost_cfg_prepend -%>
+
   <%- @vhost_cfg_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
     <%- if value.is_a?(Hash) -%>
       <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>
@@ -107,6 +105,7 @@ server {
   <%- end -%>
 <% end -%>
 <% if @vhost_cfg_ssl_prepend -%>
+
   <%- @vhost_cfg_ssl_prepend.sort_by{ |k, v| k.to_s == 'allow' ? '' : k.to_s }.each do |key,value| -%>
     <%- if value.is_a?(Hash) -%>
       <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>


### PR DESCRIPTION
I think this should make at least some improvement w/r/t #742, would love to see some folks test this in the wild, but at the least, should only affect spacing.

Based on the example configs in the acceptance tests, at least, the spacing looks Ok to me.
```
root@ubuntu-server-1404-x64:/etc/nginx/sites-available# cat www.puppetlabs.com.conf 
# MANAGED BY PUPPET
server {
  listen *:80;
  server_name           www.puppetlabs.com;

  index  index.html index.htm index.php;

  access_log            /var/log/nginx/www.puppetlabs.com.access.log combined;
  error_log             /var/log/nginx/www.puppetlabs.com.error.log;

  location / {
    root      /var/www/www.puppetlabs.com;
    index     index.html index.htm index.php;
  }
}
# MANAGED BY PUPPET
server {
  listen       *:443 ssl;
  server_name  www.puppetlabs.com;

  ssl on;

  ssl_certificate           /etc/pki/tls/certs/blah.cert;
  ssl_certificate_key       /etc/pki/tls/private/blah.key;
  ssl_session_cache         shared:SSL:10m;
  ssl_session_timeout       5m;
  ssl_protocols             TLSv1 TLSv1.1 TLSv1.2;
  ssl_ciphers               ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
  ssl_prefer_server_ciphers on;

  index  index.html index.htm index.php;

  access_log            /var/log/nginx/ssl-www.puppetlabs.com.access.log combined;
  error_log             /var/log/nginx/ssl-www.puppetlabs.com.error.log;

  location / {
    root      /var/www/www.puppetlabs.com;
    index     index.html index.htm index.php;
  }
}
```

nginx.conf has some single lines breaking up sections of the main config, but I think it looks Ok.