### PR TITLE
accept_mutex default is off, not on

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,7 +44,7 @@ class nginx::config(
   ### END Module/App Configuration ###
 
   ### START Nginx Configuration ###
-  $accept_mutex                   = 'on',
+  $accept_mutex                   = 'off',
   $accept_mutex_delay             = '500ms',
   $client_body_buffer_size        = '128k',
   $client_max_body_size           = '10m',


### PR DESCRIPTION
See also #896 and #747 
Not sure if the default has changed, but since that was fairly recent, I doubt it has... this sets what seems to be the correct default setting for accept_mutex.