### PR TITLE
'Require' vhost dir / enable dir in files

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -593,10 +593,11 @@ define nginx::resource::vhost (
   }
 
   concat { $config_file:
-    owner  => $owner,
-    group  => $group,
-    mode   => $mode,
-    notify => Class['::nginx::service'],
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
+    notify  => Class['::nginx::service'],
+    require => [File[$vhost_dir], File[$vhost_enable_dir]],
   }
 
   $ssl_only = ($ssl == true) and (($ssl_port + 0) == ($listen_port + 0))
@@ -704,7 +705,7 @@ define nginx::resource::vhost (
     ensure  => $vhost_symlink_ensure,
     path    => "${vhost_enable_dir}/${name_sanitized}.conf",
     target  => $config_file,
-    require => Concat[$config_file],
+    require => [File[$vhost_dir], File[$vhost_enable_dir], Concat[$config_file]],
     notify  => Class['::nginx::service'],
   }
 


### PR DESCRIPTION
I think this might help with #894.
It passes spec and acceptance tests, but would like a review of this to make sure it's sane and makes sense. I couldn't think of an easy way to test this, but let me know if there's a test I should add.