### PR TITLE
update URL in notice

### DIFF
--- a/manifests/notice/config.pp
+++ b/manifests/notice/config.pp
@@ -1,5 +1,5 @@
 class nginx::notice::config {
-  $message = "[nginx] *** DEPRECATION WARNING***: HI! I notice that you're declaring some attributes in Class[nginx]. It is highly recommended to set these values via Hiera going forward. This will become mandatory in the near future. Please check out https://github.com/jfryman/puppet-nginx/blob/master/docs/hiera.md for more information."
+  $message = "[nginx] *** DEPRECATION WARNING***: HI! I notice that you're declaring some attributes in Class[nginx]. It is highly recommended to set these values via Hiera going forward. This will become mandatory in the near future. Please check out https://github.com/voxpupuli/puppet-nginx/blob/master/docs/hiera.md for more information."
 
   notify { $message: }
 }


### PR DESCRIPTION
This should address one of the comments in #905 

As far as whether we should still have that warning, given that #501 said we're no longer forcing puppet-module-data pattern, I'll leave that up to others, but this one seems safe to merge.