### PR TITLE
Prevent custom fact from complaining when openresty is installed

### DIFF
--- a/lib/facter/nginx_version.rb
+++ b/lib/facter/nginx_version.rb
@@ -2,7 +2,7 @@ Facter.add(:nginx_version) do
   setcode do
     if Facter.value('kernel') != 'windows' && Facter::Util::Resolution.which('nginx')
       nginx_version = Facter::Util::Resolution.exec('nginx -v 2>&1')
-      %r{nginx version: nginx\/([\w\.]+)}.match(nginx_version)[1]
+      %r{nginx version: (nginx|openresty)\/([\w\.]+)}.match(nginx_version)[2]
     end
   end
 end


### PR DESCRIPTION
Update of #890 that should apply to current master and preserve original authorship of commit.
@shoikan @alexjfisher 

(I tried making a pull request against the pull request, but because that master is now out of date again, it didn't work).