### PR TITLE
add test for openresty nginx version fact

### DIFF
--- a/spec/unit/facter/util/fact_nginx_version_spec.rb
+++ b/spec/unit/facter/util/fact_nginx_version_spec.rb
@@ -17,4 +17,11 @@ describe Facter::Util::Fact do
     end
     it { expect(Facter.fact(:nginx_version).value).to eq('0.7.0') }
   end
+  context 'with openresty nginx' do
+    before do
+      Facter::Util::Resolution.stubs(:which).with('nginx').returns(true)
+      Facter::Util::Resolution.stubs(:exec).with('nginx -v 2>&1').returns('nginx: nginx version: openresty/1.11.2.1')
+    end
+    it { expect(Facter.fact(:nginx_version).value).to eq('1.11.2.1') }
+  end
 end


### PR DESCRIPTION
#890 and #908 didn't include a test, seems like that might be a good idea.

@3flex: if you think there's still something that needs to be fixed in the regex per @alexjfisher's comments, let me know, and I'll fix it here as well (and squash).