### PR TITLE
set manage_repo to "false" by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,7 +107,7 @@ class nginx (
   $package_name                   = $::nginx::params::package_name,
   $package_source                 = 'nginx',
   $package_flavor                 = undef,
-  $manage_repo                    = $::nginx::params::manage_repo,
+  $manage_repo                    = false,
   ### END Package Configuration ###
 
   ### START Service Configuation ###

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -18,7 +18,7 @@ class nginx::package(
   $package_source = 'nginx',
   $package_ensure = 'present',
   $package_flavor = undef,
-  $manage_repo    = $::nginx::params::manage_repo,
+  $manage_repo    = false,
 ) inherits ::nginx::params {
 
   anchor { 'nginx::package::begin': }

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -14,7 +14,7 @@
 #
 # This class file is not called directly
 class nginx::package::debian(
-    $manage_repo    = true,
+    $manage_repo    = false,
     $package_name   = 'nginx',
     $package_source = 'nginx',
     $package_ensure = 'present'

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -14,7 +14,7 @@
 #
 # This class file is not called directly
 class nginx::package::redhat (
-  $manage_repo    = true,
+  $manage_repo    = false,
   $package_ensure = 'present',
   $package_name   = 'nginx',
   $package_source = 'nginx-stable',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,6 @@ class nginx::params {
     'log_dir'     => '/var/log/nginx',
     'run_dir'     => '/var/nginx',
     'package_name' => 'nginx',
-    'manage_repo'  => false,
   }
   case $::osfamily {
     'ArchLinux': {
@@ -19,16 +18,8 @@ class nginx::params {
       }
     }
     'Debian': {
-      if ($::operatingsystem == 'ubuntu' and $::lsbdistcodename in ['lucid', 'precise', 'trusty'])
-      or ($::operatingsystem == 'debian' and $::operatingsystemmajrelease in ['6', '7', '8']) {
-        $_module_os_overrides = {
-          'manage_repo' => true,
-          'daemon_user' => 'www-data',
-        }
-      } else {
-        $_module_os_overrides = {
-          'daemon_user' => 'www-data',
-        }
+      $_module_os_overrides = {
+        'daemon_user' => 'www-data',
       }
     }
     'FreeBSD': {
@@ -41,15 +32,6 @@ class nginx::params {
     'Gentoo': {
       $_module_os_overrides = {
         'package_name' => 'www-servers/nginx',
-      }
-    }
-    'RedHat': {
-      if ($::operatingsystem in ['RedHat', 'CentOS'] and $::operatingsystemmajrelease in ['5', '6', '7']) {
-        $_module_os_overrides = {
-          'manage_repo' => true,
-        }
-      } else {
-        $_module_os_overrides = {}
       }
     }
     'Solaris': {
@@ -96,7 +78,6 @@ class nginx::params {
   $global_group          = $_module_parameters['root_group']
   $global_mode           = '0644'
   $http_access_log_file  = 'access.log'
-  $manage_repo           = $_module_parameters['manage_repo']
   $nginx_error_log_file  = 'error.log'
   $root_group            = $_module_parameters['root_group']
   $package_name          = $_module_parameters['package_name']

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe 'nginx::package' do
   shared_examples 'redhat' do |operatingsystem|
     let(:facts) { { operatingsystem: operatingsystem, osfamily: 'RedHat', operatingsystemmajrelease: '6' } }
-    context 'using defaults' do
+    context 'manage_repo => true' do
+      let(:params) { { manage_repo: true } }
       it { is_expected.to contain_package('nginx') }
       it do
         is_expected.to contain_yumrepo('nginx-release').with(
@@ -25,7 +26,7 @@ describe 'nginx::package' do
     end
 
     context 'package_source => nginx-mainline' do
-      let(:params) { { package_source: 'nginx-mainline' } }
+      let(:params) { { package_source: 'nginx-mainline', manage_repo: true } }
       it do
         is_expected.to contain_yumrepo('nginx-release').with(
           'baseurl' => "http://nginx.org/packages/mainline/#{operatingsystem == 'CentOS' ? 'centos' : 'rhel'}/6/$basearch/"
@@ -39,7 +40,7 @@ describe 'nginx::package' do
     end
 
     context 'package_source => passenger' do
-      let(:params) { { package_source: 'passenger' } }
+      let(:params) { { package_source: 'passenger', manage_repo: true } }
       it do
         is_expected.to contain_yumrepo('passenger').with(
           'baseurl'       => 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/6/$basearch',
@@ -65,6 +66,7 @@ describe 'nginx::package' do
 
     context 'operatingsystemmajrelease = 5' do
       let(:facts) { { operatingsystem: operatingsystem, osfamily: 'RedHat', operatingsystemmajrelease: '5' } }
+      let(:params) { { manage_repo: true } }
       it { is_expected.to contain_package('nginx') }
       it do
         is_expected.to contain_yumrepo('nginx-release').with(
@@ -75,7 +77,7 @@ describe 'nginx::package' do
 
     context 'RedHat / CentOS 5 with package_source => passenger' do
       let(:facts) { { operatingsystem: operatingsystem, osfamily: 'RedHat', operatingsystemmajrelease: '5' } }
-      let(:params) { { package_source: 'passenger' } }
+      let(:params) { { package_source: 'passenger', manage_repo: true } }
       it 'we fail' do
         expect { catalogue }.to raise_error(Puppet::Error, %r{is unsupported with \$package_source})
       end
@@ -102,7 +104,8 @@ describe 'nginx::package' do
       }
     end
 
-    context 'using defaults' do
+    context 'manage_repo => true' do
+      let(:params) { { manage_repo: true } }
       it { is_expected.to contain_package('nginx') }
       it { is_expected.not_to contain_package('passenger') }
       it do
@@ -117,7 +120,7 @@ describe 'nginx::package' do
     end
 
     context 'package_source => nginx-mainline' do
-      let(:params) { { package_source: 'nginx-mainline' } }
+      let(:params) { { package_source: 'nginx-mainline', manage_repo: true } }
       it do
         is_expected.to contain_apt__source('nginx').with(
           'location' => "http://nginx.org/packages/mainline/#{operatingsystem.downcase}"
@@ -126,7 +129,7 @@ describe 'nginx::package' do
     end
 
     context "package_source => 'passenger'" do
-      let(:params) { { package_source: 'passenger' } }
+      let(:params) { { package_source: 'passenger', manage_repo: true } }
       it { is_expected.to contain_package('nginx') }
       it { is_expected.to contain_package('passenger') }
       it do


### PR DESCRIPTION
Closes #863 

From now on, this will have to be manually enabled by users according to the
needs of their environment.

cc @wyardley 

As I was updating the spec tests, it occurred to me that if this parameter defaults to "false", that it's probably redundant - if a user were to set a value for `package_source` then we already know that they must set `manage_repo => true` (so it's redundant). So maybe a better approach is to add a warning so that anyone who currently has `manage_repo` set to "true" is notified that in a future release they must explicitly set `package_source`, and that `manage_repo` is going away.

I think this is better than just changing the default without any notification, and eventually leads us to the same place.

Anyway I'll leave this open and await any feedback on the above, since otherwise this can be merged as is.