### PR TITLE
Remove broken configtest_enable option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,10 +111,8 @@ class nginx (
   ### END Package Configuration ###
 
   ### START Service Configuation ###
-  $configtest_enable              = false,
   $service_ensure                 = running,
   $service_flags                  = undef,
-  $service_restart                = '/etc/init.d/nginx reload',
   $service_name                   = undef,
   $service_manage                 = true,
   ### END Service Configuration ###
@@ -302,12 +300,10 @@ class nginx (
   Class['::nginx::package'] -> Class['::nginx::config'] ~> Class['::nginx::service']
 
   class { '::nginx::service':
-    configtest_enable => $configtest_enable,
-    service_ensure    => $service_ensure,
-    service_restart   => $service_restart,
-    service_name      => $service_name,
-    service_flags     => $service_flags,
-    service_manage    => $service_manage,
+    service_ensure => $service_ensure,
+    service_name   => $service_name,
+    service_flags  => $service_flags,
+    service_manage => $service_manage,
   }
 
   create_resources('nginx::resource::upstream', $nginx_upstreams)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,8 +14,6 @@
 #
 # This class file is not called directly
 class nginx::service(
-  $configtest_enable = false,
-  $service_restart   = '/etc/init.d/nginx reload',
   $service_ensure    = 'running',
   $service_name      = 'nginx',
   $service_flags     = undef,
@@ -60,9 +58,4 @@ class nginx::service(
     }
   }
 
-  if $configtest_enable == true {
-    Service['nginx'] {
-      restart => $service_restart,
-    }
-  }
 }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 describe 'nginx::service' do
   let :params do
     {
-      configtest_enable: false,
-      service_restart: '/etc/init.d/nginx reload',
       service_ensure: 'running',
       service_name: 'nginx',
       service_manage: true
@@ -21,30 +19,6 @@ describe 'nginx::service' do
     end
 
     it { is_expected.to contain_service('nginx').without_restart }
-  end
-
-  describe 'when configtest_enable => true' do
-    let :params do
-      {
-        configtest_enable: true,
-        service_restart: '/etc/init.d/nginx reload',
-        service_ensure: 'running',
-        service_name: 'nginx'
-      }
-    end
-    it { is_expected.to contain_service('nginx').with_restart('/etc/init.d/nginx reload') }
-
-    context "when service_restart => 'a restart command'" do
-      let :params do
-        {
-          configtest_enable: true,
-          service_restart: 'a restart command',
-          service_ensure: 'running',
-          service_name: 'nginx'
-        }
-      end
-      it { is_expected.to contain_service('nginx').with_restart('a restart command') }
-    end
   end
 
   describe "when service_name => 'nginx14" do


### PR DESCRIPTION
Per #916, the `$configtest_enable` option doesn't seem if it could possibly work. In general, it would be good to review if everything here does what it is supposed to, but I think this will do the right thing on most platforms without any additional work.

I'm not sure if anyone would be using the `$service_restart` command directly, I'd think in most cases, we should be relying on `$service_name` and letting Puppet do the right thing, though I'm open to suggestion if people think `$service_restart` still needs to be exposed directly. What I don't understand is that, though it defaults to `/etc/init.d/nginx reload`, which doesn't work, the systems I tested all were using systemctl to restart the service anyway.

We still may want to revisit some kind of reporting back if the config test fails in a more generic way. I'm not going to address that one way or another for now.
