### PR TITLE
Support for proxy_pass_header directive.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -102,6 +102,7 @@ class nginx::config(
     'Proxy ""',
   ],
   $proxy_hide_header              = [],
+  $proxy_pass_header              = [],
   $sendfile                       = 'on',
   $server_tokens                  = 'on',
   $spdy                           = 'off',
@@ -133,6 +134,7 @@ class nginx::config(
   validate_string($multi_accept)
   validate_array($proxy_set_header)
   validate_array($proxy_hide_header)
+  validate_array($proxy_pass_header)
   if ($proxy_http_version != undef) {
     validate_string($proxy_http_version)
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,7 @@ class nginx (
   $proxy_send_timeout             = undef,
   $proxy_set_header               = undef,
   $proxy_hide_header              = undef,
+  $proxy_pass_header              = undef,
   $sendfile                       = undef,
   $server_tokens                  = undef,
   $spdy                           = undef,
@@ -193,6 +194,7 @@ class nginx (
         $proxy_send_timeout or
         $proxy_set_header or
         $proxy_hide_header or
+        $proxy_pass_header or
         $proxy_temp_path or
         $run_dir or
         $sendfile or
@@ -278,6 +280,7 @@ class nginx (
       proxy_send_timeout             => $proxy_send_timeout,
       proxy_set_header               => $proxy_set_header,
       proxy_hide_header              => $proxy_hide_header,
+      proxy_pass_header              => $proxy_pass_header,
       proxy_temp_path                => $proxy_temp_path,
       run_dir                        => $run_dir,
       sendfile                       => $sendfile,

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -32,6 +32,7 @@
 #     value of 90 seconds
 #   [*proxy_set_header*]     - Array of vhost headers to set
 #   [*proxy_hide_header*]    - Array of vhost headers to hide
+#   [*proxy_pass_header*]    - Array of vhost headers to pass
 #   [*fastcgi*]              - location of fastcgi (host:port)
 #   [*fastcgi_param*]        - Set additional custom fastcgi_params
 #   [*fastcgi_params*]       - optional alternative fastcgi_params file to use
@@ -153,6 +154,7 @@ define nginx::resource::location (
   $proxy_connect_timeout = $::nginx::config::proxy_connect_timeout,
   $proxy_set_header     = $::nginx::config::proxy_set_header,
   $proxy_hide_header    = $::nginx::config::proxy_hide_header,
+  $proxy_pass_header    = $::nginx::config::proxy_pass_header,
   $fastcgi              = undef,
   $fastcgi_param        = undef,
   $fastcgi_params       = "${::nginx::config::conf_dir}/fastcgi_params",
@@ -226,6 +228,7 @@ define nginx::resource::location (
   validate_string($proxy_connect_timeout)
   validate_array($proxy_set_header)
   validate_array($proxy_hide_header)
+  validate_array($proxy_pass_header)
   if ($fastcgi != undef) {
     validate_string($fastcgi)
   }

--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -234,6 +234,7 @@ define nginx::resource::vhost (
   $proxy_connect_timeout        = $::nginx::config::proxy_connect_timeout,
   $proxy_set_header             = $::nginx::config::proxy_set_header,
   $proxy_hide_header            = $::nginx::config::proxy_hide_header,
+  $proxy_pass_header            = $::nginx::config::proxy_pass_header,
   $proxy_cache                  = false,
   $proxy_cache_key              = undef,
   $proxy_cache_use_stale        = undef,
@@ -399,6 +400,7 @@ define nginx::resource::vhost (
   }
   validate_array($proxy_set_header)
   validate_array($proxy_hide_header)
+  validate_array($proxy_pass_header)
   if ($proxy_cache != false) {
     validate_string($proxy_cache)
   }
@@ -625,6 +627,7 @@ define nginx::resource::vhost (
       proxy_http_version          => $proxy_http_version,
       proxy_set_header            => $proxy_set_header,
       proxy_hide_header           => $proxy_hide_header,
+      proxy_pass_header           => $proxy_pass_header,
       proxy_set_body              => $proxy_set_body,
       proxy_buffering             => $proxy_buffering,
       fastcgi                     => $fastcgi,

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -568,6 +568,15 @@ describe 'nginx::config' do
           ]
         },
         {
+          title: 'should contain ordered appended proxy_pass_header directives',
+          attr: 'proxy_pass_header',
+          value: %w(header1 header2),
+          match: [
+            '  proxy_pass_header        header1;',
+            '  proxy_pass_header        header2;'
+          ]
+        },
+        {
           title: 'should set client_body_temp_path',
           attr: 'client_body_temp_path',
           value: '/path/to/body_temp',

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -688,6 +688,15 @@ describe 'nginx::resource::location' do
           ]
         },
         {
+          title: 'should pass proxy headers',
+          attr: 'proxy_pass_header',
+          value: ['X-TestHeader1 value1', 'X-TestHeader2 value2'],
+          match: [
+            %r{^\s+proxy_pass_header\s+X-TestHeader1 value1;},
+            %r{^\s+proxy_pass_header\s+X-TestHeader2 value2;}
+          ]
+        },
+        {
           title: 'should set proxy_http_version',
           attr: 'proxy_http_version',
           value: 'value',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -146,6 +146,9 @@ http {
 <% @proxy_hide_header.each do |header| -%>
   proxy_hide_header        <%= header %>;
 <% end -%>
+<% @proxy_pass_header.each do |header| -%>
+  proxy_pass_header        <%= header %>;
+<% end -%>
 <% if @proxy_headers_hash_bucket_size -%>
   proxy_headers_hash_bucket_size <%= @proxy_headers_hash_bucket_size %>;
 <% end -%>

--- a/templates/vhost/locations/proxy.erb
+++ b/templates/vhost/locations/proxy.erb
@@ -24,6 +24,11 @@
     proxy_hide_header      <%= header %>;
     <%- end -%>
 <% end -%>
+<% unless @proxy_pass_header.nil? -%>
+    <%- @proxy_pass_header.each do |header| -%>
+    proxy_pass_header      <%= header %>;
+    <%- end -%>
+<% end -%>
 <% if @proxy_cache -%>
     proxy_cache           <%= @proxy_cache %>;
 <% end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

It is better to explicitly define this than using raw_append or raw_prepend.

From nginx docs:
Permits passing otherwise disabled header fields from a proxied server to a client.
By default, nginx does not pass the header fields "Date", "Server", "X-Pad", and "X-Accel-..." from the response of a proxied server to a client.