### PR TITLE
Deprecate (RHEL 5, Debian 5-6, Ubuntu 10.04) in module metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -35,9 +35,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
+        "7",
+        "8"
       ]
     },
     {
@@ -46,7 +45,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -73,8 +71,7 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "12.04",
-        "10.04"
+        "12.04"
       ]
     }
   ]


### PR DESCRIPTION
Just what the title says. While it may still work, we should take official support for RHEL 5, Debian 5-6, Ubuntu 10.04 in the metadata, and add support for Debian 8 (which I believe is supported).

As to whether we will continue to list Solaris, AIX, NetBSD, etc. in the metadata, I haven't changed any of that.