### PR TITLE
uwsgi: allow custom uwsgi_param directives

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -40,6 +40,7 @@
 #   [*fastcgi_split_path*]   - Allows settings of fastcgi_split_path_info so
 #     that you can split the script_name and path_info via regex
 #   [*uwsgi*]              - location of uwsgi (host:port)
+#   [*uwsgi_param*]        - Set additional custom uwsgi_params
 #   [*uwsgi_params*]       - optional alternative uwsgi_params file to use
 #   [*uwsgi_read_timeout*]   - optional value for uwsgi_read_timeout
 #   [*ssl*]                  - Indicates whether to setup SSL bindings for
@@ -137,6 +138,17 @@
 #       'APP_ENV' => 'local',
 #    }
 #  }
+#
+#  Add Custom uwsgi_params
+#  nginx::resource::location { 'test2.local-bob':
+#    ensure   => present,
+#    www_root => '/var/www/bob',
+#    location => '/bob',
+#    vhost    => 'test2.local',
+#    uwsgi_param => {
+#       'APP_ENV' => 'local',
+#    }
+#  }
 
 define nginx::resource::location (
   $ensure               = present,
@@ -162,6 +174,7 @@ define nginx::resource::location (
   $fastcgi_script       = undef,
   $fastcgi_split_path   = undef,
   $uwsgi                = undef,
+  $uwsgi_param          = undef,
   $uwsgi_params         = "${nginx::config::conf_dir}/uwsgi_params",
   $uwsgi_read_timeout   = undef,
   $ssl                  = false,
@@ -246,6 +259,9 @@ define nginx::resource::location (
   }
   if ($uwsgi != undef) {
     validate_string($uwsgi)
+  }
+  if ($uwsgi_param != undef) {
+    validate_hash($uwsgi_param)
   }
   validate_string($uwsgi_params)
   if ($uwsgi_read_timeout != undef) {

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -602,6 +602,31 @@ describe 'nginx::resource::location' do
           end
         end
       end
+
+      context "when uwsgi_param is {'CUSTOM_PARAM' => 'value'}" do
+        let(:params) { default_params.merge(uwsgi_param: { 'CUSTOM_PARAM' => 'value', 'CUSTOM_PARAM2' => 'value2' }) }
+        it 'sets uwsgi_param' do
+          should contain_concat__fragment('vhost1-500-' + Digest::MD5.hexdigest(params[:location].to_s)).
+            with_content(%r{uwsgi_param\s+CUSTOM_PARAM\s+value;}).
+            with_content(%r{uwsgi_param\s+CUSTOM_PARAM2\s+value2;})
+        end
+      end
+
+      context 'when uwsgi_param is {\'HTTP_PROXY\' => ""}' do
+        let(:params) { default_params.merge(uwsgi_param: { 'HTTP_PROXY' => '""' }) }
+        it 'sets uwsgi_param' do
+          should contain_concat__fragment('vhost1-500-' + Digest::MD5.hexdigest(params[:location].to_s)).
+            with_content(%r{uwsgi_param\s+HTTP_PROXY\s+"";})
+        end
+      end
+
+      context 'when uwsgi_param is not set' do
+        let(:params) { default_params }
+        it 'does not set uwsgi_param' do
+          should contain_concat__fragment('vhost1-500-' + Digest::MD5.hexdigest(params[:location].to_s)).
+            without_content(%r{^\s+uwsgi_param\s+})
+        end
+      end
     end
 
     describe 'vhost_location_proxy template content' do

--- a/templates/vhost/locations/uwsgi.erb
+++ b/templates/vhost/locations/uwsgi.erb
@@ -6,6 +6,12 @@
 <% end -%>
     include <%= @uwsgi_params %>;
     uwsgi_pass <%= @uwsgi %>;
+<% if @uwsgi_param -%>
+    <%- field_width = @uwsgi_param.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
+	<%- @uwsgi_param.sort_by {|k,v| k}.each do |key, val| -%>
+    uwsgi_param <%= sprintf("%-*s", field_width, key) %> <%= val %>;
+	<%- end -%>
+<% end -%>
 <% if @uwsgi_read_timeout-%>
     uwsgi_read_timeout <%= @uwsgi_read_timeout %>;
 <% end -%>


### PR DESCRIPTION
This patch allows custom uwsgi params to be added with uwsgi_param, same way fastcgi_param work.

@wyardley, It is a replacement for #767 
