### PR TITLE
Restore $service_restart, now defaulting to undefined, but now withou…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,7 @@ class nginx (
   ### START Service Configuation ###
   $service_ensure                 = running,
   $service_flags                  = undef,
+  $service_restart                = undef,
   $service_name                   = undef,
   $service_manage                 = true,
   ### END Service Configuration ###
@@ -300,14 +301,10 @@ class nginx (
       sites_available_mode           => $sites_available_mode,
     }
   }
-  Class['::nginx::package'] -> Class['::nginx::config'] ~> Class['::nginx::service']
 
-  class { '::nginx::service':
-    service_ensure => $service_ensure,
-    service_name   => $service_name,
-    service_flags  => $service_flags,
-    service_manage => $service_manage,
-  }
+  include '::nginx::service'
+
+  Class['::nginx::package'] -> Class['::nginx::config'] ~> Class['::nginx::service']
 
   create_resources('nginx::resource::upstream', $nginx_upstreams)
   create_resources('nginx::resource::vhost', $nginx_vhosts, $nginx_vhosts_defaults)

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,11 +14,12 @@
 #
 # This class file is not called directly
 class nginx::service(
-  $service_ensure    = 'running',
-  $service_name      = 'nginx',
-  $service_flags     = undef,
-  $service_manage    = true,
-) {
+  $service_restart = $::nginx::service_restart,
+  $service_ensure  = $::nginx::service_ensure,
+  $service_name    = $::nginx::service_name,
+  $service_flags   = $::nginx::service_flags,
+  $service_manage  = $::nginx::service_manage,
+) inherits nginx {
 
   $service_enable = $service_ensure ? {
     'running' => true,
@@ -58,4 +59,10 @@ class nginx::service(
     }
   }
 
+  # Allow overriding of 'restart' of Service resource; not used by default
+  if $service_restart {
+    Service['nginx'] {
+      restart => $service_restart,
+    }
+  }
 }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -21,6 +21,17 @@ describe 'nginx::service' do
     it { is_expected.to contain_service('nginx').without_restart }
   end
 
+  context "when service_restart => 'a restart command'" do
+    let :params do
+      {
+        service_restart: 'a restart command',
+        service_ensure: 'running',
+        service_name: 'nginx'
+      }
+    end
+    it { is_expected.to contain_service('nginx').with_restart('a restart command') }
+  end
+
   describe "when service_name => 'nginx14" do
     let :params do
       {


### PR DESCRIPTION
Now defaulting to undef, but without checking whether now removed $configtest_enable param exists. This allows users to set a custom restart command if just changing the service name isn't enough. See comments in #921 

I'm still wondering if we should invoke nginx::service differently from how it is now:
          https://github.com/voxpupuli/puppet-nginx/blob/master/manifests/init.pp#L305 
and just set `$nginx::service::foo` to `$nginx::foo`; seems to me this would be a bit easier to parse.