### PR TITLE
add debugging information in error message 

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -353,10 +353,10 @@ define nginx::resource::location (
     fail('Cannot create a location reference without attaching to a virtual host')
   }
   if (($www_root == undef) and ($proxy == undef) and ($location_alias == undef) and ($stub_status == undef) and ($fastcgi == undef) and ($uwsgi == undef) and ($location_custom_cfg == undef) and ($internal == false) and ($try_files == undef)) {
-    fail('Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, uwsgi, stub_status, internal, or location_custom_cfg defined')
+    fail("Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, uwsgi, stub_status, internal, or location_custom_cfg defined in ${vhost}:${title}")
   }
   if (($www_root != undef) and ($proxy != undef)) {
-    fail('Cannot define both directory and proxy in a virtual host')
+    fail("Cannot define both directory and proxy in ${vhost}:${title}")
   }
 
   # Use proxy, fastcgi or uwsgi template if $proxy is defined, otherwise use directory template.

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -820,7 +820,7 @@ describe 'nginx::resource::location' do
           }
         end
 
-        it { expect { is_expected.to contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, %r{Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, uwsgi, stub_status, internal, or location_custom_cfg defined}) }
+        it { expect { is_expected.to contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, %r{Cannot create a location reference without a www_root, proxy, location_alias, fastcgi, uwsgi, stub_status, internal, or location_custom_cfg defined in vhost1:rspec-test}) }
       end
 
       context 'www_root and proxy are set' do
@@ -832,7 +832,7 @@ describe 'nginx::resource::location' do
           }
         end
 
-        it { expect { is_expected.to contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, %r{Cannot define both directory and proxy in a virtual host}) }
+        it { expect { is_expected.to contain_class('nginx::resource::location') }.to raise_error(Puppet::Error, %r{Cannot define both directory and proxy in vhost1:rspec-test}) }
       end
 
       context 'when vhost name is sanitized' do


### PR DESCRIPTION
Rework #414 (h/t to @zshahan)
Instead of switching it to use `$title`, I did `$vhost:$title`, which I *think* will work better given the different possible cases (default location, non-default location, etc.). Let me know if my thinking is off there, but I think except for default-foo, $title won't contain the vhost name?