### PR TITLE
Fix streamhost support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -77,6 +77,7 @@ class nginx::config(
   $keepalive_requests             = '100',
   $log_format                     = {},
   $mail                           = false,
+  $stream                         = false,
   $multi_accept                   = 'off',
   $names_hash_bucket_size         = '64',
   $names_hash_max_size            = '512',
@@ -174,6 +175,7 @@ class nginx::config(
   }
 
   validate_bool($mail)
+  validate_bool($stream)
   validate_string($server_tokens)
   validate_string($client_max_body_size)
   if (!is_integer($names_hash_bucket_size)) {
@@ -300,6 +302,7 @@ class nginx::config(
         recurse => true,
       }
     }
+    # No real reason not to make these even if $stream is not enabled.
     file { "${conf_dir}/streams-enabled":
       ensure => directory,
       owner  => $sites_available_owner,
@@ -309,7 +312,7 @@ class nginx::config(
     file { "${conf_dir}/streams-available":
       ensure => directory,
     }
-    if $vhost_purge == true {
+    if $vhost_purge {
       File["${conf_dir}/streams-enabled"] {
         purge   => true,
         recurse => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class nginx (
   $keepalive_timeout              = undef,
   $keepalive_requests             = undef,
   $mail                           = undef,
+  $stream                         = undef,
   $multi_accept                   = undef,
   $names_hash_bucket_size         = undef,
   $names_hash_max_size            = undef,
@@ -172,6 +173,7 @@ class nginx (
         $logdir or
         $log_format or
         $mail or
+        $stream or
         $multi_accept or
         $names_hash_bucket_size or
         $names_hash_max_size or
@@ -259,6 +261,7 @@ class nginx (
       log_dir                        => $logdir,
       log_format                     => $log_format,
       mail                           => $mail,
+      stream                         => $stream,
       multi_accept                   => $multi_accept,
       names_hash_bucket_size         => $names_hash_bucket_size,
       names_hash_max_size            => $names_hash_max_size,

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -28,8 +28,6 @@
 #     of 90 seconds
 #   [*resolver*]            - Array: Configures name servers used to resolve
 #     names of upstream servers into addresses.
-#   [*server_name*]         - List of streamhost names for which this streamhost will
-#     respond. Default [$name].
 #   [*raw_prepend*]            - A single string, or an array of strings to
 #     prepend to the server directive (after cfg prepend directives). NOTE:
 #     YOU are responsible for a semicolon on each line that requires one.
@@ -61,7 +59,6 @@ define nginx::resource::streamhost (
   $proxy_read_timeout           = $::nginx::config::proxy_read_timeout,
   $proxy_connect_timeout        = $::nginx::config::proxy_connect_timeout,
   $resolver                     = [],
-  $server_name                  = [$name],
   $raw_prepend                  = undef,
   $raw_append                   = undef,
   $owner                        = $::nginx::config::global_owner,
@@ -98,7 +95,6 @@ define nginx::resource::streamhost (
   validate_string($proxy_read_timeout)
 
   validate_array($resolver)
-  validate_array($server_name)
 
   validate_string($owner)
   validate_string($group)

--- a/spec/defines/resource_stream_spec.rb
+++ b/spec/defines/resource_stream_spec.rb
@@ -98,12 +98,6 @@ describe 'nginx::resource::streamhost' do
           match: %r{\s+listen\s+\[::\]:80 spdy;}
         },
         {
-          title: 'should set servername(s)',
-          attr: 'server_name',
-          value: ['www.foo.com', 'foo.com'],
-          match: %r{\s+server_name\s+www.foo.com foo.com;}
-        },
-        {
           title: 'should contain raw_prepend directives',
           attr: 'raw_prepend',
           value: [

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -190,6 +190,10 @@ mail {
 <% end -%>
 <% if @stream -%>
 stream {
+  <%-# conf.stream.d gets included either way if $stream is enabled -%>
   include <%= @conf_dir %>/conf.stream.d/*.conf;
+<% unless @confd_only -%>
+  include <%= @conf_dir %>/streams-enabled/*;
+<% end -%>
 }
 <% end -%>

--- a/templates/streamhost/streamhost.erb
+++ b/templates/streamhost/streamhost.erb
@@ -17,7 +17,6 @@ server {
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
   <%- end -%>
 <%- end -%>
-  server_name           <%= @server_name.join(" ") %>;
 
   <% Array(@raw_prepend).each do |line| -%>
     <%= line %>


### PR DESCRIPTION
h/t to @modax and @alwiesner)
This is my attempt to combine #790, #784, while also incorporating the changes from #878. It adds back the $stream variable, which I incorrectly removed in #878, thinking it wasn't used in the nginx.conf tepmlate (it is). The placement of the various conditionals could be reworked if folks think it would be easier to read or less confusing. Would love suggestions as far as any tests that should be added.

This should address #s 1,2,3 from #784, but in a way that applies cleanly to current master and doesn't include any extraneous commits.

It looks like `$stream` did, in fact, control including `/etc/nginx/conf.stream.d`, however, maybe that include didn't get updated when someone added support for `streams-{enabled,available}`. The configs will still get built if streamhosts are defined, but they won't be included unless `$stream` is set.

I don't have any experience with this functionality, so, while this is passing test, I'd love for someone to do functional testing with this if at all possible.