### PR TITLE
Allow mappings to be supplied as array of hashes.

### DIFF
--- a/manifests/resource/map.pp
+++ b/manifests/resource/map.pp
@@ -28,6 +28,16 @@
 #    }
 #  }
 #
+# Sample Usage (preserving input of order of mappings):
+#
+#  nginx::resource::map { 'backend_pool':
+#    ...
+#    mappings  => [
+#      { 'key' => '*.sf.example.com', 'value' => 'sf-pool-1' },
+#      { 'key' => '*.nyc.example.com', 'value' => 'ny-pool-1' },
+#    ]
+#  }
+#
 # Sample Hiera usage:
 #
 #  nginx::string_mappings:
@@ -39,6 +49,17 @@
 #      mappings:
 #        '*.nyc.example.com': 'ny-pool-1'
 #        '*.sf.example.com': 'sf-pool-1'
+#
+# Sample Hiera usage (preserving input of order of mappings):
+#
+#  nginx::string_mappings:
+#    client_network:
+#      ...
+#      mappings:
+#        - key: '*.sf.example.com'
+#          value: 'sf-pool-1'
+#        - key: '*.nyc.example.com'
+#          value: 'ny-pool-1'
 
 
 define nginx::resource::map (
@@ -51,7 +72,9 @@ define nginx::resource::map (
   validate_string($string)
   validate_re($string, '^.{2,}$',
     "Invalid string value [${string}]. Expected a minimum of 2 characters.")
-  validate_hash($mappings)
+  if ! ( is_array($mappings) or is_hash($mappings) ) {
+    fail("\$mappings must be a hash of the form { 'foo' => 'pool_b' } or array of hashes of form [{ 'key' => 'foo', 'value' => 'pool_b' }, ...]")
+  }
   validate_bool($hostnames)
   validate_re($ensure, '^(present|absent)$',
     "Invalid ensure value '${ensure}'. Expected 'present' or 'absent'")

--- a/spec/defines/resource_map_spec.rb
+++ b/spec/defines/resource_map_spec.rb
@@ -53,7 +53,7 @@ describe 'nginx::resource::map' do
           match: ['  default pool_a;']
         },
         {
-          title: 'should contain ordered mappings',
+          title: 'should contain ordered mappings when supplied as a hash',
           attr: 'mappings',
           value: {
             'foo' => 'pool_b',
@@ -61,9 +61,23 @@ describe 'nginx::resource::map' do
             'baz' => 'pool_d'
           },
           match: [
+            '  foo pool_b;',
             '  bar pool_c;',
-            '  baz pool_d;',
-            '  foo pool_b;'
+            '  baz pool_d;'
+          ]
+        },
+        {
+          title: 'should contain mappings in input order when supplied as an array of hashes',
+          attr:  'mappings',
+          value: [
+            { 'key' => 'foo', 'value' => 'pool_b' },
+            { 'key' => 'bar', 'value' => 'pool_c' },
+            { 'key' => 'baz', 'value' => 'pool_d' }
+          ],
+          match: [
+            '  foo pool_b;',
+            '  bar pool_c;',
+            '  baz pool_d;'
           ]
         }
       ].each do |param|
@@ -88,6 +102,16 @@ describe 'nginx::resource::map' do
         end
 
         it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-map.conf").with_ensure('absent') }
+      end
+
+      context 'when mappings is a string' do
+        let :params do
+          default_params.merge(
+            mappings: 'foo pool_b'
+          )
+        end
+
+        it { is_expected.to raise_error(Puppet::Error, %r[mappings must be a hash of the form { 'foo' => 'pool_b' }]) }
       end
     end
   end

--- a/templates/conf.d/map.erb
+++ b/templates/conf.d/map.erb
@@ -7,10 +7,16 @@ map <%= @string %> $<%= @name %> {
   default <%= @default %>;
 <% end -%>
 
-<% if @mappings -%>
+<% if @mappings.is_a?(Hash) -%>
   <%- field_width = @mappings.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
   <%- @mappings.sort_by{|k,v| k}.each do |key,value| -%>
   <%= sprintf("%-*s", field_width, key) %> <%= value %>;
+  <%- end -%>
+<% end -%>
+<% if @mappings.is_a?(Array) -%>
+  <%- field_width = @mappings.inject(0) { |l,(h)| h['key'].size > l ? h['key'].size : l } -%>
+  <%- @mappings.each do |h| -%>
+  <%= sprintf("%-*s", field_width, h['key']) %> <%= h['value'] %>;
   <%- end -%>
 <% end -%>
 }


### PR DESCRIPTION
This is a rebase of #698, also updated to follow Rubocop's enforced conventions. It passes tests, but I don't use this feature, and haven't done any work to verify that it works as expected.

Given that the module doesn't support Ruby 1.8.7 anymore, it might also be possible to fix this in a different way (just going off @btisdall's comment).