### PR TITLE
Use SSL for nginx APT repository

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -34,14 +34,14 @@ class nginx::package::debian(
     case $package_source {
       'nginx', 'nginx-stable': {
         apt::source { 'nginx':
-          location => "http://nginx.org/packages/${distro}",
+          location => "https://nginx.org/packages/${distro}",
           repos    => 'nginx',
           key      => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
         }
       }
       'nginx-mainline': {
         apt::source { 'nginx':
-          location => "http://nginx.org/packages/mainline/${distro}",
+          location => "https://nginx.org/packages/mainline/${distro}",
           repos    => 'nginx',
           key      => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
         }

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -149,7 +149,7 @@ describe 'nginx' do
         it { is_expected.not_to contain_package('passenger') }
         it do
           is_expected.to contain_apt__source('nginx').with(
-            'location'   => "http://nginx.org/packages/#{operatingsystem.downcase}",
+            'location'   => "https://nginx.org/packages/#{operatingsystem.downcase}",
             'repos'      => 'nginx',
             'key'        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'
           )
@@ -162,7 +162,7 @@ describe 'nginx' do
         let(:params) { { package_source: 'nginx-mainline' } }
         it do
           is_expected.to contain_apt__source('nginx').with(
-            'location' => "http://nginx.org/packages/mainline/#{operatingsystem.downcase}"
+            'location' => "https://nginx.org/packages/mainline/#{operatingsystem.downcase}"
           )
         end
       end


### PR DESCRIPTION
The nginx APT repository is currently not using https.
This PR will fix this.
