### PR TITLE
officially add Ubuntu 1604 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class nginx::params {
       }
     }
     'Debian': {
-      if ($::operatingsystem == 'ubuntu' and $::lsbdistcodename in ['lucid', 'precise', 'trusty'])
+      if ($::operatingsystem == 'ubuntu' and $::lsbdistcodename in ['lucid', 'precise', 'trusty', 'xenial'])
       or ($::operatingsystem == 'debian' and $::operatingsystemmajrelease in ['6', '7', '8']) {
         $_module_os_overrides = {
           'manage_repo' => true,

--- a/metadata.json
+++ b/metadata.json
@@ -71,7 +71,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",
-        "12.04"
+        "12.04",
+        "16.04"
       ]
     }
   ]


### PR DESCRIPTION
Per #935, seems to work on 16.04 (though need to get acceptance tests working, see https://tickets.puppetlabs.com/browse/BKR-970). We should update metadata and add 'xenial' to the array in params (any reason not to use the release # here?)
