### PR TITLE
Bypass puppet_install_helper, revert to install_puppet_(agent)_on

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,13 +1,12 @@
 require 'beaker-rspec'
-require 'beaker/puppet_install_helper'
-
-run_puppet_install_helper
 
 RSpec.configure do |c|
   # Project root
   proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
   c.formatter = :documentation
+
+  install_puppet_agent_on(hosts, options)
 
   # This is where we 'setup' the nodes before running our tests
   c.before :suite do


### PR DESCRIPTION
@3flex: do you remember why you switched to puppet_install_helper?
I feel like we probably want Puppet 4 by default at this point, and seems easiest to just specify the `install_puppet_agent_on` method?
