### PR TITLE
Allow setting $daemon to "on" or "off" (defaults to unset)

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -50,6 +50,7 @@ class nginx::config(
   $client_body_buffer_size        = '128k',
   $client_max_body_size           = '10m',
   $client_body_timeout            = '60',
+  $daemon                         = undef,
   $send_timeout                   = '60',
   $lingering_timeout              = '5',
   $events_use                     = false,
@@ -275,6 +276,10 @@ class nginx::config(
   file {$client_body_temp_path:
     ensure => directory,
     owner  => $daemon_user,
+  }
+
+  if ($daemon) {
+    validate_re($daemon, '^(on|off)$')
   }
 
   file {$proxy_temp_path:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class nginx (
   $client_body_temp_path          = undef,
   $client_max_body_size           = undef,
   $events_use                     = undef,
+  $daemon                         = undef,
   $fastcgi_cache_inactive         = undef,
   $fastcgi_cache_key              = undef,
   $fastcgi_cache_keys_zone        = undef,
@@ -304,6 +305,7 @@ class nginx (
       sites_available_owner          => $sites_available_owner,
       sites_available_group          => $sites_available_group,
       sites_available_mode           => $sites_available_mode,
+      daemon                         => $daemon,
     }
   }
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -108,6 +108,24 @@ describe 'nginx::config' do
           match: 'user test-user;'
         },
         {
+          title: 'should not set daemon',
+          attr: 'daemon',
+          value: :undef,
+          notmatch: %r{^\s*daemon\s+}
+        },
+        {
+          title: 'should set daemon on',
+          attr: 'daemon',
+          value: 'on',
+          match: %r{^daemon\s+on;$}
+        },
+        {
+          title: 'should set daemon off',
+          attr: 'daemon',
+          value: 'off',
+          match: %r{^daemon\s+off;$}
+        },
+        {
           title: 'should set worker_processes',
           attr: 'worker_processes',
           value: '4',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -1,4 +1,7 @@
 # MANAGED BY PUPPET
+<% if @daemon -%>
+daemon <%= @daemon %>;
+<% end -%>
 <% if @super_user -%>
 user <%= @daemon_user %>;
 <% end -%>


### PR DESCRIPTION
Noticed this in @garethr's talk -- currently, there's no way without using a custom config to turn `$daemon` off. Obviously, this is something that probably wasn't useful to most people before, but becomes a lot more useful if used along with containerization.

This doesn't change the existing behavior, but allows it to be explicitly set to 'on' or 'off' via a parameter (this is still just the string on / off; #457 addresses possibly allowing booleans to work instead or in addition to).

Let me know if these tests look reasonable.
