### PR TITLE
Add fastcgi_param parameter to vhost resource

### DIFF
--- a/manifests/resource/vhost.pp
+++ b/manifests/resource/vhost.pp
@@ -46,6 +46,7 @@
 #   [*resolver*]            - Array: Configures name servers used to resolve
 #     names of upstream servers into addresses.
 #   [*fastcgi*]             - location of fastcgi (host:port)
+#   [*fastcgi_param*]       - Set additional custom fastcgi_params
 #   [*fastcgi_params*]      - optional alternative fastcgi_params file to use
 #   [*fastcgi_script*]      - optional SCRIPT_FILE parameter
 #   [*uwsgi_read_timeout*]  - optional value for uwsgi_read_timeout
@@ -248,6 +249,7 @@ define nginx::resource::vhost (
   $proxy_buffering              = undef,
   $resolver                     = [],
   $fastcgi                      = undef,
+  $fastcgi_param                = undef,
   $fastcgi_params               = "${::nginx::config::conf_dir}/fastcgi_params",
   $fastcgi_script               = undef,
   $uwsgi                        = undef,
@@ -645,6 +647,7 @@ define nginx::resource::vhost (
       proxy_set_body              => $proxy_set_body,
       proxy_buffering             => $proxy_buffering,
       fastcgi                     => $fastcgi,
+      fastcgi_param               => $fastcgi_param,
       fastcgi_params              => $fastcgi_params,
       fastcgi_script              => $fastcgi_script,
       uwsgi                       => $uwsgi,

--- a/spec/defines/resource_vhost_spec.rb
+++ b/spec/defines/resource_vhost_spec.rb
@@ -948,6 +948,14 @@ describe 'nginx::resource::vhost' do
         it { is_expected.to contain_file('/etc/nginx/fastcgi_params').with_mode('0770') }
       end
 
+      context 'when fastcgi_param => {key => value}' do
+        let :params do
+          default_params.merge(fastcgi_param: { 'key' => 'value' })
+        end
+
+        it { is_expected.to contain_nginx__resource__location("#{title}-default").with_fastcgi_param('key' => 'value') }
+      end
+
       context 'when uwsgi => "uwsgi_upstream"' do
         let :params do
           default_params.merge(uwsgi: 'uwsgi_upstream')


### PR DESCRIPTION
Without this change, specifying fastcgi parameters are not possible on
the vhost.  This change modifies vhost resource to allow passing the
fastcgi_param to the location resource directly, as is the case with a
few of the other fastcgi related parameters.