### PR TITLE
Add 'require' for parent dir of upstream, map, and geo configs as wel…

### DIFF
--- a/manifests/resource/geo.pp
+++ b/manifests/resource/geo.pp
@@ -16,7 +16,7 @@
 #   [*proxy_recursive*] - Changes the behavior of address acquisition when
 #                         specifying trusted proxies via 'proxies' directive
 #   [*proxies*]         - Hash of network->value mappings.
-
+#
 # Actions:
 #
 # Requires:
@@ -74,6 +74,7 @@ define nginx::resource::geo (
   if ($proxy_recursive != undef) { validate_bool($proxy_recursive) }
 
   $root_group = $::nginx::config::root_group
+  $conf_dir   = "${::nginx::config::conf_dir}/conf.d"
 
   $ensure_real = $ensure ? {
     'absent' => 'absent',
@@ -86,9 +87,10 @@ define nginx::resource::geo (
     mode  => '0644',
   }
 
-  file { "${::nginx::config::conf_dir}/conf.d/${name}-geo.conf":
+  file { "${conf_dir}/${name}-geo.conf":
     ensure  => $ensure_real,
     content => template('nginx/conf.d/geo.erb'),
     notify  => Class['::nginx::service'],
+    require => File[$conf_dir],
   }
 }

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -130,7 +130,8 @@ define nginx::resource::mailhost (
   validate_string($xclient)
   validate_array($server_name)
 
-  $config_file = "${::nginx::config::conf_dir}/conf.mail.d/${name}.conf"
+  $config_dir  = "${::nginx::config::conf_dir}/conf.mail.d"
+  $config_file = "${config_dir}/${name}.conf"
 
   # Add IPv6 Logic Check - Nginx service will not start if ipv6 is enabled
   # and support does not exist for it in the kernel.
@@ -146,10 +147,11 @@ define nginx::resource::mailhost (
   }
 
   concat { $config_file:
-    owner  => 'root',
-    group  => $root_group,
-    mode   => '0644',
-    notify => Class['::nginx::service'],
+    owner   => 'root',
+    group   => $root_group,
+    mode    => '0644',
+    notify  => Class['::nginx::service'],
+    require => File[$config_dir],
   }
 
   if (($ssl_port == undef) or ($listen_port + 0) != ($ssl_port + 0)) {

--- a/manifests/resource/map.pp
+++ b/manifests/resource/map.pp
@@ -10,7 +10,7 @@
 #   [*mappings*]   - Hash of map lookup keys and resultant values
 #   [*hostnames*]  - Indicates that source values can be hostnames with a
 #                    prefix or suffix mask.
-
+#
 # Actions:
 #
 # Requires:
@@ -81,6 +81,7 @@ define nginx::resource::map (
   if ($default != undef) { validate_string($default) }
 
   $root_group = $::nginx::config::root_group
+  $conf_dir   = "${::nginx::config::conf_dir}/conf.d"
 
   $ensure_real = $ensure ? {
     'absent' => absent,
@@ -93,9 +94,10 @@ define nginx::resource::map (
     mode  => '0644',
   }
 
-  file { "${::nginx::config::conf_dir}/conf.d/${name}-map.conf":
+  file { "${conf_dir}/${name}-map.conf":
     ensure  => $ensure_real,
     content => template('nginx/conf.d/map.erb'),
     notify  => Class['::nginx::service'],
+    require => File[$conf_dir],
   }
 }

--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -77,15 +77,18 @@ define nginx::resource::upstream (
     default  => 'conf.d',
   }
 
+  $conf_dir = "${::nginx::config::conf_dir}/${conf_dir_real}"
+
   Concat {
     owner => 'root',
     group => $root_group,
     mode  => '0644',
   }
 
-  concat { "${::nginx::config::conf_dir}/${conf_dir_real}/${name}-upstream.conf":
-    ensure => $ensure_real,
-    notify => Class['::nginx::service'],
+  concat { "${conf_dir}/${name}-upstream.conf":
+    ensure  => $ensure_real,
+    notify  => Class['::nginx::service'],
+    require => File[$conf_dir],
   }
 
   # Uses: $name, $upstream_cfg_prepend

--- a/spec/defines/resource_geo_spec.rb
+++ b/spec/defines/resource_geo_spec.rb
@@ -27,6 +27,7 @@ describe 'nginx::resource::geo' do
     describe 'basic assumptions' do
       let(:params) { default_params }
 
+      it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-geo.conf").that_requires('File[/etc/nginx/conf.d]') }
       it do
         is_expected.to contain_file("/etc/nginx/conf.d/#{title}-geo.conf").with(
           'owner' => 'root',

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -15,6 +15,7 @@ describe 'nginx::resource::mailhost' do
     describe 'basic assumptions' do
       let(:params) { default_params }
       it { is_expected.to contain_class('nginx::config') }
+      it { is_expected.to contain_concat("/etc/nginx/conf.mail.d/#{title}.conf").that_requires('File[/etc/nginx/conf.mail.d]') }
       it do
         is_expected.to contain_concat("/etc/nginx/conf.mail.d/#{title}.conf").with('owner' => 'root',
                                                                                    'group' => 'root',

--- a/spec/defines/resource_map_spec.rb
+++ b/spec/defines/resource_map_spec.rb
@@ -27,6 +27,7 @@ describe 'nginx::resource::map' do
     describe 'basic assumptions' do
       let(:params) { default_params }
 
+      it { is_expected.to contain_file("/etc/nginx/conf.d/#{title}-map.conf").that_requires('File[/etc/nginx/conf.d]') }
       it do
         is_expected.to contain_file("/etc/nginx/conf.d/#{title}-map.conf").with(
           'owner' => 'root',

--- a/spec/defines/resource_upstream_spec.rb
+++ b/spec/defines/resource_upstream_spec.rb
@@ -27,7 +27,7 @@ describe 'nginx::resource::upstream' do
     describe 'basic assumptions' do
       let(:params) { default_params }
 
-      it { is_expected.to contain_concat("/etc/nginx/conf.d/#{title}-upstream.conf") }
+      it { is_expected.to contain_concat("/etc/nginx/conf.d/#{title}-upstream.conf").that_requires('File[/etc/nginx/conf.d]') }
       it { is_expected.to contain_concat__fragment("#{title}_upstream_header").with_content(%r{upstream #{title}}) }
 
       it do


### PR DESCRIPTION
I think this should come a lot closer to resolving #942.

Few questions:

1. Should these be class specs, not defines? And should I have one test for the file existing, and another for it existing and having the require, or is this fine?
1. Should I avoid using `$conf_dir` within the resource manifests (since we've got `$::nginx::config::conf_dir`? Or is this fine?
1. I went back and forth on making some of these variables within the scope of `$::nginx::config`, but decided to leave it this way, but open to discussion. Upstream and vhost specifically differs depending on settings like `$confd_only`, and some of the other resources have their own directories, like `conf.mail.d`, so I'm not sure if making it more generic is worth the effort.