### PR TITLE
Set log directory ownership / permissions explicitly

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,6 +24,8 @@ class nginx::config(
   $global_group                   = $::nginx::params::global_group,
   $global_mode                    = $::nginx::params::global_mode,
   $log_dir                        = $::nginx::params::log_dir,
+  $log_group                      = $::nginx::params::log_group,
+  $log_mode                       = '0750',
   $http_access_log                = "${log_dir}/${::nginx::params::http_access_log_file}",
   $http_format_log                = undef,
   $nginx_error_log                = "${log_dir}/${::nginx::params::nginx_error_log_file}",
@@ -271,6 +273,9 @@ class nginx::config(
 
   file { $log_dir:
     ensure => directory,
+    mode   => $log_mode,
+    owner  => $daemon_user,
+    group  => $log_group,
   }
 
   file {$client_body_temp_path:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class nginx::params {
     'pid'         => '/var/run/nginx.pid',
     'root_group'  => 'root',
     'log_dir'     => '/var/log/nginx',
+    'log_group'   => 'root',
     'run_dir'     => '/var/nginx',
     'package_name' => 'nginx',
     'manage_repo'  => false,
@@ -16,6 +17,7 @@ class nginx::params {
       $_module_os_overrides = {
         'pid'         => false,
         'daemon_user' => 'http',
+        'log_group'   => 'log',
       }
     }
     'Debian': {
@@ -24,10 +26,12 @@ class nginx::params {
         $_module_os_overrides = {
           'manage_repo' => true,
           'daemon_user' => 'www-data',
+          'log_group'   => 'adm',
         }
       } else {
         $_module_os_overrides = {
           'daemon_user' => 'www-data',
+          'log_group'   => 'adm',
         }
       }
     }
@@ -36,6 +40,7 @@ class nginx::params {
         'conf_dir'    => '/usr/local/etc/nginx',
         'daemon_user' => 'www',
         'root_group'  => 'wheel',
+        'log_group'   => 'wheel',
       }
     }
     'Gentoo': {
@@ -47,9 +52,12 @@ class nginx::params {
       if ($::operatingsystem in ['RedHat', 'CentOS'] and $::operatingsystemmajrelease in ['5', '6', '7']) {
         $_module_os_overrides = {
           'manage_repo' => true,
+          'log_group'   => 'nginx',
         }
       } else {
-        $_module_os_overrides = {}
+        $_module_os_overrides = {
+          'log_group' => 'nginx',
+        }
       }
     }
     'Solaris': {
@@ -63,6 +71,7 @@ class nginx::params {
         'daemon_user' => 'www',
         'root_group'  => 'wheel',
         'log_dir'     => '/var/www/logs',
+        'log_group'   => 'wheel',
         'run_dir'     => '/var/www',
       }
     }
@@ -86,6 +95,7 @@ class nginx::params {
   ### Referenced Variables
   $conf_dir              = $_module_parameters['conf_dir']
   $log_dir               = $_module_parameters['log_dir']
+  $log_group             = $_module_parameters['log_group']
   $run_dir               = $_module_parameters['run_dir']
   $temp_dir              = '/tmp'
   $pid                   = $_module_parameters['pid']

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -88,8 +88,9 @@ describe 'nginx::config' do
     it do
       is_expected.to contain_file('/var/log/nginx').with(
         ensure: 'directory',
-        group: 'root',
-        mode: '0644'
+        owner: 'www-data',
+        group: 'adm',
+        mode: '0750'
       )
     end
 
@@ -841,6 +842,25 @@ describe 'nginx::config' do
           %r{error_log  /foo/bar/error.log error;}
         )
       end
+    end
+
+    context 'when log_mode is non-default' do
+      let(:params) { { log_mode: '0771' } }
+
+      it { is_expected.to contain_file('/var/log/nginx').with(mode: '0771') }
+    end
+  end
+
+  context 'With RedHat facts' do
+    let(:facts) { { operatingsystem: 'redhat', osfamily: 'RedHat', operatingsystemmajrelease: '6' } }
+
+    it do
+      is_expected.to contain_file('/var/log/nginx').with(
+        ensure: 'directory',
+        owner: 'nginx',
+        group: 'nginx',
+        mode: '0750'
+      )
     end
   end
 end


### PR DESCRIPTION
Does this look sane as a fix for #664? This is one we should definitely try and get right, as it could cause problems if the ownership isn't correct on various platforms.

1. Should this also have an interface in `::nginx` as well as `::nginx::config`? I think with new parameters, it's better not to do that until we work out the exact structural changes.
1. @bastelfreak: can you confirm permissions on ArchLinux?

I added `log_mode` in nginx::config, as I think it's important to have a sane default that's restrictive (0700), but people often do also need to grant group / other permissions on the nginx logdir that are custom. We could make the default 0750 or 0751 if that makes more sense.