### PR TITLE
fix map.erb to work on Redhat 6 releases

### DIFF
--- a/templates/conf.d/map.erb
+++ b/templates/conf.d/map.erb
@@ -14,7 +14,7 @@ map <%= @string %> $<%= @name %> {
   <%- end -%>
 <% end -%>
 <% if @mappings.is_a?(Array) -%>
-  <%- field_width = @mappings.inject(0) { |l,(h)| h['key'].size > l ? h['key'].size : l } -%>
+  <%- field_width = @mappings.inject(0) { |l,h| h['key'].size > l ? h['key'].size : l } -%>
   <%- @mappings.each do |h| -%>
   <%= sprintf("%-*s", field_width, h['key']) %> <%= h['value'] %>;
   <%- end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

Currently our team still requires support for RHEL and CentOS6.7 releases. This has a back level 
ruby of 1.8.7 the  map.erb doesn't compile correctly

erb -x -T '-' map.erb | ruby -c
-:17: syntax error, unexpected '|', expecting tCOLON2 or '[' or '.'
... @mappings.inject(0) { |l,(h)| h['key'].size > l ? h['key']....
                              ^
-:17: syntax error, unexpected '}', expecting kEND
...size > l ? h['key'].size : l } 


With the latest changes to  Ran UT test. This is the relevant section and the final tally

nginx::resource::map
  os-independent items
    basic assumptions

      should contain File[/etc/nginx/conf.d/backend_pool-map.conf] with owner => "root", group => "root", mode => "0644", ensure => "file" and content =~ /map \$uri \$backend_pool/
    map.conf template content
      when hostnames is true
        should contain File[/etc/nginx/conf.d/backend_pool-map.conf] with mode => "0644"
        should set hostnames
      when default is pool_a
        should contain File[/etc/nginx/conf.d/backend_pool-map.conf] with mode => "0644"
        should set default
      when mappings is {"foo"=>"pool_b", "bar"=>"pool_c", "baz"=>"pool_d"}
        should contain File[/etc/nginx/conf.d/backend_pool-map.conf] with mode => "0644"
        should contain ordered mappings when supplied as a hash
      when mappings is [{"key"=>"foo", "value"=>"pool_b"}, {"key"=>"bar", "value"=>"pool_c"}, {"key"=>"baz", "value"=>"pool_d"}]
        should contain File[/etc/nginx/conf.d/backend_pool-map.conf] with mode => "0644"
        should contain mappings in input order when supplied as an array of hashes
      when ensure => absent
        should contain File[/etc/nginx/conf.d/backend_pool-map.conf] with ensure => "absent"
      when mappings is a string

        should raise Puppet::Error with message matching /mappings must be a hash of the form { 'foo' => 'pool_b' }/

Finished in 2 minutes 24.4 seconds (files took 1.43 seconds to load)
864 examples, 0 failures


