### PR TITLE
Fix Bug: ensure => absent was not working on nginx::resource::location

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -433,33 +433,34 @@ define nginx::resource::location (
     }
   }
 
-
-  ## Create stubs for vHost File Fragment Pattern
-  $location_md5 = md5($location)
-  if ($ssl_only != true) {
-    concat::fragment { "${vhost_sanitized}-${priority}-${location_md5}":
-      target  => $config_file,
-      content => join([
-        template('nginx/vhost/location_header.erb'),
-        $content_real,
-        template('nginx/vhost/location_footer.erb'),
-      ], ''),
-      order   => $priority,
+  if $ensure == present {
+    ## Create stubs for vHost File Fragment Pattern
+    $location_md5 = md5($location)
+    if ($ssl_only != true) {
+      concat::fragment { "${vhost_sanitized}-${priority}-${location_md5}":
+        target  => $config_file,
+        content => join([
+          template('nginx/vhost/location_header.erb'),
+          $content_real,
+          template('nginx/vhost/location_footer.erb'),
+        ], ''),
+        order   => $priority,
+      }
     }
-  }
 
-  ## Only create SSL Specific locations if $ssl is true.
-  if ($ssl == true or $ssl_only == true) {
-    $ssl_priority = $priority + 300
+    ## Only create SSL Specific locations if $ssl is true.
+    if ($ssl == true or $ssl_only == true) {
+      $ssl_priority = $priority + 300
 
-    concat::fragment { "${vhost_sanitized}-${ssl_priority}-${location_md5}-ssl":
-      target  => $config_file,
-      content => join([
-        template('nginx/vhost/location_header.erb'),
-        $content_real,
-        template('nginx/vhost/location_footer.erb'),
-      ], ''),
-      order   => $ssl_priority,
+      concat::fragment { "${vhost_sanitized}-${ssl_priority}-${location_md5}-ssl":
+        target  => $config_file,
+        content => join([
+          template('nginx/vhost/location_header.erb'),
+          $content_real,
+          template('nginx/vhost/location_footer.erb'),
+        ], ''),
+        order   => $ssl_priority,
+      }
     }
   }
 }

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -891,6 +891,31 @@ describe 'nginx::resource::location' do
         it { is_expected.to contain_concat__fragment('www_rspec-vhost_com-500-' + Digest::MD5.hexdigest('www.rspec-location.com')).with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
         it { is_expected.to contain_concat__fragment('www_rspec-vhost_com-800-' + Digest::MD5.hexdigest('www.rspec-location.com') + '-ssl').with_target('/etc/nginx/sites-available/www_rspec-vhost_com.conf') }
       end
+
+      context 'when ensure => absent' do
+        let :params do
+          {
+            vhost: 'vhost1',
+            www_root: '/',
+            ensure: 'absent'
+          }
+        end
+
+        it { is_expected.not_to contain_concat__fragment('vhost1-500-' + Digest::MD5.hexdigest('rspec-test')) }
+      end
+
+      context 'when ensure => absent and ssl => true' do
+        let :params do
+          {
+            ssl: true,
+            vhost: 'vhost1',
+            www_root: '/',
+            ensure: 'absent'
+          }
+        end
+
+        it { is_expected.not_to contain_concat__fragment('vhost1-800-' + Digest::MD5.hexdigest('rspec-test') + '-ssl') }
+      end
     end
   end
 end


### PR DESCRIPTION
- Fixes: ensure => absent was not working on nginx::resource::location
- Added tests to avoid happening again

I hope this helps. We are having this issue since we updated the module version. Let me know if I need to do some changes before merging.