### PR TITLE
Reorganize templates for clearer understanding

### DIFF
--- a/templates/vhost/location.erb
+++ b/templates/vhost/location.erb
@@ -1,0 +1,13 @@
+<%= scope.function_template(['nginx/vhost/location_header.erb']) -%>
+<%= scope.function_template(['nginx/vhost/locations/alias.erb']) -%>
+<%= scope.function_template(['nginx/vhost/locations/stub_status.erb']) -%>
+<% if @fastcgi or @uwsgi or @proxy -%>
+<%= scope.function_template(['nginx/vhost/locations/proxy.erb']) -%>
+<%= scope.function_template(['nginx/vhost/locations/uwsgi.erb']) -%>
+<%= scope.function_template(['nginx/vhost/locations/fastcgi.erb']) -%>
+<% else -%>
+<%= scope.function_template(['nginx/vhost/locations/directory.erb']) -%>
+<% end -%>
+<%= scope.function_template(['nginx/vhost/locations/try_files.erb']) -%>
+<%= scope.function_template(['nginx/vhost/locations/empty.erb']) -%>
+<%= scope.function_template(['nginx/vhost/location_footer.erb']) -%>

--- a/templates/vhost/locations/alias.erb
+++ b/templates/vhost/locations/alias.erb
@@ -1,10 +1,3 @@
+<% if @location_alias -%>
     alias <%= @location_alias %>;
-<% if defined? @autoindex -%>
-    autoindex <%= @autoindex %>;
-<% end -%>
-<% if @index_files and @index_files.count > 0 -%>
-    index    <% Array(@index_files).each do |i| %> <%= i %><% end %>;
-<% end -%>
-<% if @try_files -%>
-    try_files<% @try_files.each do |try| -%> <%= try %><% end -%>;
 <% end -%>

--- a/templates/vhost/locations/directory.erb
+++ b/templates/vhost/locations/directory.erb
@@ -8,6 +8,3 @@
 <% if @index_files and @index_files.count > 0 -%>
     index    <% Array(@index_files).each do |i| %> <%= i %><% end %>;
 <% end -%>
-<% if @try_files -%>
-    try_files<% @try_files.each do |try| -%> <%= try %><% end -%>;
-<% end -%>

--- a/templates/vhost/locations/fastcgi.erb
+++ b/templates/vhost/locations/fastcgi.erb
@@ -1,14 +1,15 @@
+<% if @fastcgi -%>
 <% if defined? @www_root -%>
     root          <%= @www_root %>;
 <% end -%>
     include       <%= @fastcgi_params %>;
 
     fastcgi_pass  <%= @fastcgi %>;
+<% if @fastcgi_index -%>
+    fastcgi_index <%= @fastcgi_index %>;
+<% end -%>
 <% if @fastcgi_split_path -%>
     fastcgi_split_path_info <%= @fastcgi_split_path %>;
-<% end -%>
-<% if @try_files -%>
-    try_files    <% @try_files.each do |try| -%> <%= try %><% end -%>;
 <% end -%>
 <% if defined? @fastcgi_script -%>
     <%-# this setting can be overridden by setting it in the fastcgi_param hash too %>
@@ -19,4 +20,5 @@
 	<%- @fastcgi_param.sort_by {|k,v| k}.each do |key, val| -%>
     fastcgi_param <%= sprintf("%-*s", field_width, key) %> <%= val %>;
 	<%- end -%>
+<% end -%>
 <% end -%>

--- a/templates/vhost/locations/proxy.erb
+++ b/templates/vhost/locations/proxy.erb
@@ -1,3 +1,4 @@
+<% if @proxy -%>
     proxy_pass            <%= @proxy %>;
     proxy_read_timeout    <%= @proxy_read_timeout %>;
     proxy_connect_timeout <%= @proxy_connect_timeout %>;
@@ -44,4 +45,5 @@
 <% end -%>
 <% if @proxy_cache_key -%>
     proxy_cache_key         <%= @proxy_cache_key %>;
+<% end -%>
 <% end -%>

--- a/templates/vhost/locations/stub_status.erb
+++ b/templates/vhost/locations/stub_status.erb
@@ -1,1 +1,3 @@
+<% if @stub_status -%>
     stub_status on;
+<% end -%>

--- a/templates/vhost/locations/uwsgi.erb
+++ b/templates/vhost/locations/uwsgi.erb
@@ -1,8 +1,6 @@
+<% if @uwsgi -%>
 <% if defined? @www_root -%>
     root  <%= @www_root %>;
-<% end -%>
-<% if @try_files -%>
-    try_files<% @try_files.each do |try| -%> <%= try %><% end -%>;
 <% end -%>
     include <%= @uwsgi_params %>;
     uwsgi_pass <%= @uwsgi %>;
@@ -14,4 +12,5 @@
 <% end -%>
 <% if @uwsgi_read_timeout-%>
     uwsgi_read_timeout <%= @uwsgi_read_timeout %>;
+<% end -%>
 <% end -%>


### PR DESCRIPTION
Without this change, the structure of the templates for locations are
bit rigid and hard to understand.  Each component of a location uses an
isolated template which means that much of the common logic is hard
coded to a particular location style, the deployment of which is chosen
based on a somewhat arbitrary idea of what it means to be a location,
and in some cases, the module gets it wrong.  In cases where there is
seeming correctness, modifications to a particular selection of logic
are duplicated among the nested templates.

This work is the results of what was necessary for me to understand what
the templates were doing, and to deploy a fastcgi PHP application.  As
such, the templates have been centralized and conditions about their
functionality have been moved into the template to determine if
rendering needs to be taken.  This allows a more complete, and leaves
potential for more complex examples easier to understand and reason
about.

Also here is the addition of a new param fastcgi_index on the location
class.

This work should result in on-disk configurations that are functionally
equivalent to what was in place before, except in places where the
module was masking conflicting options that were not being rendered in
the templates.