### PR TITLE
fix validation range for location priority

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -362,8 +362,8 @@ define nginx::resource::location (
     fail('$priority must be an integer.')
   }
   validate_array($rewrite_rules)
-  if (($priority + 0) < 401) or (($priority + 0) > 899) {
-    fail('$priority must be in the range 401-899.')
+  if (($priority + 0) < 401) or (($priority + 0) > 599) {
+    fail('$priority must be in the range 401-599.')
   }
   if ($expires != undef) {
     validate_string($expires)


### PR DESCRIPTION
See #971 
Fix the validation range for location's "priority" attribute to match docs. Using a higher value seems to cause unpredictable behavior.