### PR TITLE
Add support for proxy_cache_path loader directives

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -87,6 +87,9 @@ class nginx::config {
   $proxy_cache_levels             = $::nginx::proxy_cache_levels
   $proxy_cache_max_size           = $::nginx::proxy_cache_max_size
   $proxy_cache_path               = $::nginx::proxy_cache_path
+  $proxy_cache_loader_files       = $::nginx::proxy_cache_loader_files
+  $proxy_cache_loader_sleep       = $::nginx::proxy_cache_loader_sleep
+  $proxy_cache_loader_threshold   = $::nginx::proxy_cache_loader_threshold
   $proxy_use_temp_path            = $::nginx::proxy_use_temp_path
   $proxy_connect_timeout          = $::nginx::proxy_connect_timeout
   $proxy_headers_hash_bucket_size = $::nginx::proxy_headers_hash_bucket_size

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,9 @@ class nginx (
   $proxy_cache_levels             = '1',
   $proxy_cache_max_size           = '500m',
   $proxy_cache_path               = false,
+  $proxy_cache_loader_files       = undef,
+  $proxy_cache_loader_sleep       = undef,
+  $proxy_cache_loader_threshold   = undef,
   $proxy_use_temp_path            = false,
   $proxy_connect_timeout          = '90',
   $proxy_headers_hash_bucket_size = '64',
@@ -195,6 +198,12 @@ class nginx (
   validate_string($proxy_cache_keys_zone)
   validate_string($proxy_cache_max_size)
   validate_string($proxy_cache_inactive)
+
+  if ($proxy_cache_loader_files != undef) and !is_integer($proxy_cache_loader_files) {
+    fail('proxy_cache_loader_files must be an integer')
+  }
+  validate_string($proxy_cache_loader_sleep)
+  validate_string($proxy_cache_loader_threshold)
 
   if ($proxy_use_temp_path != false) {
         validate_re($proxy_use_temp_path, '^(on|off)$')

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -897,6 +897,21 @@ describe 'nginx' do
         end
       end
 
+      context 'when proxy_cache_path is /path/to/proxy.cache and loader_files is 1000' do
+        let(:params) { { conf_dir: '/path/to/nginx', proxy_cache_path: '/path/to/proxy.cache', proxy_cache_loader_files: '1000' } }
+        it { is_expected.to contain_file('/path/to/nginx/nginx.conf').with_content(%r{\s+proxy_cache_path\s+/path/to/proxy.cache levels=1 keys_zone=d2:100m max_size=500m inactive=20m loader_files=1000;}) }
+      end
+
+      context 'when proxy_cache_path is /path/to/nginx and loader_sleep is 50ms' do
+        let(:params) { { conf_dir: '/path/to/nginx', proxy_cache_path: '/path/to/proxy.cache', proxy_cache_loader_sleep: '50ms' } }
+        it { is_expected.to contain_file('/path/to/nginx/nginx.conf').with_content(%r{\s+proxy_cache_path\s+/path/to/proxy.cache levels=1 keys_zone=d2:100m max_size=500m inactive=20m loader_sleep=50ms;}) }
+      end
+
+      context 'when proxy_cache_path is /path/to/nginx and loader_threshold is 300ms' do
+        let(:params) { { conf_dir: '/path/to/nginx', proxy_cache_path: '/path/to/proxy.cache', proxy_cache_loader_threshold: '300ms' } }
+        it { is_expected.to contain_file('/path/to/nginx/nginx.conf').with_content(%r{\s+proxy_cache_path\s+/path/to/proxy.cache levels=1 keys_zone=d2:100m max_size=500m inactive=20m loader_threshold=300ms;}) }
+      end
+
       context 'when conf_dir is /path/to/nginx' do
         let(:params) { { conf_dir: '/path/to/nginx' } }
         it { is_expected.to contain_file('/path/to/nginx/nginx.conf').with_content(%r{include       /path/to/nginx/mime\.types;}) }

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -157,10 +157,18 @@ http {
 <% end -%>
 <% if @proxy_cache_path.is_a?(Hash) -%>
 <% @proxy_cache_path.sort_by{|k,v| k}.each do |key,value| -%>
-  proxy_cache_path        <%= key %> keys_zone=<%= value %> levels=<%= @proxy_cache_levels %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive %><% if @proxy_use_temp_path %> use_temp_path=<%= @proxy_use_temp_path %><% end -%>;
+  proxy_cache_path        <%= key %> keys_zone=<%= value %> levels=<%= @proxy_cache_levels %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive -%>
+   <%- if @proxy_use_temp_path %> use_temp_path=<%= @proxy_use_temp_path %><% end -%>
+   <%- if @proxy_cache_loader_files %> loader_files=<%= @proxy_cache_loader_files %><% end -%>
+   <%- if @proxy_cache_loader_sleep %> loader_sleep=<%= @proxy_cache_loader_sleep %><% end -%>
+   <%- if @proxy_cache_loader_threshold %> loader_threshold=<%= @proxy_cache_loader_threshold %><% end -%>;
 <% end -%>
 <% elsif @proxy_cache_path -%>
-  proxy_cache_path        <%= @proxy_cache_path %> levels=<%= @proxy_cache_levels %> keys_zone=<%= @proxy_cache_keys_zone %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive %><% if @proxy_use_temp_path %> use_temp_path=<%= @proxy_use_temp_path %><% end %>;
+  proxy_cache_path        <%= @proxy_cache_path %> levels=<%= @proxy_cache_levels %> keys_zone=<%= @proxy_cache_keys_zone %> max_size=<%= @proxy_cache_max_size %> inactive=<%= @proxy_cache_inactive -%>
+  <%- if @proxy_use_temp_path %> use_temp_path=<%= @proxy_use_temp_path %><% end -%>
+  <%- if @proxy_cache_loader_files %> loader_files=<%= @proxy_cache_loader_files %><% end -%>
+  <%- if @proxy_cache_loader_sleep %> loader_sleep=<%= @proxy_cache_loader_sleep %><% end -%>
+  <%- if @proxy_cache_loader_threshold %> loader_threshold=<%= @proxy_cache_loader_threshold %><% end -%>;
 <% end -%>
 <% if @fastcgi_cache_path -%>
   fastcgi_cache_path    	<%= @fastcgi_cache_path %> levels=<%= @fastcgi_cache_levels %> keys_zone=<%= @fastcgi_cache_keys_zone %> max_size=<%= @fastcgi_cache_max_size %> inactive=<%= @fastcgi_cache_inactive %>;


### PR DESCRIPTION
Add support for loader_files, loader_sleep and loader_threshold for proxy_cache_path.

http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_path

```
Syntax:	proxy_cache_path path [levels=levels] [use_temp_path=on|off] keys_zone=name:size [inactive=time] [max_size=size] [manager_files=number] [manager_sleep=time] [manager_threshold=time] [loader_files=number] [loader_sleep=time] [loader_threshold=time] [purger=on|off] [purger_files=number] [purger_sleep=time] [purger_threshold=time];
Default:	—
Context:	http
```

Signed-off-by: Christophe Vanlancker <christophe.vanlancker@inuits.eu>