### PR TITLE
add passenger_package_ensure parameter to allow pinning passenger version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,6 +140,7 @@ class nginx (
   $package_source                 = 'nginx',
   $package_flavor                 = undef,
   $manage_repo                    = $::nginx::params::manage_repo,
+  $passenger_package_ensure       = 'present',
   ### END Package Configuration ###
 
   ### START Service Configuation ###
@@ -267,12 +268,13 @@ class nginx (
   ### END VALIDATIONS ###
 
   class { '::nginx::package':
-    package_name   => $package_name,
-    package_source => $package_source,
-    package_ensure => $package_ensure,
-    package_flavor => $package_flavor,
-    notify         => Class['::nginx::service'],
-    manage_repo    => $manage_repo,
+    package_name             => $package_name,
+    package_source           => $package_source,
+    package_ensure           => $package_ensure,
+    package_flavor           => $package_flavor,
+    passenger_package_ensure => $passenger_package_ensure,
+    notify                   => Class['::nginx::service'],
+    manage_repo              => $manage_repo,
   }
 
   include '::nginx::config'

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -14,11 +14,12 @@
 #
 # This class file is not called directly
 class nginx::package(
-  $package_name   = $::nginx::params::package_name,
-  $package_source = 'nginx',
-  $package_ensure = 'present',
-  $package_flavor = undef,
-  $manage_repo    = $::nginx::params::manage_repo,
+  $package_name             = $::nginx::params::package_name,
+  $package_source           = 'nginx',
+  $package_ensure           = 'present',
+  $package_flavor           = undef,
+  $passenger_package_ensure = 'present',
+  $manage_repo              = $::nginx::params::manage_repo,
 ) {
 
   assert_private()
@@ -29,22 +30,24 @@ class nginx::package(
   case $::osfamily {
     'redhat': {
       class { '::nginx::package::redhat':
-        manage_repo    => $manage_repo,
-        package_source => $package_source,
-        package_ensure => $package_ensure,
-        package_name   => $package_name,
-        require        => Anchor['nginx::package::begin'],
-        before         => Anchor['nginx::package::end'],
+        manage_repo              => $manage_repo,
+        package_source           => $package_source,
+        package_ensure           => $package_ensure,
+        passenger_package_ensure => $passenger_package_ensure,
+        package_name             => $package_name,
+        require                  => Anchor['nginx::package::begin'],
+        before                   => Anchor['nginx::package::end'],
       }
     }
     'debian': {
       class { '::nginx::package::debian':
-        package_name   => $package_name,
-        package_source => $package_source,
-        package_ensure => $package_ensure,
-        manage_repo    => $manage_repo,
-        require        => Anchor['nginx::package::begin'],
-        before         => Anchor['nginx::package::end'],
+        package_name             => $package_name,
+        package_source           => $package_source,
+        package_ensure           => $package_ensure,
+        passenger_package_ensure => $passenger_package_ensure,
+        manage_repo              => $manage_repo,
+        require                  => Anchor['nginx::package::begin'],
+        before                   => Anchor['nginx::package::end'],
       }
     }
     'Solaris': {

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -13,11 +13,12 @@
 # Sample Usage:
 #
 # This class file is not called directly
-class nginx::package::debian(
-    $manage_repo    = true,
-    $package_name   = 'nginx',
-    $package_source = 'nginx',
-    $package_ensure = 'present'
+class nginx::package::debian (
+    $manage_repo              = true,
+    $package_name             = 'nginx',
+    $package_source           = 'nginx',
+    $package_ensure           = 'present',
+    $passenger_package_ensure = 'present'
   ) {
 
   $distro = downcase($::operatingsystem)
@@ -58,7 +59,7 @@ class nginx::package::debian(
         Package['apt-transport-https','ca-certificates'] -> Apt::Source['nginx']
 
         package { 'passenger':
-          ensure  => 'present',
+          ensure  => $passenger_package_ensure,
           require => Exec['apt_update'],
         }
 

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -14,10 +14,11 @@
 #
 # This class file is not called directly
 class nginx::package::redhat (
-  $manage_repo    = true,
-  $package_ensure = 'present',
-  $package_name   = 'nginx',
-  $package_source = 'nginx-stable',
+  $manage_repo                 = true,
+  $package_ensure              = 'present',
+  $package_name                = 'nginx',
+  $package_source              = 'nginx-stable',
+  $passenger_package_ensure    = 'present',
 ) {
 
   #Install the CentOS-specific packages on that OS, otherwise assume it's a RHEL
@@ -84,7 +85,7 @@ class nginx::package::redhat (
           }
 
           package { 'passenger':
-            ensure  => present,
+            ensure  => $passenger_package_ensure,
             require => Yumrepo['passenger'],
           }
 

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -95,7 +95,15 @@ describe 'nginx' do
         end
         it { is_expected.to contain_yumrepo('passenger').that_comes_before('Package[nginx]') }
         it { is_expected.to contain_yumrepo('nginx-release').that_comes_before('Package[nginx]') }
-        it { is_expected.to contain_package('passenger') }
+        it { is_expected.to contain_package('passenger').with('ensure' => 'present') }
+      end
+
+      describe 'installs the requested passenger package version' do
+        let(:params) { { package_source: 'passenger', passenger_package_ensure: '4.1.0-1.el9' } }
+
+        it 'installs specified version exactly' do
+          is_expected.to contain_package('passenger').with('ensure' => '4.1.0-1.el9')
+        end
       end
 
       context 'manage_repo => false' do


### PR DESCRIPTION
I'd have to integrate this into #938, but needed this Right Now at work, and thought I'd add it in.

Basically, the passenger and nginx versions for the passenger repo need to be in lockstep, or problems come up, and setting `package_ensure` for nginx without being able to lock passenger version too causes some problems.