### PR TITLE
Bump puppet minimum version_requirement to 3.8.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ This module manages NGINX configuration.
 
 ### Requirements
 
-* Puppet 3.0.0 or later
-* Facter 1.7.0 or later
-* Ruby 1.9.3 or later (Support for Ruby-1.8.7 is not guaranteed. YMMV).
+* Puppet 3.8.7 or later
 
 ### Additional Documentation
 

--- a/metadata.json
+++ b/metadata.json
@@ -23,12 +23,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet 3 versions

Also remove deprecated pe version_requirement

Also remove explicit references to Ruby and Facter versions