### PR TITLE
Use double, vs single quotes around add_header values (#991)

### DIFF
--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -1200,12 +1200,7 @@ describe 'nginx::resource::server' do
         end
 
         it 'has correctly ordered entries in the config' do
-          is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{
-            %r|
-            \s+add_header\s+header1 test value 1;\n
-            \s+add_header\s+header2 test value 2;\n
-            \s+add_header\s+header3 test value 3;\n
-            |})
+          is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+add_header\s+"header1" "test value 1";\n\s+add_header\s+"header2" "test value 2";\n\s+add_header\s+"header3" "test value 3";\n})
         end
       end
 
@@ -1218,12 +1213,7 @@ describe 'nginx::resource::server' do
         end
 
         it 'has correctly ordered entries in the config' do
-          is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{
-            %r|
-            \s+add_header\s+header1 test value 1;\n
-            \s+add_header\s+header2 test value 2;\n
-            \s+add_header\s+header3 test value 3;\n
-            |})
+          is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{\s+add_header\s+"header1" "test value 1";\n\s+add_header\s+"header2" "test value 2";\n\s+add_header\s+"header3" "test value 3";\n})
         end
       end
     end

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -131,7 +131,7 @@ server {
 <% end -%>
 <% if @add_header -%>
   <%- @add_header.keys.sort.each do |key| -%>
-  add_header              '<%= key %>' '<%= @add_header[key] %>';
+  add_header              "<%= key %>" "<%= @add_header[key] %>";
   <%- end -%>
 <% end -%>
 <% if @maintenance -%>

--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -161,6 +161,6 @@ server {
 <% end -%>
 <% if @add_header -%>
   <%- @add_header.keys.sort.each do |key| -%>
-  add_header              '<%= key %>' '<%= @add_header[key] %>';
+  add_header              "<%= key %>" "<%= @add_header[key] %>";
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
Not sure how 

https://github.com/voxpupuli/puppet-nginx/blob/master/spec/defines/resource_server_spec.rb#L1197-L1227
passes either before / after, but this seems to pass tests. I'm going to mark this as in-progress, though.