### PR TITLE
Bump minimum version dependencies (for Puppet 4)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.2.0 <5.0.0"
+      "version_requirement": ">= 4.6.0 <5.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 1.8.0 <3.0.0"
+      "version_requirement": ">= 2.1.0 <3.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.1.1 <3.0.0"
+      "version_requirement": ">= 1.2.5 <3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata