### PR TITLE
Permissions on fastcgi_params and uwsgi_params files (#1002)

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -413,7 +413,7 @@ define nginx::resource::location (
   if $ensure == present and $fastcgi != undef and !defined(File[$fastcgi_params]) {
     file { $fastcgi_params:
       ensure  => present,
-      mode    => '0770',
+      mode    => '0644',
       content => template('nginx/server/fastcgi_params.erb'),
     }
   }
@@ -421,7 +421,7 @@ define nginx::resource::location (
   if $ensure == present and $uwsgi != undef and !defined(File[$uwsgi_params]) {
     file { $uwsgi_params:
       ensure  => present,
-      mode    => '0770',
+      mode    => '0644',
       content => template('nginx/server/uwsgi_params.erb'),
     }
   }

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -694,7 +694,7 @@ define nginx::resource::server (
   if $fastcgi != undef and !defined(File[$fastcgi_params]) {
     file { $fastcgi_params:
       ensure  => present,
-      mode    => '0770',
+      mode    => '0644',
       content => template('nginx/server/fastcgi_params.erb'),
     }
   }
@@ -702,7 +702,7 @@ define nginx::resource::server (
   if $uwsgi != undef and !defined(File[$uwsgi_params]) {
     file { $uwsgi_params:
       ensure  => present,
-      mode    => '0660',
+      mode    => '0644',
       content => template('nginx/server/uwsgi_params.erb'),
     }
   }

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -856,7 +856,7 @@ describe 'nginx::resource::location' do
       context 'when fastcgi => "localhost:9000"' do
         let(:params) { { fastcgi: 'localhost:9000', server: 'server1' } }
 
-        it { is_expected.to contain_file('/etc/nginx/fastcgi_params').with_mode('0770') }
+        it { is_expected.to contain_file('/etc/nginx/fastcgi_params').with_mode('0644') }
       end
 
       context 'when uwsgi => "unix:/home/project/uwsgi.socket"' do

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -997,7 +997,7 @@ describe 'nginx::resource::server' do
           default_params.merge(fastcgi: 'localhost:9000')
         end
 
-        it { is_expected.to contain_file('/etc/nginx/fastcgi_params').with_mode('0770') }
+        it { is_expected.to contain_file('/etc/nginx/fastcgi_params').with_mode('0644') }
       end
 
       context 'when fastcgi_param => {key => value}' do
@@ -1013,7 +1013,7 @@ describe 'nginx::resource::server' do
           default_params.merge(uwsgi: 'uwsgi_upstream')
         end
 
-        it { is_expected.to contain_file('/etc/nginx/uwsgi_params').with_mode('0660') }
+        it { is_expected.to contain_file('/etc/nginx/uwsgi_params').with_mode('0644') }
       end
 
       context 'when listen_port == ssl_port' do


### PR DESCRIPTION
This attempts to resolve #1002 (but curious if anyone knows why the permissions on `fastcgi_params` and `uwsgi_params` were 0770 and 0660 respectively, rather than 0644 or 0444).