### PR TITLE
Fix for apt-transport-https

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -14,12 +14,12 @@
 #
 # This class file is not called directly
 class nginx::package::debian (
-    $manage_repo              = true,
-    $package_name             = 'nginx',
-    $package_source           = 'nginx',
-    $package_ensure           = 'present',
-    $passenger_package_ensure = 'present'
-  ) {
+  $manage_repo              = true,
+  $package_name             = 'nginx',
+  $package_source           = 'nginx',
+  $package_ensure           = 'present',
+  $passenger_package_ensure = 'present'
+) {
 
   $distro = downcase($::operatingsystem)
 
@@ -31,6 +31,10 @@ class nginx::package::debian (
   if $manage_repo {
     include '::apt'
     Exec['apt_update'] -> Package['nginx']
+
+    ensure_packages([ 'apt-transport-https', 'ca-certificates' ])
+
+    Package['apt-transport-https','ca-certificates'] -> Apt::Source['nginx']
 
     case $package_source {
       'nginx', 'nginx-stable': {
@@ -53,10 +57,6 @@ class nginx::package::debian (
           repos    => 'main',
           key      => '16378A33A6EF16762922526E561F9B9CAC40B2F7',
         }
-
-        ensure_packages([ 'apt-transport-https', 'ca-certificates' ])
-
-        Package['apt-transport-https','ca-certificates'] -> Apt::Source['nginx']
 
         package { 'passenger':
           ensure  => $passenger_package_ensure,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -155,7 +155,6 @@ describe 'nginx' do
       context 'using defaults' do
         it { is_expected.to contain_package('nginx') }
         it { is_expected.not_to contain_package('passenger') }
-        it { is_expected.not_to contain_package('apt-transport-https') }
         it do
           is_expected.to contain_apt__source('nginx').with(
             'location'   => "https://nginx.org/packages/#{operatingsystem.downcase}",
@@ -194,7 +193,6 @@ describe 'nginx' do
         it { is_expected.to contain_package('nginx') }
         it { is_expected.not_to contain_apt__source('nginx') }
         it { is_expected.not_to contain_package('passenger') }
-        it { is_expected.not_to contain_package('apt-transport-https') }
       end
     end
 


### PR DESCRIPTION
  The installation for the package apt-transport-https is put only for
the passenger case. But event with « just » nginx we need the
apt-transport-https because the url for nginx repot is on https://nginx

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
