### PR TITLE
Switched apt::source key from string to hash.

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -37,21 +37,21 @@ class nginx::package::debian (
         apt::source { 'nginx':
           location => "https://nginx.org/packages/${distro}",
           repos    => 'nginx',
-          key      => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
+          key      => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'},
         }
       }
       'nginx-mainline': {
         apt::source { 'nginx':
           location => "https://nginx.org/packages/mainline/${distro}",
           repos    => 'nginx',
-          key      => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62',
+          key      => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'},
         }
       }
       'passenger': {
         apt::source { 'nginx':
           location => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
           repos    => 'main',
-          key      => '16378A33A6EF16762922526E561F9B9CAC40B2F7',
+          key      => {'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7'},
         }
 
         ensure_packages([ 'apt-transport-https', 'ca-certificates' ])

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -159,7 +159,7 @@ describe 'nginx' do
           is_expected.to contain_apt__source('nginx').with(
             'location'   => "https://nginx.org/packages/#{operatingsystem.downcase}",
             'repos'      => 'nginx',
-            'key'        => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'}
+            'key'        => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' }
           )
         end
         it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::debian]') }
@@ -183,7 +183,7 @@ describe 'nginx' do
           is_expected.to contain_apt__source('nginx').with(
             'location'   => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
             'repos'      => 'main',
-            'key'        => {'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7'}
+            'key'        => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' }
           )
         end
       end

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -159,7 +159,7 @@ describe 'nginx' do
           is_expected.to contain_apt__source('nginx').with(
             'location'   => "https://nginx.org/packages/#{operatingsystem.downcase}",
             'repos'      => 'nginx',
-            'key'        => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'
+            'key'        => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'}
           )
         end
         it { is_expected.to contain_anchor('nginx::package::begin').that_comes_before('Class[nginx::package::debian]') }
@@ -183,7 +183,7 @@ describe 'nginx' do
           is_expected.to contain_apt__source('nginx').with(
             'location'   => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
             'repos'      => 'main',
-            'key'        => '16378A33A6EF16762922526E561F9B9CAC40B2F7'
+            'key'        => {'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7'}
           )
         end
       end


### PR DESCRIPTION
Updated to resolve #995 for new apt usage.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
