### PR TITLE
warn if $ssl=false but $ssl_port == $listen_port (#1015)

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -354,6 +354,12 @@ define nginx::resource::server (
     }
   }
 
+  # Try to error in the case where the user sets ssl_port == listen_port but
+  # doesn't set ssl = true
+  if (!($ssl == true) and ($ssl_port == $listen_port)) {
+    warning('nginx: ssl must be true if listen_port is the same as ssl_port')
+  }
+
   concat { $config_file:
     owner   => $owner,
     group   => $group,

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -990,14 +990,16 @@ describe 'nginx::resource::server' do
         it { is_expected.to contain_file('/etc/nginx/uwsgi_params').with_mode('0644') }
       end
 
-      context 'when listen_port == ssl_port' do
+      context 'when listen_port == ssl_port but ssl = false' do
         let :params do
           default_params.merge(listen_port: 80,
-                               ssl_port: 80)
+                               ssl_port: 80,
+                               ssl: false)
         end
 
-        it { is_expected.not_to contain_concat__fragment("#{title}-header") }
-        it { is_expected.not_to contain_concat__fragment("#{title}-footer") }
+        # TODO: implement test after this can be tested
+        # msg = %r{nginx: ssl must be true if listen_port is the same as ssl_port}
+        it 'Testing for warnings not yet implemented in classes'
       end
 
       context 'when listen_port != ssl_port' do


### PR DESCRIPTION
See #1015 
I would appreciate review on this... I'm not totally sure why these tests exist, or why there appear to be 2 sets of identical tests there:
https://github.com/voxpupuli/puppet-nginx/blob/master/spec/defines/resource_server_spec.rb#L1019-L1057
vs, say, https://github.com/voxpupuli/puppet-nginx/blob/master/spec/defines/resource_server_spec.rb#L1071-L1086

or what the use case is for having `ssl_port` == `listen_port` when `ssl` is _not_true, but I think this PR might make some sense.