### PR TITLE
allow service and package to be called outside of main class

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -22,8 +22,6 @@ class nginx::package(
   $manage_repo              = $::nginx::params::manage_repo,
 ) {
 
-  assert_private()
-
   anchor { 'nginx::package::begin': }
   anchor { 'nginx::package::end': }
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -21,8 +21,6 @@ class nginx::service(
   $service_manage  = $::nginx::service_manage,
 ) {
 
-  assert_private()
-
   $service_enable = $service_ensure ? {
     'running' => true,
     'absent'  => false,


### PR DESCRIPTION
Hi, this allows the service and package classes to be called outside the main class. This reverts part of the change made in https://github.com/voxpupuli/puppet-nginx/pull/950 which disallowed calling any other sub classes. This does not break existing functionality.

Its use case is to allow installing the nginx package via the module, without doing any of the other configuration. This is pretty useful in a wrapper module, which installs the rest of the configuration via templates instead.
```
    include nginx::params

    # install nginx package only
    class { 'nginx::package' : }
```

I think in the future having a feature flag `install_only` would be pretty handy too.

Thanks
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
