### PR TITLE
Avoid spurious location block when redirecting to SSL in another server block

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -370,7 +370,7 @@ define nginx::resource::server (
     $_ssl_redirect_port = $ssl_port
   }
 
-  # Suppress unneded stuff in non-SSL location block when certain conditions are
+  # Suppress unneeded stuff in non-SSL location block when certain conditions are
   # met.
   if (($ssl == true) and ($ssl_port == $listen_port)) or ($ssl_redirect) {
     $ssl_only = true
@@ -378,7 +378,11 @@ define nginx::resource::server (
     $ssl_only = false
   }
 
-  if $use_default_location == true {
+  # If we're redirecting to SSL, the default location block is useless, *unless*
+  # SSL is enabled for this server
+  # either       and    ssl -> true
+  # ssl redirect and no ssl -> false
+  if ($ssl_redirect != true or $ssl == true) and $use_default_location == true {
     # Create the default location reference for the server
     nginx::resource::location {"${name_sanitized}-default":
       ensure                      => $ensure,

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -898,10 +898,28 @@ describe 'nginx::resource::server' do
         it { is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{  return 301 https://\$host:9787\$request_uri;}) }
       end
 
-      context 'ssl_redirect should set ssl_only' do
-        let(:params) { { ssl_redirect: true } }
+      context 'ssl_redirect should set ssl_only when ssl => true' do
+        let(:params) do
+          {
+            ssl_redirect: true,
+            ssl: true,
+            ssl_key: 'dummy.key',
+            ssl_cert: 'dummy.crt'
+          }
+        end
 
         it { is_expected.to contain_nginx__resource__location("#{title}-default").with_ssl_only(true) }
+      end
+
+      context 'ssl_redirect should not include default location when ssl => false' do
+        let(:params) do
+          {
+            ssl_redirect: true,
+            ssl: false
+          }
+        end
+
+        it { is_expected.not_to contain_nginx__resource__location("#{title}-default") }
       end
 
       context 'SSL cert and key are both set to fully qualified paths' do


### PR DESCRIPTION
Fixes #1029

I'm pretty sure this is sane behaviour. Any thoughts?