### PR TITLE
Adds hiera nginx_mailhosts_defaults like nginx_servers_defaults

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,6 +155,7 @@ class nginx (
   $string_mappings                                                                              = {},
   $nginx_locations                                                                              = {},
   $nginx_mailhosts                                                                              = {},
+  $nginx_mailhosts_defaults                                                                     = {},
   $nginx_streamhosts                                                                            = {},
   $nginx_upstreams                                                                              = {},
   $nginx_servers                                                                                = {},
@@ -180,7 +181,7 @@ class nginx (
   create_resources('nginx::resource::upstream', $nginx_upstreams)
   create_resources('nginx::resource::server', $nginx_servers, $nginx_servers_defaults)
   create_resources('nginx::resource::location', $nginx_locations)
-  create_resources('nginx::resource::mailhost', $nginx_mailhosts)
+  create_resources('nginx::resource::mailhost', $nginx_mailhosts, $nginx_mailhosts_defaults)
   create_resources('nginx::resource::streamhost', $nginx_streamhosts)
   create_resources('nginx::resource::map', $string_mappings)
   create_resources('nginx::resource::geo', $geo_mappings)

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -14,6 +14,7 @@ describe 'nginx' do
       nginx_servers_defaults: { 'listen_options' => 'default_server' },
       nginx_locations: { 'test2.local' => { 'server' => 'test2.local', 'www_root' => '/' } },
       nginx_mailhosts: { 'smtp.test2.local' => { 'auth_http' => 'server2.example/cgi-bin/auth', 'protocol' => 'smtp', 'listen_port' => 587 } },
+      nginx_mailhosts_defaults: { 'listen_options' => 'default_server_smtp' },
       nginx_streamhosts: { 'streamhost1' => { 'proxy' => 'streamproxy' } }
     }
   end
@@ -33,6 +34,7 @@ describe 'nginx' do
     it { is_expected.to contain_nginx__resource__server('test2.local').with_listen_options('default_server') }
     it { is_expected.to contain_nginx__resource__location('test2.local') }
     it { is_expected.to contain_nginx__resource__mailhost('smtp.test2.local') }
+    it { is_expected.to contain_nginx__resource__mailhost('smtp.test2.local').with_listen_options('default_server_smtp') }
     it { is_expected.to contain_nginx__resource__streamhost('streamhost1').with_proxy('streamproxy') }
   end
 


### PR DESCRIPTION
Set mailhosts default value. This is useful when setting the SSL settings on multiple ports and protocols or disable xclient.
Similar to this commit for vhost (aka servers):
https://github.com/voxpupuli/puppet-nginx/commit/ad391f67bf5297f472bf7ccdd163dc7899dbe1fd