### PR TITLE
Fail defined types if nginx class was not declared before

### DIFF
--- a/manifests/resource/geo.pp
+++ b/manifests/resource/geo.pp
@@ -63,6 +63,10 @@ define nginx::resource::geo (
   Optional[Boolean] $proxy_recursive  = undef
 ) {
 
+  if ! defined(Class['nginx']) {
+    fail('You must include the nginx base class before using any defined resources')
+  }
+
   $root_group = $::nginx::root_group
   $conf_dir   = "${::nginx::conf_dir}/conf.d"
 

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -214,6 +214,10 @@ define nginx::resource::location (
   Optional[String] $expires                           = undef,
 ) {
 
+  if ! defined(Class['nginx']) {
+    fail('You must include the nginx base class before using any defined resources')
+  }
+
   $root_group = $::nginx::root_group
 
   File {

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -118,6 +118,10 @@ define nginx::resource::mailhost (
   Array $server_name                             = [$name]
 ) {
 
+  if ! defined(Class['nginx']) {
+    fail('You must include the nginx base class before using any defined resources')
+  }
+
   $root_group = $::nginx::root_group
 
   File {

--- a/manifests/resource/map.pp
+++ b/manifests/resource/map.pp
@@ -69,6 +69,10 @@ define nginx::resource::map (
   Enum['absent', 'present'] $ensure = 'present',
   Boolean $hostnames                = false
 ) {
+  if ! defined(Class['nginx']) {
+    fail('You must include the nginx base class before using any defined resources')
+  }
+
   validate_re($string, '^.{2,}$',
     "Invalid string value [${string}]. Expected a minimum of 2 characters.")
 

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -249,6 +249,10 @@ define nginx::resource::server (
   Hash $locations                                                                = {}
 ) {
 
+  if ! defined(Class['nginx']) {
+    fail('You must include the nginx base class before using any defined resources')
+  }
+
   # Variables
   if $::nginx::confd_only {
     $server_dir = "${::nginx::conf_dir}/conf.d"

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -66,6 +66,10 @@ define nginx::resource::streamhost (
   String $mode                            = $::nginx::global_mode,
 ) {
 
+  if ! defined(Class['nginx']) {
+    fail('You must include the nginx base class before using any defined resources')
+  }
+
   # Variables
   if $::nginx::confd_only {
     $streamhost_dir = "${::nginx::conf_dir}/conf.stream.d"

--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -51,6 +51,10 @@ define nginx::resource::upstream (
   Enum['http', 'stream'] $upstream_context  = 'http',
 ) {
 
+  if ! defined(Class['nginx']) {
+    fail('You must include the nginx base class before using any defined resources')
+  }
+
   $root_group = $::nginx::root_group
 
   $ensure_real = $ensure ? {

--- a/manifests/resource/upstream/member.pp
+++ b/manifests/resource/upstream/member.pp
@@ -41,6 +41,9 @@ define nginx::resource::upstream::member (
   Integer $port                     = 80,
   $upstream_fail_timeout  = '10s',
 ) {
+  if ! defined(Class['nginx']) {
+    fail('You must include the nginx base class before using any defined resources')
+  }
 
   # Uses: $server, $port, $upstream_fail_timeout
   concat::fragment { "${upstream}_upstream_member_${name}":


### PR DESCRIPTION
Because the `ngnix::resource:*` types access ::ngnix class
parameters the nginx class needs to be declared before calling
the defined type.

`include ::nginx` inside the defined type is not enough because
params are evaluated before include is parsed.

Two of the defined types only access params inside. The include
way would work there - but for consistency I also added the fail.

Closes #983 