### PR TITLE
Add location defaults to init and server resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -154,6 +154,7 @@ class nginx (
   $geo_mappings                                     = {},
   $string_mappings                                  = {},
   $nginx_locations                                  = {},
+  $nginx_locations_defaults                         = {},
   $nginx_mailhosts                                  = {},
   $nginx_mailhosts_defaults                         = {},
   $nginx_streamhosts                                = {},
@@ -169,7 +170,7 @@ class nginx (
 
   create_resources('nginx::resource::upstream', $nginx_upstreams)
   create_resources('nginx::resource::server', $nginx_servers, $nginx_servers_defaults)
-  create_resources('nginx::resource::location', $nginx_locations)
+  create_resources('nginx::resource::location', $nginx_locations, $nginx_locations_defaults)
   create_resources('nginx::resource::mailhost', $nginx_mailhosts, $nginx_mailhosts_defaults)
   create_resources('nginx::resource::streamhost', $nginx_streamhosts)
   create_resources('nginx::resource::map', $string_mappings)

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -121,6 +121,7 @@
 #   [*maintenance_value*]          - Value to return when maintenance is on.  Default to return 503
 #   [*error_pages*]                - Hash: setup errors pages, hash key is the http code and hash value the page
 #   [*locations*]                  - Hash of servers resources used by this server
+#   [*locations_defaults*]         - Hash of location default settings
 # Actions:
 #
 # Requires:
@@ -248,7 +249,8 @@ define nginx::resource::server (
   Boolean $maintenance                                                           = false,
   String $maintenance_value                                                      = 'return 503',
   $error_pages                                                                   = undef,
-  Hash $locations                                                                = {}
+  Hash $locations                                                                = {},
+  Hash $locations_defaults                                                       = {}
 ) {
 
   # Variables
@@ -447,5 +449,5 @@ define nginx::resource::server (
     ssl      => $ssl,
     ssl_only => $ssl_only,
     www_root => $www_root,
-  })
+  } + $locations_defaults)
 }

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -13,6 +13,7 @@ describe 'nginx' do
       nginx_servers: { 'test2.local' => { 'www_root' => '/' } },
       nginx_servers_defaults: { 'listen_options' => 'default_server' },
       nginx_locations: { 'test2.local' => { 'server' => 'test2.local', 'www_root' => '/' } },
+      nginx_locations_defaults: { 'expires' => '@12h34m' },
       nginx_mailhosts: { 'smtp.test2.local' => { 'auth_http' => 'server2.example/cgi-bin/auth', 'protocol' => 'smtp', 'listen_port' => 587 } },
       nginx_mailhosts_defaults: { 'listen_options' => 'default_server_smtp' },
       nginx_streamhosts: { 'streamhost1' => { 'proxy' => 'streamproxy' } }
@@ -29,6 +30,7 @@ describe 'nginx' do
     it { is_expected.to contain_nginx__resource__server('test2.local') }
     it { is_expected.to contain_nginx__resource__server('test2.local').with_listen_options('default_server') }
     it { is_expected.to contain_nginx__resource__location('test2.local') }
+    it { is_expected.to contain_nginx__resource__location('test2.local').with_expires('@12h34m') }
     it { is_expected.to contain_nginx__resource__mailhost('smtp.test2.local') }
     it { is_expected.to contain_nginx__resource__mailhost('smtp.test2.local').with_listen_options('default_server_smtp') }
     it { is_expected.to contain_nginx__resource__streamhost('streamhost1').with_proxy('streamproxy') }

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -1212,5 +1212,81 @@ describe 'nginx::resource::server' do
         end
       end
     end
+
+    describe 'with locations' do
+      context 'simple location' do
+        let(:params) do
+          {
+            use_default_location: false,
+            locations: {
+              'one' => {
+                'location_custom_cfg' => {},
+                'location' => '/one',
+                'expires' => '@12h34m'
+              }
+            }
+          }
+        end
+        it { is_expected.to contain_nginx__resource__location('one') }
+        it { is_expected.to contain_nginx__resource__location('one').with_location('/one') }
+        it { is_expected.to contain_nginx__resource__location('one').with_expires('@12h34m') }
+      end
+
+      context 'multiple locations' do
+        let(:params) do
+          {
+            use_default_location: false,
+            locations: {
+              'one' => {
+                'location_custom_cfg' => {},
+                'location' => '/one',
+                'expires' => '@12h34m'
+              },
+              'two' => {
+                'location_custom_cfg' => {},
+                'location' => '= /two',
+                'expires' => '@23h45m'
+              }
+            }
+          }
+        end
+        it { is_expected.to contain_nginx__resource__location('one') }
+        it { is_expected.to contain_nginx__resource__location('one').with_location('/one') }
+        it { is_expected.to contain_nginx__resource__location('one').with_expires('@12h34m') }
+        it { is_expected.to contain_nginx__resource__location('two') }
+        it { is_expected.to contain_nginx__resource__location('two').with_location('= /two') }
+        it { is_expected.to contain_nginx__resource__location('two').with_expires('@23h45m') }
+      end
+
+      context 'with locations default' do
+        let(:params) do
+          {
+            www_root: '/toplevel',
+            locations_defaults: {
+              'www_root' => '/overwrite',
+              'expires' => '@12h34m'
+            },
+            locations: {
+              'one' => {
+                'location_custom_cfg' => {},
+                'location' => '/one'
+              },
+              'two' => {
+                'location_custom_cfg' => {},
+                'location' => '= /two'
+              }
+            }
+          }
+        end
+        it { is_expected.to contain_nginx__resource__location('one') }
+        it { is_expected.to contain_nginx__resource__location('one').with_location('/one') }
+        it { is_expected.to contain_nginx__resource__location('one').with_www_root('/overwrite') }
+        it { is_expected.to contain_nginx__resource__location('one').with_expires('@12h34m') }
+        it { is_expected.to contain_nginx__resource__location('two') }
+        it { is_expected.to contain_nginx__resource__location('two').with_location('= /two') }
+        it { is_expected.to contain_nginx__resource__location('two').with_www_root('/overwrite') }
+        it { is_expected.to contain_nginx__resource__location('two').with_expires('@12h34m') }
+      end
+    end
   end
 end


### PR DESCRIPTION
By adding location defaults it's possible to overwrite location
value like 'index_files'.

Related to #1068 