### PR TITLE
Use nginx defaults for fastcgi_params / uwsgi_params

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -173,12 +173,12 @@ define nginx::resource::location (
   Optional[String] $fastcgi                           = undef,
   Optional[String] $fastcgi_index                     = undef,
   Optional[Hash] $fastcgi_param                       = undef,
-  String $fastcgi_params                              = "${::nginx::conf_dir}/fastcgi_params",
+  Optional[String] $fastcgi_params                    = "${::nginx::conf_dir}/fastcgi.conf",
   Optional[String] $fastcgi_script                    = undef,
   Optional[String] $fastcgi_split_path                = undef,
   Optional[String] $uwsgi                             = undef,
   Optional[Hash] $uwsgi_param                         = undef,
-  String $uwsgi_params                                = "${nginx::config::conf_dir}/uwsgi_params",
+  Optional[String] $uwsgi_params                      = "${nginx::config::conf_dir}/uwsgi_params",
   Optional[String] $uwsgi_read_timeout                = undef,
   Boolean $ssl                                        = false,
   Boolean $ssl_only                                   = false,
@@ -248,15 +248,18 @@ define nginx::resource::location (
 
   $config_file = "${server_dir}/${server_sanitized}.conf"
 
-  if $ensure == present and $fastcgi != undef and !defined(File[$fastcgi_params]) {
+  # Only try to manage these files if they're the default one (as you presumably
+  # usually don't want the default template if you're using a custom file.
+
+  if $ensure == present and $fastcgi != undef and !defined(File[$fastcgi_params]) and $fastcgi_params == "${::nginx::conf_dir}/fastcgi.conf" {
     file { $fastcgi_params:
       ensure  => present,
       mode    => '0644',
-      content => template('nginx/server/fastcgi_params.erb'),
+      content => template('nginx/server/fastcgi.conf.erb'),
     }
   }
 
-  if $ensure == present and $uwsgi != undef and !defined(File[$uwsgi_params]) {
+  if $ensure == present and $uwsgi != undef and !defined(File[$uwsgi_params]) and $uwsgi_params == "${::nginx::conf_dir}/uwsgi_params" {
     file { $uwsgi_params:
       ensure  => present,
       mode    => '0644',

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -194,10 +194,10 @@ define nginx::resource::server (
   Optional[String] $fastcgi                                                      = undef,
   Optional[String] $fastcgi_index                                                = undef,
   $fastcgi_param                                                                 = undef,
-  String $fastcgi_params                                                         = "${::nginx::conf_dir}/fastcgi_params",
+  Optional[String] $fastcgi_params                                               = "${::nginx::conf_dir}/fastcgi.conf",
   Optional[String] $fastcgi_script                                               = undef,
   Optional[String] $uwsgi                                                        = undef,
-  String $uwsgi_params                                                           = "${nginx::config::conf_dir}/uwsgi_params",
+  Optional[String] $uwsgi_params                                                 = "${nginx::config::conf_dir}/uwsgi_params",
   Optional[String] $uwsgi_read_timeout                                           = undef,
   Array $index_files                                                             = [
     'index.html',
@@ -380,15 +380,18 @@ define nginx::resource::server (
     $root = $www_root
   }
 
-  if $fastcgi != undef and !defined(File[$fastcgi_params]) {
+  # Only try to manage these files if they're the default one (as you presumably
+  # usually don't want the default template if you're using a custom file.
+
+  if $fastcgi != undef and !defined(File[$fastcgi_params]) and $fastcgi_params == "${::nginx::conf_dir}/fastcgi.conf" {
     file { $fastcgi_params:
       ensure  => present,
       mode    => '0644',
-      content => template('nginx/server/fastcgi_params.erb'),
+      content => template('nginx/server/fastcgi.conf.erb'),
     }
   }
 
-  if $uwsgi != undef and !defined(File[$uwsgi_params]) {
+  if $uwsgi != undef and !defined(File[$uwsgi_params]) and $uwsgi_params == "${::nginx::conf_dir}/uwsgi_params" {
     file { $uwsgi_params:
       ensure  => present,
       mode    => '0644',

--- a/templates/server/fastcgi.conf.erb
+++ b/templates/server/fastcgi.conf.erb
@@ -1,16 +1,18 @@
 # This file managed by puppet on host <%= @fqdn %>
 
+fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
 fastcgi_param  QUERY_STRING       $query_string;
 fastcgi_param  REQUEST_METHOD     $request_method;
 fastcgi_param  CONTENT_TYPE       $content_type;
 fastcgi_param  CONTENT_LENGTH     $content_length;
 
-fastcgi_param  SCRIPT_FILENAME    $request_filename;
 fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
 fastcgi_param  REQUEST_URI        $request_uri;
 fastcgi_param  DOCUMENT_URI       $document_uri;
 fastcgi_param  DOCUMENT_ROOT      $document_root;
 fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+fastcgi_param  REQUEST_SCHEME     $scheme;
+fastcgi_param  HTTPS              $https if_not_empty;
 
 fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
 fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
@@ -21,10 +23,5 @@ fastcgi_param  SERVER_ADDR        $server_addr;
 fastcgi_param  SERVER_PORT        $server_port;
 fastcgi_param  SERVER_NAME        $server_name;
 
-fastcgi_param  HTTPS              $https;
-
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param  REDIRECT_STATUS    200;
-
-# Mitigate httpoxy, see https://httpoxy.org/#fix-now
-fastcgi_param  HTTP_PROXY          "";

--- a/templates/server/locations/fastcgi.erb
+++ b/templates/server/locations/fastcgi.erb
@@ -2,7 +2,9 @@
 <% if defined? @www_root -%>
     root          <%= @www_root %>;
 <% end -%>
+<% if defined? @fastcgi_params -%>
     include       <%= @fastcgi_params %>;
+<% end -%>
 
     fastcgi_pass  <%= @fastcgi %>;
 <% if @fastcgi_index -%>

--- a/templates/server/uwsgi_params.erb
+++ b/templates/server/uwsgi_params.erb
@@ -1,15 +1,18 @@
 # This file managed by puppet on host <%= @fqdn %>
 
-uwsgi_param QUERY_STRING $query_string;
-uwsgi_param REQUEST_METHOD $request_method;
-uwsgi_param CONTENT_TYPE $content_type;
-uwsgi_param CONTENT_LENGTH $content_length;
-uwsgi_param REQUEST_URI $request_uri;
-uwsgi_param PATH_INFO $document_uri;
-uwsgi_param DOCUMENT_ROOT $document_root;
-uwsgi_param SERVER_PROTOCOL $server_protocol;
-uwsgi_param REMOTE_ADDR $remote_addr;
-uwsgi_param REMOTE_PORT $remote_port;
-uwsgi_param SERVER_ADDR $server_addr;
-uwsgi_param SERVER_PORT $server_port;
-uwsgi_param SERVER_NAME $server_name;
+uwsgi_param  QUERY_STRING       $query_string;
+uwsgi_param  REQUEST_METHOD     $request_method;
+uwsgi_param  CONTENT_TYPE       $content_type;
+uwsgi_param  CONTENT_LENGTH     $content_length;
+
+uwsgi_param  REQUEST_URI        $request_uri;
+uwsgi_param  PATH_INFO          $document_uri;
+uwsgi_param  DOCUMENT_ROOT      $document_root;
+uwsgi_param  SERVER_PROTOCOL    $server_protocol;
+uwsgi_param  REQUEST_SCHEME     $scheme;
+uwsgi_param  HTTPS              $https if_not_empty;
+
+uwsgi_param  REMOTE_ADDR        $remote_addr;
+uwsgi_param  REMOTE_PORT        $remote_port;
+uwsgi_param  SERVER_PORT        $server_port;
+uwsgi_param  SERVER_NAME        $server_name;


### PR DESCRIPTION
Per various discussions (#862), use nginx shipped defaults for fastcgi_params / uwsgi_params. 

Obsoletes #855, etc.

I think long-term, we still may need a way to make this more customizable, but I think we have signoff in principle on at least pulling in the current vendor defaults from 1.10 / 1.11.