### PR TITLE
set manage_repo for Oracle "RedHat" (and not 5.x for any flavor anymore, for consistency with rest of module)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,7 +49,7 @@ class nginx::params {
       }
     }
     'RedHat': {
-      if ($::operatingsystem in ['RedHat', 'CentOS'] and $::operatingsystemmajrelease in ['5', '6', '7']) {
+      if ($::operatingsystem in ['RedHat', 'CentOS', 'Oracle'] and $::operatingsystemmajrelease in ['6', '7']) {
         $_module_os_overrides = {
           'manage_repo' => true,
           'log_group'   => 'nginx',

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -109,19 +109,10 @@ describe 'nginx' do
         it { is_expected.not_to contain_yumrepo('nginx-release') }
       end
 
-      context 'operatingsystemmajrelease = 5' do
-        let(:facts) { { operatingsystem: operatingsystem, osfamily: 'RedHat', operatingsystemmajrelease: '5' } }
-        it { is_expected.to contain_package('nginx') }
-        it do
-          is_expected.to contain_yumrepo('nginx-release').with(
-            'baseurl' => "http://nginx.org/packages/#{operatingsystem == 'CentOS' ? 'centos' : 'rhel'}/5/$basearch/"
-          )
-        end
-      end
-
       context 'RedHat / CentOS 5 with package_source => passenger' do
         let(:facts) { { operatingsystem: operatingsystem, osfamily: 'RedHat', operatingsystemmajrelease: '5' } }
-        let(:params) { { package_source: 'passenger' } }
+
+        let(:params) { { package_source: 'passenger', manage_repo: true } }
         it 'we fail' do
           expect { catalogue }.to raise_error(Puppet::Error, %r{is unsupported with \$package_source})
         end


### PR DESCRIPTION
This resolves #988 and also drops setting `manage_repo` for v5, for consistency with the rest of the module.
This doesn't really change much, just toggles the `manage_repo` flag.