### PR TITLE
Bump puppetlabs-concat, puppetlabs-stdlib and Puppet minimum versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 <5.0.0"
+      "version_requirement": ">= 4.13.1 <5.0.0"
     },
     {
       "name": "puppetlabs/apt",
@@ -18,13 +18,13 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.5 <3.0.0"
+      "version_requirement": ">= 3.0.0 <4.0.0"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.1 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This bumps the dependency on puppetlabs-concat to v3.0.0 and raises the minimum versions of the following dependencies to match:
  * puppet:            4.6.1 -> 4.7.0
  * puppetlabs-stdlib: 4.6.0 -> 4.13.1
