### PR TITLE
Use correct scheme with rewrite_www_to_non_www

### DIFF
--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -30,7 +30,11 @@ server {
     <%- end -%>
   <%- end -%>
   server_name  www.<%= s.gsub(/^www\./, '') %>;
+  <%- if @ssl_redirect or @ssl_only -%>
+  return       301 https://<%= s.gsub(/^www\./, '') %><% if @_ssl_redirect_port.to_i != 443 %>:<%= @_ssl_redirect_port %><% end %>$request_uri;
+  <%- else -%>
   return       301 http://<%= s.gsub(/^www\./, '') %>$request_uri;
+  <%- end -%>
 }
 
 <% end -%>


### PR DESCRIPTION
If `ssl_redirect` is enabled along with `rewrite_www_to_non_www`, then the user is redirected from the www version, to the http non-www one, and finally to https.
