### PR TITLE
Ensure absent on concat resource for server resource with ensure => absent (#1103)

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -302,6 +302,7 @@ define nginx::resource::server (
   }
 
   concat { $config_file:
+    ensure  => $ensure,
     owner   => $owner,
     group   => $group,
     mode    => $mode,

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -1117,6 +1117,7 @@ describe 'nginx::resource::server' do
 
             it { is_expected.to contain_nginx__resource__location("#{title}-default").with_ensure('absent') }
             it { is_expected.to contain_file("#{title}.conf symlink").with_ensure('absent') }
+            it { is_expected.to contain_concat("/etc/nginx/sites-available/#{title}.conf").with_ensure('absent') }
           end
 
           context 'when ssl => true and ssl_port == listen_port' do


### PR DESCRIPTION
While this doesn't seem like a super big deal (#1103), I agree with the proposed fix, and it's pretty easy to implement and to test for.