### PR TITLE
add new redirect_non_www_to_www option (#1092)

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -69,8 +69,8 @@
 #   [*http2*]                      - Toggles HTTP/2 protocol.
 #   [*server_name*]                - List of servernames for which this server will respond. Default [$name].
 #   [*www_root*]                   - Specifies the location on disk for files to be read from. Cannot be set in conjunction with $proxy
-#   [*rewrite_www_to_non_www*]     - Adds a server directive and rewrite rule to rewrite www.domain.com to domain.com in order to avoid
-#     duplicate content (SEO);
+#   [*rewrite_www_to_non_www*]     - Adds a server directive and rewrite rule to rewrite www.example.com to example.com
+#   [*rewrite_non_www_to_www*]     - Adds a server directive and rewrite rule to rewrite example.com to www.example.com.
 #   [*try_files*]                  - Specifies the locations for files to be checked as an array. Cannot be used in conjuction with $proxy.
 #   [*proxy_cache*]                - This directive sets name of zone for caching. The same zone can be used in multiple places.
 #   [*proxy_cache_key*]            - Override the default proxy_cache_key of $scheme$proxy_host$request_uri
@@ -208,6 +208,7 @@ define nginx::resource::server (
   Array[String] $server_name                                                     = [$name],
   Optional[String] $www_root                                                     = undef,
   Boolean $rewrite_www_to_non_www                                                = false,
+  Boolean $rewrite_non_www_to_www                                                = false,
   Optional[Hash] $location_custom_cfg                                            = undef,
   Optional[Hash] $location_cfg_prepend                                           = undef,
   Optional[Hash] $location_cfg_append                                            = undef,
@@ -287,6 +288,11 @@ define nginx::resource::server (
   # and support does not exist for it in the kernel.
   if $ipv6_enable and !$ipv6_listen_ip {
     warning('nginx: IPv6 support is not enabled or configured properly')
+  }
+
+  # Mutually exclusive for obvious reasons.
+  if $rewrite_www_to_non_www and $rewrite_non_www_to_www {
+    fail('rewrite_www_to_non_www and rewrite_non_www_to_www are mutually exclusive')
   }
 
   # Check to see if SSL Certificates are properly defined.

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -1,5 +1,5 @@
 # MANAGED BY PUPPET
-<% if @rewrite_www_to_non_www -%>
+<% if @rewrite_www_to_non_www or @rewrite_non_www_to_www -%>
 <%- @server_name.each do |s| -%>
 server {
   <%- if @listen_ip.is_a?(Array) then -%>
@@ -19,11 +19,20 @@ server {
     <%- end -%>
   <%- end -%>
 <%= scope.function_template(["nginx/server/server_ipv6_listen.erb"]) %>
+  <%- if @rewrite_www_to_non_www  -%>
   server_name  www.<%= s.gsub(/^www\./, '') %>;
-  <%- if @ssl_redirect or @ssl_only -%>
+    <%- if @ssl_redirect or @ssl_only -%>
   return       301 https://<%= s.gsub(/^www\./, '') %><% if @_ssl_redirect_port.to_i != 443 %>:<%= @_ssl_redirect_port %><% end %>$request_uri;
-  <%- else -%>
+    <%- else -%>
   return       301 http://<%= s.gsub(/^www\./, '') %>$request_uri;
+    <%- end -%>
+  <%- elsif @rewrite_non_www_to_www  -%>
+  server_name  <%= s.gsub(/(www\.)*/, '') %>;
+    <%- if @ssl_redirect or @ssl_only -%>
+  return       301 https://<%= s.gsub(/^(?!www\.)/, 'www.') %><% if @_ssl_redirect_port.to_i != 443 %>:<%= @_ssl_redirect_port %><% end %>$request_uri;
+    <%- else -%>
+  return       301 http://<%= s.gsub(/^(?!www\.)/, 'www.') %>$request_uri;
+    <%- end -%>
   <%- end -%>
 }
 
@@ -48,6 +57,13 @@ server {
 <%- end -%>
 <%= scope.function_template(["nginx/server/server_ipv6_listen.erb"]) %>
   server_name           <%= @rewrite_www_to_non_www ? @server_name.join("  ").gsub(/(^| )(www\.)?(?=[a-z0-9])/, '') : @server_name.join(" ") %>;
+  <%- if @rewrite_www_to_non_www -%>
+  server_name           <%= @server_name.join("  ").gsub(/(^| )(www\.)?(?=[a-z0-9])/, '') %>;
+  <%- elsif @rewrite_non_www_to_www -%>
+  server_name           <%= @server_name.join("  ").gsub(/(^| )(?!www\.)+(?=[a-z0-9])/, '\1www.') %>;
+  <%- else -%>
+  server_name           <%= @server_name.join(" ") %>;
+  <%- end -%>
 <%- if instance_variables.any? { |iv| iv.to_s.include? 'auth_basic' } -%>
   <%- if defined? @auth_basic -%>
   auth_basic           "<%= @auth_basic %>";

--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -1,5 +1,5 @@
 # MANAGED BY PUPPET
-<% if @rewrite_www_to_non_www -%>
+<% if @rewrite_www_to_non_www or @rewrite_non_www_to_www -%>
 <%- @server_name.each do |s| -%>
 server {
   <%- if @listen_ip.is_a?(Array) then -%>
@@ -10,8 +10,13 @@ server {
   listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
   <%- end -%>
 <%= scope.function_template(["nginx/server/server_ssl_ipv6_listen.erb"]) %>
+  <% if @rewrite_www_to_non_www -%>
   server_name  www.<%= s.gsub(/^www\./, '') %>;
   return       301 https://<%= s.gsub(/^www\./, '') %>$request_uri;
+  <% elsif @rewrite_non_www_to_www -%>
+  server_name  <%= s.gsub(/^(?!www\.)/, 'www.') %>;
+  return       301 https://<%= s.gsub(/^(?!www\.)/, 'www.') %>$request_uri;
+  <%- end -%>
 
 <%= scope.function_template(["nginx/server/server_ssl_settings.erb"]) %>
 
@@ -29,6 +34,13 @@ server {
   <%- end -%>
 <%= scope.function_template(["nginx/server/server_ssl_ipv6_listen.erb"]) %>
   server_name  <%= @rewrite_www_to_non_www ? @server_name.join("  ").gsub(/(^| )(www\.)?(?=[a-z0-9])/, '') : @server_name.join(" ") %>;
+  <%- if @rewrite_www_to_non_www -%>
+  server_name           <%= @server_name.join("  ").gsub(/(^| )(www\.)?(?=[a-z0-9])/, '') %>;
+  <%- elsif @rewrite_non_www_to_www -%>
+  server_name           <%= @server_name.join("  ").gsub(/(^| )(?!www\.)+(?=[a-z0-9])/, '\1www.') %>;
+  <%- else -%>
+  server_name           <%= @server_name.join(" ") %>;
+  <%- end -%>
 
 <%= scope.function_template(["nginx/server/server_ssl_settings.erb"]) %>
 <% if @maintenance -%>


### PR DESCRIPTION
This was harder than I thought, mostly because of the way the existing feature was implemented. Welcome reviews, or suggestions on how to make this logic cleaner and more bulletproof.

I think this should work for the typical / simple use cases, but have not tested well. I don't really know what the behavior should be if someone put in a hostname like `www.www.example.com`.

Welcome feedback too on whether the existing tests are sufficient (and whether there are redundant tests), and specifically, whether I need to replicate https://github.com/wyardley/puppet-nginx/blob/issues_1092/spec/defines/resource_server_spec.rb#L965-L972 for SSL as well (the normal test for the other case doesn't really work well because the default hostname has www. in it). 