### PR TITLE
bump concat to <5.0.0 instead of <4.0.0 (#1107)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 3.0.0 <4.0.0"
+      "version_requirement": ">= 3.0.0 <5.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
I think this should resolve #1107, as I'm guessing the module will still work w/ v 5.0.0, but let's see how the tests look.