### PR TITLE
Fix dependency on apt-transport-https

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -31,7 +31,8 @@ class nginx::package::debian {
 
   if $manage_repo {
     include '::apt'
-    Exec['apt_update'] -> Package['nginx']
+    ensure_packages([ 'apt-transport-https', 'ca-certificates' ])
+    Package['apt-transport-https','ca-certificates'] -> Exec['apt_update'] -> Package['nginx']
 
     case $package_source {
       'nginx', 'nginx-stable': {
@@ -54,8 +55,6 @@ class nginx::package::debian {
           repos    => 'main',
           key      => {'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7'},
         }
-
-        ensure_packages([ 'apt-transport-https', 'ca-certificates' ])
 
         Package['apt-transport-https','ca-certificates'] -> Apt::Source['nginx']
 


### PR DESCRIPTION
Without this change, the nginx https repository url is added to sources.list.d
and apt-get update is executed immediately after, failing because
apt-transport-https is not yet installed. Subsequently all package
installs fail because the apt cache has been invalidated.

With this change we ensure the apt-transport-https package is present
before running apt-get update. Since all sources are now https, the
package is always necessary, which is why I moved it out of the 'case'
statement.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
