### PR TITLE
Fix location ssl and ssl_only checks to match README.md

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -275,7 +275,7 @@ define nginx::resource::location (
   if $ensure == present {
     ## Create stubs for server File Fragment Pattern
     $location_md5 = md5($location)
-    if ($ssl_only != true) {
+    if ($ssl != true or $ssl_only != true) {
       concat::fragment { "${server_sanitized}-${priority}-${location_md5}":
         target  => $config_file,
         content => template('nginx/server/location.erb'),
@@ -284,7 +284,7 @@ define nginx::resource::location (
     }
 
     ## Only create SSL Specific locations if $ssl is true.
-    if ($ssl == true or $ssl_only == true) {
+    if ($ssl == true) {
       $ssl_priority = $priority + 300
 
       concat::fragment { "${server_sanitized}-${ssl_priority}-${location_md5}-ssl":

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -917,28 +917,32 @@ describe 'nginx::resource::location' do
             it { is_expected.not_to contain_file('/etc/nginx/uwsgi_params') }
           end
 
-          context 'when ssl_only => true' do
+          # defaults are ssl => false, ssl_only => false
+          context 'when ssl => false and ssl_only => true' do
             let(:params) { { ssl_only: true, server: 'server1', www_root: '/' } }
 
-            it { is_expected.not_to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('rspec-test')) }
+            it { is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('rspec-test')) }
+            it { is_expected.not_to contain_concat__fragment('server1-800-' + Digest::MD5.hexdigest('rspec-test') + '-ssl') }
           end
 
-          context 'when ssl_only => false' do
-            let(:params) { { ssl_only: false, server: 'server1', www_root: '/' } }
+          context 'when ssl => false and ssl_only => false' do
+            let(:params) { { server: 'server1', www_root: '/' } }
 
             it { is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('rspec-test')) }
+            it { is_expected.not_to contain_concat__fragment('server1-800-' + Digest::MD5.hexdigest('rspec-test') + '-ssl') }
           end
 
-          context 'when ssl => true' do
+          context 'when ssl => true and ssl_only => false' do
             let(:params) { { ssl: true, server: 'server1', www_root: '/' } }
 
+            it { is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('rspec-test')) }
             it { is_expected.to contain_concat__fragment('server1-800-' + Digest::MD5.hexdigest('rspec-test') + '-ssl') }
           end
 
-          context 'when ssl => false' do
-            let(:params) { { ssl: false, server: 'server1', www_root: '/' } }
-
-            it { is_expected.not_to contain_concat__fragment('server1-800-' + Digest::MD5.hexdigest('rspec-test') + '-ssl') }
+          context 'when ssl => true and ssl_only => true' do
+            let(:params) { { ssl: true, ssl_only: true, server: 'server1', www_root: '/' } }
+            it { is_expected.not_to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('rspec-test')) }
+            it { is_expected.to contain_concat__fragment('server1-800-' + Digest::MD5.hexdigest('rspec-test') + '-ssl') }
           end
 
           context 'www_root and proxy are set' do

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -941,6 +941,7 @@ describe 'nginx::resource::location' do
 
           context 'when ssl => true and ssl_only => true' do
             let(:params) { { ssl: true, ssl_only: true, server: 'server1', www_root: '/' } }
+
             it { is_expected.not_to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('rspec-test')) }
             it { is_expected.to contain_concat__fragment('server1-800-' + Digest::MD5.hexdigest('rspec-test') + '-ssl') }
           end


### PR DESCRIPTION
This Addresses issue #1120.

The documentation states that if you set  $ssl to false it will only add to http server.

If $ssl is true it will then add to https and http if ssl_only is false.

This is causing a little confusion on how to set the values.