### PR TITLE
Fix indent auth_basic_user_file ssl server

### DIFF
--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -60,7 +60,7 @@ server {
   <% if defined? @auth_basic -%>
   auth_basic                "<%= @auth_basic %>";
   <% end -%>
-  <% if defined? @auth_basic_user_file -%>
+  <%- if defined? @auth_basic_user_file -%>
   auth_basic_user_file      "<%= @auth_basic_user_file %>";
   <% end -%>
 <%- end -%>


### PR DESCRIPTION
Hi,

Juste fix a bad indent:

```DIFF
--- /etc/nginx/sites-available/myvhost.conf	2017-09-07 15:15:15.643976037 +0200
+++ /tmp/puppet-file20170907-746-127bflk	2017-09-07 15:15:36.412100955 +0200
@@ -26,7 +26,7 @@
   ssl_prefer_server_ciphers on;
 
     auth_basic                "Vhost authentification";
-      auth_basic_user_file      "/etc/nginx/.vhost-htpasswd";
+    auth_basic_user_file      "/etc/nginx/.vhost-htpasswd";
     index  index.html index.htm index.php;
```
