### PR TITLE
add settable nginx daemon group

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -23,6 +23,7 @@ class nginx::config {
   $conf_dir                       = $::nginx::conf_dir
   $daemon                         = $::nginx::daemon
   $daemon_user                    = $::nginx::daemon_user
+  $daemon_group                   = $::nginx::daemon_group
   $global_owner                   = $::nginx::global_owner
   $global_group                   = $::nginx::global_group
   $global_mode                    = $::nginx::global_mode

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class nginx (
   $conf_dir                                                  = $::nginx::params::conf_dir,
   Optional[Enum['on', 'off']] $daemon                        = undef,
   $daemon_user                                               = $::nginx::params::daemon_user,
+  $daemon_group                                              = undef,
   $global_owner                                              = $::nginx::params::global_owner,
   $global_group                                              = $::nginx::params::global_group,
   $global_mode                                               = $::nginx::params::global_mode,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -344,6 +344,12 @@ describe 'nginx' do
                 notmatch: %r{user}
               },
               {
+                title: 'should not set group',
+                attr: 'daemon_group',
+                value: :undef,
+                notmatch: %r{^user \S+ \S+;}
+              },
+              {
                 title: 'should set user',
                 attr: 'daemon_user',
                 value: 'test-user',
@@ -1072,6 +1078,12 @@ describe 'nginx' do
             it { is_expected.to contain_file('/var/nginx/client_body_temp').with(owner: 'www-data') }
             it { is_expected.to contain_file('/var/nginx/proxy_temp').with(owner: 'www-data') }
             it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content %r{^user www-data;} }
+          end
+
+          context 'when daemon_group = test-group' do
+            let(:params) { { daemon_group: 'test-group' } }
+
+            it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content %r{^user .* test-group;} }
           end
 
           context 'when log_dir is non-default' do

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -3,7 +3,7 @@
 daemon <%= @daemon %>;
 <% end -%>
 <% if @super_user -%>
-user <%= @daemon_user %>;
+user <%= @daemon_user %><% if @daemon_group -%> <%= @daemon_group %><% end -%>;
 <% end -%>
 worker_processes <%= @worker_processes %>;
 <% if @worker_rlimit_nofile -%>


### PR DESCRIPTION
Hello,
in a problem I was trying to solve with your module today, I needed to specify both `user` and `group` name for the nginx.conf `name` descriptor, as these were not the same. Simply setting the `daemon_user` param to `$user $group` doesn't work, because it is used below in config.pp as an owner for multiple directories:

```
file { $log_dir:
  ensure => directory,
  mode   => $log_mode,
  owner  => $daemon_user,
  group  => $log_group,
}
```

Therefore I believe I had to add this parameter, which fixes this issue nicely.