### PR TITLE
refactoring ssl_redirect block in template for a more flexible location-…

### DIFF
--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -31,7 +31,9 @@ server {
   <%- end -%>
   server_name  www.<%= s.gsub(/^www\./, '') %>;
   <%- if @ssl_redirect or @ssl_only -%>
-  return       301 https://<%= s.gsub(/^www\./, '') %><% if @_ssl_redirect_port.to_i != 443 %>:<%= @_ssl_redirect_port %><% end %>$request_uri;
+  location / {
+    return       301 https://<%= s.gsub(/^www\./, '') %><% if @_ssl_redirect_port.to_i != 443 %>:<%= @_ssl_redirect_port %><% end %>$request_uri;
+  }
   <%- else -%>
   return       301 http://<%= s.gsub(/^www\./, '') %>$request_uri;
   <%- end -%>
@@ -143,7 +145,9 @@ server {
   <%= @maintenance_value %>;
 <% end -%>
 <% if @ssl_redirect -%>
-  return 301 https://$host<% if @_ssl_redirect_port.to_i != 443 %>:<%= @_ssl_redirect_port %><% end %>$request_uri;
+  location / { 
+    return 301 https://$host<% if @_ssl_redirect_port.to_i != 443 %>:<%= @_ssl_redirect_port %><% end %>$request_uri;
+  }
 <% end -%>
 <% if @index_files and @index_files.count > 0 and not @ssl_only -%>
   index <% Array(@index_files).each do |i| %> <%= i %><% end %>;


### PR DESCRIPTION
…/ redirect

A redirect in this format is necessary to support sites who would like to use the 'webroot' functionality of LetsEncrypt (a common program/organization who provides signed SSL certificates for free).  

  (Exceedingly) long story short, the LE-webroot plugin makes an http (not https) request to the server, and expects a token to be in a specific directory.  Any attempts to blindly rewrite the http request to https, regardless of the current state of the server's cert, will fail.  Folks who expect LE certs to auto-renew via this method tend to get a little... excitable when they don't.  This refactor makes the :80 listener perform its redirect against a specific location (location /), instead of a global non-location-specific redirect.  From there, we can add a location-block for the Lets Encrypt directory that does NOT get picked up by a global redirect, for appropriate processing on the LE side.  

  For example, this will fail (LE-request gets a 301 redirect to https; tested on nginx 1.10.3 on Ubuntu 16.04.3 LTS, nginx 1.13.5-1 on Debian Testing/Buster): 
```
# nginx server definition in /etc/nginx/sites-enabled/example.com.conf
server {
  listen *:80 default_server;
  server_name           example.com;

  return 301 https://$host$request_uri;

  location /.well-known {
    root      /var/www/letsencrypt/;
    try_files $uri $uri/ =404;
  }
  
}
```

  This will succeed (LE-request succeeds over HTTP, everything else gets the 301 redirect to HTTPS)
```
# nginx server definition in /etc/nginx/sites-enabled/example.com.conf
server {
  listen *:80 default_server;
  server_name           example.com;

  location / {
    return 301 https://$host$request_uri;
  }

  location /.well-known {
    root      /var/www/letsencrypt/;
    try_files $uri $uri/ =404;
  }
}
```

  Supporting Puppet role definition: 
```
class role::webserver (
  $nginx_vhosts,
  $nginx_location,
) {
  class { 'nginx': }
    create_resources('nginx::resource::server', $nginx_vhosts)
    create_resources('nginx::resource::location', $nginx_location)
} 
```
  Supporting Hieradata: 
```
---
role::webserver::nginx_vhosts:
  "example-vhost":
    www_root: '/var/www'
    server_name: [ "example.com" ]
    access_log: '/var/log/nginx/example-access.log'
    error_log: '/var/log/nginx/example-error.log'
    ssl_redirect: true
    ssl: true
    ssl_cert: "/etc/letsencrypt/live/example.com/fullchain.pem"
    ssl_key: "/etc/letsencrypt/live/example.com/privkey.pem"

role::webserver::nginx_location:
  'letsencrypt-well-known':
    location: '/.well-known'
    www_root: '/var/www/letsencrypt'
    try_files: ['$uri $uri/ =404']
    ssl_only: false
    server: "example-vhost"
```