### PR TITLE
Confine NGINX version fact to exclude Cisco Nexus switches

### DIFF
--- a/lib/facter/nginx_version.rb
+++ b/lib/facter/nginx_version.rb
@@ -1,6 +1,8 @@
 Facter.add(:nginx_version) do
+  confine { Facter.value(:kernel) != 'windows' }
+  confine { Facter.value(:operatingsystem) != 'nexus' }
   setcode do
-    if Facter.value('kernel') != 'windows' && (Facter::Util::Resolution.which('nginx') || Facter::Util::Resolution.which('openresty'))
+    if Facter::Util::Resolution.which('nginx') || Facter::Util::Resolution.which('openresty')
       nginx_version_command = Facter::Util::Resolution.which('nginx') ? 'nginx -v 2>&1' : 'openresty -v 2>&1'
       nginx_version = Facter::Util::Resolution.exec(nginx_version_command)
       %r{nginx version: (nginx|openresty)\/([\w\.]+)}.match(nginx_version)[2]


### PR DESCRIPTION
Cisco Nexus Switches may run older version of NGINX internally in which the command 'nginx -v' disables the nxapi socket (deletes sock file) on second or later runs.  Tested on CIsco NXOS 9k physical and virtual, and confirmed with Cisco engineers. 

Nginx is an underlying component, and should not be managed by resources other than the Cisco module(s) for the Nexus devices, hence prevention of this fact running on the Nexus operating system.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
