### PR TITLE
Update upstream.pp

### DIFF
--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -6,7 +6,7 @@
 #   [*members*]               - Array of member URIs for NGINX to connect to. Must follow valid NGINX syntax.
 #                               If omitted, individual members should be defined with nginx::resource::upstream::member
 #   [*ensure*]                - Enables or disables the specified location (present|absent)
-#   [*upstream_cfg_append*]   - Hash of custom directives to put after other directives in upstream
+#   [*upstream_cfg_append*]   - Hash or value of custom directives to put after other directives in upstream
 #   [*upstream_cfg_prepend*]  - It expects a hash with custom directives to put before anything else inside upstream
 #   [*upstream_fail_timeout*] - Set the fail_timeout for the upstream. Default is 10 seconds - As that is what Nginx does normally.
 #   [*upstream_max_fails*]    - Set the max_fails for the upstream. Default is to use nginx default value which is 1.


### PR DESCRIPTION
Per the ERB template, the value is inserted even if it's not a hash.
```
  <%- @upstream_cfg_prepend.each do |key,value| -%>
    <%- if value.is_a?(Hash) -%>
      <%- value.each do |subkey,subvalue| -%>
        <%- Array(subvalue).each do |asubvalue| -%>
  <%= key %> <%= subkey %> <%= asubvalue %>;
        <%- end -%>
      <%- end -%>
    <%- else -%>
      <%- Array(value).each do |asubvalue| -%>
  <%= key %> <%= asubvalue %>;
      <%- end -%>
```