### PR TITLE
Doc-only: Fix proxy/blog location reference

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -82,7 +82,7 @@ Combining our configurations above into a single manifest, our code block looks 
     www_root => '/opt/html/',
   }
 
-  nginx::resource::location{'/proxy':
+  nginx::resource::location{'/blog':
     proxy => 'http://upstream_app/' ,
     server => 'www.myhost.com',
 


### PR DESCRIPTION
Just a very small correction for consistency within the doc.