### PR TITLE
Enhance distro support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,6 +143,7 @@ class nginx (
   $package_source                                            = 'nginx',
   $package_flavor                                            = undef,
   $manage_repo                                               = $::nginx::params::manage_repo,
+  $repo_release                                              = undef,
   $passenger_package_ensure                                  = 'present',
   ### END Package Configuration ###
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,7 +143,7 @@ class nginx (
   $package_source                                            = 'nginx',
   $package_flavor                                            = undef,
   $manage_repo                                               = $::nginx::params::manage_repo,
-  $repo_release                                              = undef,
+  Optional[String] $repo_release                             = undef,
   $passenger_package_ensure                                  = 'present',
   ### END Package Configuration ###
 

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -21,6 +21,7 @@ class nginx::package::debian {
   $package_flavor           = $::nginx::package_flavor
   $passenger_package_ensure = $::nginx::passenger_package_ensure
   $manage_repo              = $::nginx::manage_repo
+  $release                  = $::nginx::repo_release
 
   $distro = downcase($::operatingsystem)
 
@@ -40,6 +41,7 @@ class nginx::package::debian {
           location => "https://nginx.org/packages/${distro}",
           repos    => 'nginx',
           key      => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'},
+          release  => pick($release, $::lsbdistcodename),
         }
       }
       'nginx-mainline': {
@@ -47,6 +49,7 @@ class nginx::package::debian {
           location => "https://nginx.org/packages/mainline/${distro}",
           repos    => 'nginx',
           key      => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'},
+          release  => pick($release, $::lsbdistcodename),
         }
       }
       'passenger': {

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -41,7 +41,7 @@ class nginx::package::debian {
           location => "https://nginx.org/packages/${distro}",
           repos    => 'nginx',
           key      => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'},
-          release  => pick($release, $::lsbdistcodename),
+          release  => $release,
         }
       }
       'nginx-mainline': {
@@ -49,7 +49,7 @@ class nginx::package::debian {
           location => "https://nginx.org/packages/mainline/${distro}",
           repos    => 'nginx',
           key      => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'},
-          release  => pick($release, $::lsbdistcodename),
+          release  => $release,
         }
       }
       'passenger': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,7 +27,7 @@ class nginx::params {
     }
     'Debian': {
       if ($::operatingsystem == 'ubuntu' and $::lsbdistcodename in ['lucid', 'precise', 'trusty', 'xenial'])
-      or ($::operatingsystem == 'debian' and $::operatingsystemmajrelease in ['6', '7', '8']) {
+      or ($::operatingsystem == 'debian' and $::operatingsystemmajrelease in ['6', '7', '8', '9']) {
         $_module_os_overrides = {
           'manage_repo' => true,
           'daemon_user' => 'www-data',


### PR DESCRIPTION
Add explicit Debian 9 (stretch) support, and add support for Ubilinux.

Ubilinux 4 (that supports all variants of the Up boards) is a derivative of Debian 9. However it reports dolcetto as the lsbdistcodename instead of stretch so the nginx repo fails. This PR adds support for a $nginx::repo_release parameter that allows the distro code name to be specified rather than blindly taking it from lsbdistcodename.

```
    class { 'nginx':
        manage_repo     => true,
        repo_release    => "stretch",
    }
```

See:
https://github.com/voxpupuli/puppet-nodejs/pull/342