### PR TITLE
Use $service_name for service resource title.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,7 +150,7 @@ class nginx (
   $service_ensure                                            = running,
   $service_flags                                             = undef,
   $service_restart                                           = undef,
-  $service_name                                              = "nginx",
+  $service_name                                              = 'nginx',
   $service_manage                                            = true,
   ### END Service Configuration ###
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,7 +150,7 @@ class nginx (
   $service_ensure                                            = running,
   $service_flags                                             = undef,
   $service_restart                                           = undef,
-  $service_name                                              = undef,
+  $service_name                                              = "nginx",
   $service_manage                                            = true,
   ### END Service Configuration ###
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -40,7 +40,7 @@ class nginx::service(
   if $service_manage {
     case $::osfamily {
       'OpenBSD': {
-        service { 'nginx':
+        service { 'puppet_nginx':
           ensure     => $service_ensure_real,
           name       => $service_name,
           enable     => $service_enable,
@@ -50,7 +50,7 @@ class nginx::service(
         }
       }
       default: {
-        service { 'nginx':
+        service { 'puppet_nginx':
           ensure     => $service_ensure_real,
           name       => $service_name,
           enable     => $service_enable,
@@ -63,7 +63,7 @@ class nginx::service(
 
   # Allow overriding of 'restart' of Service resource; not used by default
   if $service_restart {
-    Service['nginx'] {
+    Service['puppet_nginx'] {
       restart => $service_restart,
     }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -40,9 +40,8 @@ class nginx::service(
   if $service_manage {
     case $::osfamily {
       'OpenBSD': {
-        service { 'puppet_nginx':
+        service { $service_name:
           ensure     => $service_ensure_real,
-          name       => $service_name,
           enable     => $service_enable,
           flags      => $service_flags,
           hasstatus  => true,
@@ -50,7 +49,7 @@ class nginx::service(
         }
       }
       default: {
-        service { 'puppet_nginx':
+        service { $service_name:
           ensure     => $service_ensure_real,
           name       => $service_name,
           enable     => $service_enable,
@@ -63,7 +62,7 @@ class nginx::service(
 
   # Allow overriding of 'restart' of Service resource; not used by default
   if $service_restart {
-    Service['puppet_nginx'] {
+    Service[$service_name] {
       restart => $service_restart,
     }
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -51,7 +51,6 @@ class nginx::service(
       default: {
         service { $service_name:
           ensure     => $service_ensure_real,
-          name       => $service_name,
           enable     => $service_enable,
           hasstatus  => true,
           hasrestart => true,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -211,7 +211,7 @@ describe 'nginx' do
             }
           end
 
-          it { is_expected.to contain_service('nginx').with_name('nginx14') }
+          it { is_expected.to contain_service('nginx14') }
         end
 
         describe 'when service_manage => false' do


### PR DESCRIPTION
This allows to specify a custom service name such as 'custom-nginx', while also separately controlling the system nginx service outside of puppet-nginx module.

Closes #1158 