### PR TITLE
Add add_header parameter to location

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -103,6 +103,7 @@
 #   [*flv*]             - Indicates whether or not this loation can be
 #     used for flv streaming. Default: false
 #   [*expires*]         - Setup expires time for locations content
+#   [*add_header*]      - Hash: Adds headers to the location block.  If any are specified, locations will no longer inherit headers from the parent server context
 #
 #
 # Actions:
@@ -216,6 +217,7 @@ define nginx::resource::location (
   Boolean $mp4                                         = false,
   Boolean $flv                                         = false,
   Optional[String] $expires                            = undef,
+  Hash $add_header                                     = {},
 ) {
 
   if ! defined(Class['nginx']) {

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -370,6 +370,43 @@ describe 'nginx::resource::location' do
           end
         end
 
+        describe 'server_location_add_header template content' do
+          let :default_params do
+            {
+              location: 'location',
+              server: 'server1'
+            }
+          end
+
+          context 'location_add_header template with default params' do
+            let(:params) { default_params }
+
+            it { is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('location')) }
+            it 'doesn\'t add any add_header lines' do
+              is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('location')).
+                without_content(%r{add_header})
+            end
+          end
+
+          context 'location_add_header template with add_header parameter containing hash of two headers' do
+            let(:params) do
+              default_params.merge(
+                'add_header' => {
+                  'X-Frame-Options' => 'SAMEORIGIN',
+                  'X-Powered-By'    => 'Puppet'
+                }
+              )
+            end
+
+            it 'contains both add_header lines' do
+              is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('location')).
+                with_content(%r{^\s+add_header\s+"X-Frame-Options"\s+"SAMEORIGIN";$})
+              is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('location')).
+                with_content(%r{^\s+add_header\s+"X-Powered-By"\s+"Puppet";$})
+            end
+          end
+        end
+
         describe 'server_location_directory template content' do
           let :default_params do
             {

--- a/templates/server/location.erb
+++ b/templates/server/location.erb
@@ -1,5 +1,6 @@
 <%= scope.function_template(['nginx/server/location_header.erb']) -%>
 <%= scope.function_template(['nginx/server/locations/alias.erb']) -%>
+<%= scope.function_template(['nginx/server/locations/headers.erb']) -%>
 <%= scope.function_template(['nginx/server/locations/stub_status.erb']) -%>
 <% if @fastcgi or @uwsgi or @proxy -%>
 <%= scope.function_template(['nginx/server/locations/proxy.erb']) -%>

--- a/templates/server/locations/headers.erb
+++ b/templates/server/locations/headers.erb
@@ -1,0 +1,3 @@
+<%- @add_header.keys.sort.each do |key| -%>
+    add_header "<%= key %>" "<%= @add_header[key] %>";
+<%- end -%>


### PR DESCRIPTION
As well as in a server context, add_header is also valid in a location.
See
http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
