### PR TITLE
Compatibility with puppetlabs-apt 4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This module manages NGINX configuration.
 ### Requirements
 
 * Puppet 4.6.1 or later.  Puppet 3 was supported up until release 0.6.0.
-* apt is now a soft dependency. If your system uses apt, you'll need to configure an appropriate version of the apt module.
+* apt is now a soft dependency. If your system uses apt, you'll need to configure an appropriate version of the apt module. Version 4.4.0 or higher is recommended because of the proper handling of `apt-transport-https`.
 
 ### Additional Documentation
 

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -31,8 +31,7 @@ class nginx::package::debian {
 
   if $manage_repo {
     include '::apt'
-    ensure_packages([ 'apt-transport-https', 'ca-certificates' ])
-    Package['apt-transport-https','ca-certificates'] -> Exec['apt_update'] -> Package['nginx']
+    Exec['apt_update'] -> Package['nginx']
 
     case $package_source {
       'nginx', 'nginx-stable': {
@@ -55,8 +54,6 @@ class nginx::package::debian {
           repos    => 'main',
           key      => {'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7'},
         }
-
-        Package['apt-transport-https','ca-certificates'] -> Apt::Source['nginx']
 
         package { 'passenger':
           ensure  => $passenger_package_ensure,


### PR DESCRIPTION
It's better to have this handled in puppetlabs-apt since this will also work for Debian 10 which has removed the apt-transport-https package.