### PR TITLE
Fix syntax error in ERB template for fastcgi location.

### DIFF
--- a/templates/server/locations/fastcgi.erb
+++ b/templates/server/locations/fastcgi.erb
@@ -14,7 +14,7 @@
     fastcgi_split_path_info <%= @fastcgi_split_path %>;
 <% end -%>
 <% if defined? @fastcgi_script -%>
-    <%-# this setting can be overridden by setting it in the fastcgi_param hash too %>
+    <%# this setting can be overridden by setting it in the fastcgi_param hash too %>
     <%- @fastcgi_param = { 'SCRIPT_FILENAME' => @fastcgi_script }.merge(@fastcgi_param || {}) -%>
 <% end -%>
 <% if defined? @fastcgi_param -%>


### PR DESCRIPTION
Fix syntax error in ERB template for fastcgi location.

This commit fixes a syntax error in the generated ruby script of this erb file.
Using ruby version `2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux]` and erb version `erb.rb [2.1.0 2017-12-22]`, the erb template was being converted into the following ruby code:
```
 if defined? @fastcgi_script 
# this setting can be overridden by setting it in the fastcgi_param hash too ; _erbout.<<(-"\n"
);  @fastcgi_param = { 'SCRIPT_FILENAME' => @fastcgi_script }.merge(@fastcgi_param || {}) 
 end 
```
which resulted in the following error when doing a syntax check with `ruby -c`:
```
-:19: syntax error, unexpected ')'
);  @fastcgi_param = { 'SCRIPT...
^
```

With this commit applied, the converted ruby code will look like this:
```
 if defined? @fastcgi_script
_erbout.<<(-"    "); _erbout.<<(-"\n"
);  @fastcgi_param = { 'SCRIPT_FILENAME' => @fastcgi_script }.merge(@fastcgi_param || {})
 end
```
which is now correct ruby code.
