### PR TITLE
Add more per-location proxy options: proxy_send_timeout, proxy_ignore…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,6 +122,7 @@ class nginx (
   ],
   Array $proxy_hide_header                                   = [],
   Array $proxy_pass_header                                   = [],
+  Array $proxy_ignore_header                                 = [],
   $sendfile                                                  = 'on',
   String $server_tokens                                      = 'on',
   $spdy                                                      = 'off',

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -30,9 +30,13 @@
 #     value of 90 seconds
 #   [*proxy_connect_timeout*] - Override the default the proxy connect timeout
 #     value of 90 seconds
+#   [*proxy_send_timeout*]   - Override the default the proxy send timeout
+#     value of 90 seconds
 #   [*proxy_set_header*]     - Array of server headers to set
 #   [*proxy_hide_header*]    - Array of server headers to hide
 #   [*proxy_pass_header*]    - Array of server headers to pass
+#   [*proxy_ignore_header*]  - Array of server headers to ignore
+#   [*proxy_next_upstream*]  - Specify cases a request should be passed to the next server in the upstream.
 #   [*fastcgi*]              - location of fastcgi (host:port)
 #   [*fastcgi_param*]        - Set additional custom fastcgi_params
 #   [*fastcgi_params*]       - optional alternative fastcgi_params file to use
@@ -170,9 +174,12 @@ define nginx::resource::location (
   Optional[String] $proxy_redirect                     = $::nginx::proxy_redirect,
   String $proxy_read_timeout                           = $::nginx::proxy_read_timeout,
   String $proxy_connect_timeout                        = $::nginx::proxy_connect_timeout,
+  String $proxy_send_timeout                           = $::nginx::proxy_send_timeout,
   Array $proxy_set_header                              = $::nginx::proxy_set_header,
   Array $proxy_hide_header                             = $::nginx::proxy_hide_header,
   Array $proxy_pass_header                             = $::nginx::proxy_pass_header,
+  Array $proxy_ignore_header                           = $::nginx::proxy_ignore_header,
+  Optional[String] $proxy_next_upstream                = undef,
   Optional[String] $fastcgi                            = undef,
   Optional[String] $fastcgi_index                      = undef,
   Optional[Hash] $fastcgi_param                        = undef,

--- a/templates/server/locations/proxy.erb
+++ b/templates/server/locations/proxy.erb
@@ -2,6 +2,7 @@
     proxy_pass            <%= @proxy %>;
     proxy_read_timeout    <%= @proxy_read_timeout %>;
     proxy_connect_timeout <%= @proxy_connect_timeout %>;
+    proxy_send_timeout    <%= @proxy_send_timeout %>;
 <% if @proxy_redirect -%>
     proxy_redirect        <%= @proxy_redirect %>;
 <% end -%>
@@ -25,6 +26,11 @@
 <% unless @proxy_hide_header.nil? -%>
     <%- @proxy_hide_header.each do |header| -%>
     proxy_hide_header      <%= header %>;
+    <%- end -%>
+<% end -%>
+<% unless @proxy_ignore_header.nil? -%>
+    <%- @proxy_ignore_header.each do |header| -%>
+    proxy_ignore_headers      <%= header %>;
     <%- end -%>
 <% end -%>
 <% unless @proxy_pass_header.nil? -%>
@@ -53,5 +59,8 @@
 <% end -%>
 <% if @proxy_cache_lock -%>
     proxy_cache_lock         <%= @proxy_cache_lock %>;
+<% end -%>
+<% if @proxy_next_upstream -%>
+    proxy_next_upstream      <%= @proxy_next_upstream %>;
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Added more options configurable per-location to proxy template and manifests:
- proxy_send_timeout
- proxy_ignore_header (nginx config option is proxy_ignore_headers, but I used 'proxy_ignore_header' name to be compatible with other options)
- proxy_next_upstream

All these options are supported by Nginx.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
