### PR TITLE
add missing autoindex parameter in template of server resource

### DIFF
--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -331,6 +331,12 @@ describe 'nginx::resource::server' do
               attr: 'index_files',
               value: [],
               notmatch: %r{\s+index\s+}
+            },
+            {
+              title: 'should set autoindex',
+              attr: 'autoindex',
+              value: 'on',
+              match: '    autoindex on;'
             }
           ].each do |param|
             context "when #{param[:attr]} is #{param[:value]}" do

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -128,7 +128,9 @@ server {
 <% end -%>
 <% if @index_files and @index_files.count > 0 and not @ssl_only -%>
   index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
-
+<% end -%>
+<% if defined? @autoindex -%>
+    autoindex <%= @autoindex %>;
 <% end -%>
 <% if defined? @log_by_lua -%>
   log_by_lua '<%= @log_by_lua %>';


### PR DESCRIPTION
The server resource has an ```autoindex``` parameter but the templates did not reflect this. There was also no testcase for this parameter.