### PR TITLE
Add support for dynamic modules.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,6 +24,7 @@ class nginx::config {
   $daemon                         = $nginx::daemon
   $daemon_user                    = $nginx::daemon_user
   $daemon_group                   = $nginx::daemon_group
+  $dynamic_modules                = $nginx::dynamic_modules
   $global_owner                   = $nginx::global_owner
   $global_group                   = $nginx::global_group
   $global_mode                    = $nginx::global_mode

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class nginx (
   Optional[Enum['on', 'off']] $daemon                        = undef,
   $daemon_user                                               = $nginx::params::daemon_user,
   $daemon_group                                              = undef,
+  Array[String] $dynamic_modules                             = [],
   $global_owner                                              = $nginx::params::global_owner,
   $global_group                                              = $nginx::params::global_group,
   $global_mode                                               = $nginx::params::global_mode,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -360,6 +360,12 @@ describe 'nginx' do
           describe 'nginx.conf template content' do
             [
               {
+                title: 'should not set load_module',
+                attr: 'dynamic_modules',
+                value: :undef,
+                notmatch: %r{load_module}
+              },
+              {
                 title: 'should not set user',
                 attr: 'super_user',
                 value: false,
@@ -908,6 +914,26 @@ describe 'nginx' do
                 end
               end
             end
+          end
+
+          context 'when dynamic_modules is "[\'ngx_http_geoip_module\']" ' do
+            let(:params) do
+              {
+                dynamic_modules: ['ngx_http_geoip_module']
+              }
+            end
+
+            it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(%r{load_module "modules/ngx_http_geoip_module.so";}) }
+          end
+
+          context 'when dynamic_modules is "[\'/path/to/module/ngx_http_geoip_module.so\']" ' do
+            let(:params) do
+              {
+                dynamic_modules: ['/path/to/module/ngx_http_geoip_module.so']
+              }
+            end
+
+            it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(%r{load_module "/path/to/module/ngx_http_geoip_module.so";}) }
           end
 
           context 'when proxy_cache_path is /path/to/proxy.cache and loader_files is 1000' do

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -1,4 +1,11 @@
 # MANAGED BY PUPPET
+<% @dynamic_modules.each do |mod_item| -%>
+  <%- if mod_item =~ /^\/.*/ -%>
+load_module "<%= mod_item -%>";
+  <%- else -%>
+load_module "modules/<%= mod_item -%>.so";
+  <%- end -%>
+<%- end -%>
 <% if @daemon -%>
 daemon <%= @daemon %>;
 <% end -%>


### PR DESCRIPTION
Allow nginx to load dynamic modules by specifying an absolute or a
relative ("modules/") path. Modules must be installed separately and
before loading the puppet nginx module.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
