### PR TITLE
add etag support at the http level

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -51,6 +51,7 @@ class nginx::config {
   $client_body_timeout            = $::nginx::client_body_timeout
   $send_timeout                   = $::nginx::send_timeout
   $lingering_timeout              = $::nginx::lingering_timeout
+  $etag                           = $::nginx::etag
   $events_use                     = $::nginx::events_use
   $fastcgi_cache_inactive         = $::nginx::fastcgi_cache_inactive
   $fastcgi_cache_key              = $::nginx::fastcgi_cache_key

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,7 @@ class nginx (
   $client_body_timeout                                       = '60s',
   $send_timeout                                              = '60s',
   $lingering_timeout                                         = '5s',
+  Optional[Enum['on', 'off']] $etag                          = undef,
   Optional[String] $events_use                               = undef,
   String $fastcgi_cache_inactive                             = '20m',
   Optional[String] $fastcgi_cache_key                        = undef,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -479,6 +479,12 @@ describe 'nginx' do
                 notmatch: %r{multi_accept}
               },
               {
+                title: 'should set etag',
+                attr: 'etag',
+                value: 'off',
+                match: '  etag off;'
+              },
+              {
                 title: 'should set events_use',
                 attr: 'events_use',
                 value: 'eventport',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -96,6 +96,10 @@ http {
   lingering_timeout   <%= @lingering_timeout %>;
   tcp_nodelay         <%= @http_tcp_nodelay %>;
 
+<% if defined? @etag -%>
+  etag <%= @etag %>;
+<% end -%>
+
 <% if @gzip == 'on' -%>
   gzip              on;
 <% if @gzip_buffers -%>


### PR DESCRIPTION
This change adds support for enabling/disabling the etag nginx directive in the http context. http://nginx.org/en/docs/http/ngx_http_core_module.html#etag

If no value is supplied it will not add anything and allow the nginx-defined default to take effect.