### PR TITLE
Fix #1190 Accommodate default package name nginx-mainline for Arch Linux

### DIFF
--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -165,6 +165,10 @@ describe 'nginx' do
             it { is_expected.not_to contain_apt__source('nginx') }
             it { is_expected.not_to contain_package('passenger') }
           end
+        when 'Archlinux'
+          context 'using defaults' do
+            it { is_expected.to contain_package('nginx-mainline') }
+          end
         else
           it { is_expected.to contain_package('nginx') }
         end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->

See #1190 