### PR TITLE
Fix indent of autoindex param in server template

### DIFF
--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -336,7 +336,7 @@ describe 'nginx::resource::server' do
               title: 'should set autoindex',
               attr: 'autoindex',
               value: 'on',
-              match: '    autoindex on;'
+              match: '  autoindex on;'
             }
           ].each do |param|
             context "when #{param[:attr]} is #{param[:value]}" do

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -130,7 +130,7 @@ server {
   index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
 <% end -%>
 <% if defined? @autoindex -%>
-    autoindex <%= @autoindex %>;
+  autoindex <%= @autoindex %>;
 <% end -%>
 <% if defined? @log_by_lua -%>
   log_by_lua '<%= @log_by_lua %>';


### PR DESCRIPTION
This fixes the indenting of the autoindex parameter in the server template to be consistent with all the other parameters at the server level.

## Before ##
```
server {
  listen *:80; 
 
  server_name           example.com;
 
  root /usr/local/www/example.com/; 
  return 301 https://$host$request_uri;
    autoindex off; 
  access_log            /var/log/nginx/example.com_redirect.access.log combined;
  error_log             /var/log/nginx/example.com_redirect.error.log;
}
```
## After ##
```
server {
  listen *:80; 
 
  server_name           example.com;
 
  root /usr/local/www/example.com/; 
  return 301 https://$host$request_uri;
  autoindex off; 
  access_log            /var/log/nginx/example.com_redirect.access.log combined;
  error_log             /var/log/nginx/example.com_redirect.error.log;
}
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
