### PR TITLE
Update readme: listen_port is integer for Hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ nginx::nginx_cfg_prepend:
 nginx::nginx_streamhosts:
   'syslog':
     ensure:                 'present'
-    listen_port:            '514'
+    listen_port:            514
     listen_options:         'udp'
     proxy:                  'syslog'
     proxy_read_timeout:     '1'


### PR DESCRIPTION
#### Pull Request (PR) description
Fix readme example for streamhosts using Hiera. It incorrectly states that listen_port is a string value when using hiera.

#### This Pull Request (PR) fixes the following issues
Using the example hiera data for streamhosts gives the following error:
```
[root@nginxlbmasters /]# puppet agent -t
Info: Using configured environment 'kubernetes'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Nginx::Resource::Streamhost[kubernetes-api-streamhost]: parameter 'listen_port' expects an Integer value, got String (file: /etc/puppetlabs/code/environments/kubernetes/modules/nginx/manifests/init.pp, line: 181) on node nginxlbmasters.dkkiwezbbzwezjsuf2qq5optbd.ax.internal.cloudapp.net
```