### PR TITLE
Update minimum version of puppetlabs/stdlib to 4.22.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 <5.0.0"
+      "version_requirement": ">= 4.22.0 <5.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
Updates minimum version of stdlib to 4.22.0, which includes support for the Stdlib::Filemode type.
This type will be used in the process of adding types to all parameters (#1189).
