### PR TITLE
Remove unnecessary class parameters from nginx::service

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,32 +13,25 @@
 # Sample Usage:
 #
 # This class file is not called directly
-class nginx::service(
-  $service_restart = $nginx::service_restart,
-  $service_ensure  = $nginx::service_ensure,
-  $service_enable  = $nginx::service_enable,
-  $service_name    = $nginx::service_name,
-  $service_flags   = $nginx::service_flags,
-  $service_manage  = $nginx::service_manage,
-) {
+class nginx::service {
 
   assert_private()
 
-  if $service_manage {
+  if $nginx::service_manage {
     case $facts['os']['name'] {
       'OpenBSD': {
-        service { $service_name:
-          ensure     => $service_ensure,
-          enable     => $service_enable,
-          flags      => $service_flags,
+        service { $nginx::service_name:
+          ensure     => $nginx::service_ensure,
+          enable     => $nginx::service_enable,
+          flags      => $nginx::service_flags,
           hasstatus  => true,
           hasrestart => true,
         }
       }
       default: {
-        service { $service_name:
-          ensure     => $service_ensure,
-          enable     => $service_enable,
+        service { $nginx::service_name:
+          ensure     => $nginx::service_ensure,
+          enable     => $nginx::service_enable,
           hasstatus  => true,
           hasrestart => true,
         }
@@ -47,9 +40,9 @@ class nginx::service(
   }
 
   # Allow overriding of 'restart' of Service resource; not used by default
-  if $service_restart {
-    Service[$service_name] {
-      restart => $service_restart,
+  if $nginx::service_restart {
+    Service[$nginx::service_name] {
+      restart => $nginx::service_restart,
     }
   }
 }


### PR DESCRIPTION
Class `nginx::service` is private, declared once and should reference
variables only from the main class.
