### PR TITLE
Support setting `ssl_verify_depth` in nginx::resource::server

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -67,6 +67,7 @@
 #   [*ssl_session_ticket_key*]     - String: Sets a file with the secret key used to encrypt and decrypt TLS session tickets.
 #   [*ssl_trusted_cert*]           - String: Specifies a file with trusted CA certificates in the PEM format used to verify client
 #     certificates and OCSP responses if ssl_stapling is enabled.
+#   [*ssl_verify_depth*]           - Integer: Sets the verification depth in the client certificates chain.
 #   [*spdy*]                       - Toggles SPDY protocol.
 #   [*http2*]                      - Toggles HTTP/2 protocol.
 #   [*server_name*]                - List of servernames for which this server will respond. Default [$name].
@@ -179,6 +180,7 @@ define nginx::resource::server (
   Optional[String] $ssl_session_tickets                                          = undef,
   Optional[String] $ssl_session_ticket_key                                       = undef,
   Optional[String] $ssl_trusted_cert                                             = undef,
+  Optional[Integer] $ssl_verify_depth                                            = undef,
   String $spdy                                                                   = $::nginx::spdy,
   $http2                                                                         = $::nginx::http2,
   Optional[String] $proxy                                                        = undef,

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -579,6 +579,12 @@ describe 'nginx::resource::server' do
               match: %r{\s+ssl_trusted_certificate\s+/tmp/trusted_certificate;}
             },
             {
+              title: 'should set ssl_verify_depth',
+              attr: 'ssl_verify_depth',
+              value: 2,
+              match: %r{^\s+ssl_verify_depth\s+2;}
+            },
+            {
               title: 'should set the SSL cache',
               attr: 'ssl_cache',
               value: 'shared:SSL:1m',

--- a/templates/server/server_ssl_settings.erb
+++ b/templates/server/server_ssl_settings.erb
@@ -49,4 +49,7 @@
   <%- if defined? @ssl_trusted_cert -%>
   ssl_trusted_certificate   <%= @ssl_trusted_cert %>;
   <%- end -%>
+  <%- if @ssl_verify_depth -%>
+  ssl_verify_depth          <%= @ssl_verify_depth %>;
+  <%- end -%>
 <% end -%>


### PR DESCRIPTION
This adds support for specifying the `ssl_verify_depth` option in server sections.