### PR TITLE
allow people to not purge passenger yumrepo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -168,6 +168,7 @@ class nginx (
   $nginx_upstreams                                           = {},
   $nginx_servers                                             = {},
   $nginx_servers_defaults                                    = {},
+  Boolean $purge_passenger_repo                              = true,
   ### END Hiera Lookups ###
 ) inherits nginx::params {
 

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -21,6 +21,7 @@ class nginx::package::redhat {
   $package_flavor           = $nginx::package_flavor
   $passenger_package_ensure = $nginx::passenger_package_ensure
   $manage_repo              = $nginx::manage_repo
+  $purge_passenger_repo     = $nginx::purge_passenger_repo
 
   #Install the CentOS-specific packages on that OS, otherwise assume it's a RHEL
   #clone and provide the Red Hat-specific package. This comes into play when not
@@ -43,11 +44,12 @@ class nginx::package::redhat {
           before   => Package['nginx'],
         }
 
-        yumrepo { 'passenger':
-          ensure => absent,
-          before => Package['nginx'],
+        if $purge_passenger_repo {
+          yumrepo { 'passenger':
+            ensure => absent,
+            before => Package['nginx'],
+          }
         }
-
       }
       'nginx-mainline': {
         yumrepo { 'nginx-release':
@@ -60,11 +62,12 @@ class nginx::package::redhat {
           before   => Package['nginx'],
         }
 
-        yumrepo { 'passenger':
-          ensure => absent,
-          before => Package['nginx'],
+        if $purge_passenger_repo {
+          yumrepo { 'passenger':
+            ensure => absent,
+            before => Package['nginx'],
+          }
         }
-
       }
       'passenger': {
         if ($facts['os']['name'] in ['RedHat', 'CentOS']) and ($facts['os']['release']['major'] in ['6', '7']) {


### PR DESCRIPTION
The idea is that people can switch between the different available nginx
repos. in case somebody switched from the passenger one to the upstream
repo we want to purge the passenger repo. However this gets us intro
trouble if the person never switched, but another module declares a
resource with this name.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
