### PR TITLE
Add service_enable and simplify service_ensure, #1208

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -151,6 +151,7 @@ class nginx (
 
   ### START Service Configuation ###
   $service_ensure                                            = running,
+  $service_enable                                            = true,
   $service_flags                                             = undef,
   $service_restart                                           = undef,
   $service_name                                              = 'nginx',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -16,6 +16,7 @@
 class nginx::service(
   $service_restart = $nginx::service_restart,
   $service_ensure  = $nginx::service_ensure,
+  $service_enable  = $nginx::service_enable,
   $service_name    = $nginx::service_name,
   $service_flags   = $nginx::service_flags,
   $service_manage  = $nginx::service_manage,
@@ -23,25 +24,11 @@ class nginx::service(
 
   assert_private()
 
-  $service_enable = $service_ensure ? {
-    'running' => true,
-    'absent'  => false,
-    'stopped' => false,
-    'undef'   => undef,
-    default   => true,
-  }
-
-  if $service_ensure == 'undef' {
-    $service_ensure_real = undef
-  } else {
-    $service_ensure_real = $service_ensure
-  }
-
   if $service_manage {
     case $facts['os']['name'] {
       'OpenBSD': {
         service { $service_name:
-          ensure     => $service_ensure_real,
+          ensure     => $service_ensure,
           enable     => $service_enable,
           flags      => $service_flags,
           hasstatus  => true,
@@ -50,7 +37,7 @@ class nginx::service(
       }
       default: {
         service { $service_name:
-          ensure     => $service_ensure_real,
+          ensure     => $service_ensure,
           enable     => $service_enable,
           hasstatus  => true,
           hasrestart => true,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -196,6 +196,7 @@ describe 'nginx' do
         let :params do
           {
             service_ensure: 'running',
+            service_enable: true,
             service_name: 'nginx',
             service_manage: true
           }
@@ -219,6 +220,7 @@ describe 'nginx' do
             {
               service_restart: 'a restart command',
               service_ensure: 'running',
+              service_enable: true,
               service_name: 'nginx'
             }
           end


### PR DESCRIPTION
#### Pull Request (PR) description
Adds an explicit $service_enable parameter. Sets to undef by default, which then follows the previous behaviour of auto-setting from $service_ensure.

This replaces a previous effort #1211

#### This Pull Request (PR) fixes the following issues
Fixes #1208
