### PR TITLE
dont deploy "ssl on" on nginx 1.15 or newer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -170,6 +170,7 @@ class nginx (
   $nginx_servers                                             = {},
   $nginx_servers_defaults                                    = {},
   Boolean $purge_passenger_repo                              = true,
+  Boolean $add_listen_directive                              = $nginx::params::add_listen_directive,
   ### END Hiera Lookups ###
 ) inherits nginx::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -121,5 +121,11 @@ class nginx::params {
   $sites_available_group = $_module_parameters['root_group']
   $sites_available_mode  = '0644'
   $super_user            = true
+  if fact('nginx_version') {
+    # enable only for releases that are older than 1.15.0
+    $add_listen_directive = versioncmp(fact('nginx_version'), '1.15.0') < 0
+  } else {
+    $add_listen_directive = true
+  }
   ### END Referenced Variables
 }

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -127,6 +127,7 @@
 #   [*error_pages*]                - Hash: setup errors pages, hash key is the http code and hash value the page
 #   [*locations*]                  - Hash of servers resources used by this server
 #   [*locations_defaults*]         - Hash of location default settings
+#   [*add_listen_directive*]       - Boolean to determine if we should add 'ssl on;' to the vhost or not. defaults to true for nginx 1.14 and older, otherwise false
 # Actions:
 #
 # Requires:
@@ -260,7 +261,8 @@ define nginx::resource::server (
   String $maintenance_value                                                      = 'return 503',
   $error_pages                                                                   = undef,
   Hash $locations                                                                = {},
-  Hash $locations_defaults                                                       = {}
+  Hash $locations_defaults                                                       = {},
+  Boolean $add_listen_directive                                                  = $nginx::add_listen_directive,
 ) {
 
   if ! defined(Class['nginx']) {

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -425,6 +425,49 @@ describe 'nginx::resource::server' do
         end
 
         describe 'server_ssl_header template content' do
+          context 'without a value for the nginx_version fact do' do
+            let :facts do
+              facts[:nginx_version] ? facts.delete(:nginx_version) : facts
+            end
+            let :params do
+              default_params.merge(
+                ssl: true,
+                ssl_key: 'dummy.key',
+                ssl_cert: 'dummy.crt'
+              )
+            end
+
+            it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{  ssl on;}) }
+          end
+          context 'with fact nginx_version=1.14.1' do
+            let :facts do
+              facts.merge(nginx_version: '1.14.1')
+            end
+            let :params do
+              default_params.merge(
+                ssl: true,
+                ssl_key: 'dummy.key',
+                ssl_cert: 'dummy.crt'
+              )
+            end
+
+            it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{  ssl on;}) }
+          end
+
+          context 'with fact nginx_version=1.15.1' do
+            let :facts do
+              facts.merge(nginx_version: '1.15.1')
+            end
+            let :params do
+              default_params.merge(
+                ssl: true,
+                ssl_key: 'dummy.key',
+                ssl_cert: 'dummy.crt'
+              )
+            end
+
+            it { is_expected.not_to contain_concat__fragment("#{title}-ssl-header").with_content(%r{  ssl on;}) }
+          end
           [
             {
               title: 'should not contain www to non-www rewrite',

--- a/templates/server/server_ssl_settings.erb
+++ b/templates/server/server_ssl_settings.erb
@@ -1,5 +1,6 @@
+<% if @add_listen_directive -%>
   ssl on;
-
+<% end -%>
 <% if @ssl_cert -%>
   ssl_certificate           <%= @ssl_cert %>;
 <% end -%>


### PR DESCRIPTION
fixes #1224. the option 'ssl on' within a server block is deprecated since nginx 1.15.0.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
