### PR TITLE
initial support for snippets

### DIFF
--- a/examples/snippet.pp
+++ b/examples/snippet.pp
@@ -1,0 +1,30 @@
+
+class { 'nginx':
+  snippets_dir        => '/etc/nginx/snippets',
+}
+
+$snippet = @("SNIPPET"/L)
+location @custom_451_error {
+  return 451;
+}
+| SNIPPET
+
+nginx::resource::snippet { 'test_snippet':
+  raw_content   => $snippet,
+}
+
+nginx::resource::server { 'test.local:8080':
+  ensure        => present,
+  listen_port   => 8080,
+  server_name   => ['test.local test'],
+  include_files => ["${nginx::snippets_dir}/test_snippet.conf"],
+  try_files     => [ 'non-existant', '@custom_451_error'],
+}
+
+nginx::resource::server { 'test.local:8081':
+  ensure        => present,
+  listen_port   => 8081,
+  server_name   => ['test.local test'],
+  include_files => ["${nginx::snippets_dir}/test_snippet.conf"],
+  try_files     => [ 'non-existant', '@custom_451_error'],
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -181,6 +181,12 @@ class nginx::config {
     ensure => directory,
   }
 
+  if $nginx::manage_snippets_dir {
+    file { $nginx::snippets_dir:
+      ensure => directory,
+    }
+  }
+
   file { $log_dir:
     ensure => directory,
     mode   => $log_mode,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -134,6 +134,8 @@ class nginx (
   Enum['on', 'off'] $spdy                                    = 'off',
   Enum['on', 'off'] $http2                                   = 'off',
   Enum['on', 'off'] $ssl_stapling                            = 'off',
+  Stdlib::Absolutepath $snippets_dir                         = $nginx::params::snippets_dir,
+  Boolean $manage_snippets_dir                               = true,
   $types_hash_bucket_size                                    = '512',
   $types_hash_max_size                                       = '1024',
   Integer $worker_connections                                = 1024,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -202,6 +202,7 @@ class nginx::params {
 
   ### Referenced Variables
   $conf_dir              = $_module_parameters['conf_dir']
+  $snippets_dir          = "${conf_dir}/snippets"
   $log_dir               = $_module_parameters['log_dir']
   $log_user              = $_module_parameters['log_user']
   $log_group             = $_module_parameters['log_group']

--- a/manifests/resource/snippet.pp
+++ b/manifests/resource/snippet.pp
@@ -1,0 +1,37 @@
+# This definition creates a reusable config snippet that can be included by other resources
+#
+# @param ensure Enables or disables the specified snippet
+# @param owner Defines owner of the .conf file
+# @param group Defines group of the .conf file
+# @param mode Defines mode of the .conf file
+# @param raw_content Raw content that will be inserted into the snipped as-is
+
+define nginx::resource::snippet (
+  String[1] $raw_content,
+  Enum['absent', 'present'] $ensure = 'present',
+  String $owner                     = $nginx::global_owner,
+  String $group                     = $nginx::global_group,
+  Stdlib::Filemode $mode            = $nginx::global_mode,
+) {
+  if ! defined(Class['nginx']) {
+    fail('You must include the nginx base class before using any defined resources')
+  }
+
+  $name_sanitized = regsubst($name, ' ', '_', 'G')
+  $config_file = "${nginx::snippets_dir}/${name_sanitized}.conf"
+
+  concat { $config_file:
+    ensure  => $ensure,
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
+    notify  => Class['nginx::service'],
+    require => File[$nginx::snippets_dir],
+  }
+
+  concat::fragment { "snippet-${name_sanitized}-header":
+    target  => $config_file,
+    content => epp("${module_name}/snippet/snippet_header.epp", { 'raw_content' => $raw_content }),
+    order   => '001',
+  }
+}

--- a/spec/defines/resource_snippet_spec.rb
+++ b/spec/defines/resource_snippet_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'nginx::resource::snippet' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      let :title do
+        'some_snippet'
+      end
+
+      let :pre_condition do
+        'include nginx'
+      end
+
+      describe 'basic snippet' do
+        let :params do
+          {
+            raw_content: 'this is a test'
+          }
+        end
+
+        it { is_expected.to contain_concat__fragment('snippet-some_snippet-header').with_target("/etc/nginx/snippets/#{title}.conf").with_content(%r{this is a test}) }
+        it { is_expected.to contain_concat('/etc/nginx/snippets/some_snippet.conf') }
+        it { is_expected.to compile.with_all_deps }
+      end
+    end
+  end
+end

--- a/templates/snippet/snippet_header.epp
+++ b/templates/snippet/snippet_header.epp
@@ -1,0 +1,5 @@
+<%- | String $raw_content,
+| -%>
+# MANAGED BY PUPPET
+
+<%= $raw_content %>


### PR DESCRIPTION
#### Pull Request (PR) description
Add basic support for creating snippets (reusable configuration files) that can be included by other resources. In phase 1 of this effort I am just introducing the ability to create include files by providing the raw contents, but future phases will include writing server::resource::location output into a snippet for reusability.

Please let me know your thoughts on the direction this is going.

#### This Pull Request (PR) fixes the following issues
Fixes #644
Fixes #1135
