### PR TITLE
Update nginx.conf.erb - only included files with the extension '.conf'

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -217,7 +217,7 @@ http {
 
   include <%= @conf_dir %>/conf.d/*.conf;
 <% unless @confd_only -%>
-  include <%= @conf_dir %>/sites-enabled/*;
+  include <%= @conf_dir %>/sites-enabled/*.conf;
 <% end -%>
 }
 <% if @mail -%>
@@ -230,7 +230,7 @@ stream {
   <%-# conf.stream.d gets included either way if $stream is enabled -%>
   include <%= @conf_dir %>/conf.stream.d/*.conf;
 <% unless @confd_only -%>
-  include <%= @conf_dir %>/streams-enabled/*;
+  include <%= @conf_dir %>/streams-enabled/*.conf;
 <% end -%>
 }
 <% end -%>


### PR DESCRIPTION
suffix the 'to include' files. I expect only *.conf files to be configuration files for nginx.

Usecase:

troubleshooting and 'disabling' the file quickly by adding .bck for example (vhost.conf.bck) so this vhost (or stream) is ignored.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->
