### PR TITLE
Use HTTPS for Yum repositories

### DIFF
--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -35,12 +35,12 @@ class nginx::package::redhat {
     case $package_source {
       'nginx', 'nginx-stable': {
         yumrepo { 'nginx-release':
-          baseurl  => "http://nginx.org/packages/${_os}/${facts['os']['release']['major']}/\$basearch/",
+          baseurl  => "https://nginx.org/packages/${_os}/${facts['os']['release']['major']}/\$basearch/",
           descr    => 'nginx repo',
           enabled  => '1',
           gpgcheck => '1',
           priority => '1',
-          gpgkey   => 'http://nginx.org/keys/nginx_signing.key',
+          gpgkey   => 'https://nginx.org/keys/nginx_signing.key',
           before   => Package['nginx'],
         }
 
@@ -53,12 +53,12 @@ class nginx::package::redhat {
       }
       'nginx-mainline': {
         yumrepo { 'nginx-release':
-          baseurl  => "http://nginx.org/packages/mainline/${_os}/${facts['os']['release']['major']}/\$basearch/",
+          baseurl  => "https://nginx.org/packages/mainline/${_os}/${facts['os']['release']['major']}/\$basearch/",
           descr    => 'nginx repo',
           enabled  => '1',
           gpgcheck => '1',
           priority => '1',
-          gpgkey   => 'http://nginx.org/keys/nginx_signing.key',
+          gpgkey   => 'https://nginx.org/keys/nginx_signing.key',
           before   => Package['nginx'],
         }
 

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -43,12 +43,12 @@ describe 'nginx' do
             it { is_expected.to contain_package('nginx') }
             it do
               is_expected.to contain_yumrepo('nginx-release').with(
-                'baseurl'  => "http://nginx.org/packages/#{facts[:operatingsystem] == 'CentOS' ? 'centos' : 'rhel'}/#{facts[:operatingsystemmajrelease]}/$basearch/",
+                'baseurl'  => "https://nginx.org/packages/#{facts[:operatingsystem] == 'CentOS' ? 'centos' : 'rhel'}/#{facts[:operatingsystemmajrelease]}/$basearch/",
                 'descr'    => 'nginx repo',
                 'enabled'  => '1',
                 'gpgcheck' => '1',
                 'priority' => '1',
-                'gpgkey'   => 'http://nginx.org/keys/nginx_signing.key'
+                'gpgkey'   => 'https://nginx.org/keys/nginx_signing.key'
               )
             end
             it do
@@ -66,12 +66,12 @@ describe 'nginx' do
             it { is_expected.to contain_package('nginx') }
             it do
               is_expected.to contain_yumrepo('nginx-release').with(
-                'baseurl'  => "http://nginx.org/packages/#{facts[:operatingsystem] == 'CentOS' ? 'centos' : 'rhel'}/#{facts[:operatingsystemmajrelease]}/$basearch/",
+                'baseurl'  => "https://nginx.org/packages/#{facts[:operatingsystem] == 'CentOS' ? 'centos' : 'rhel'}/#{facts[:operatingsystemmajrelease]}/$basearch/",
                 'descr'    => 'nginx repo',
                 'enabled'  => '1',
                 'gpgcheck' => '1',
                 'priority' => '1',
-                'gpgkey'   => 'http://nginx.org/keys/nginx_signing.key'
+                'gpgkey'   => 'https://nginx.org/keys/nginx_signing.key'
               )
             end
 
@@ -83,7 +83,7 @@ describe 'nginx' do
 
             it do
               is_expected.to contain_yumrepo('nginx-release').with(
-                'baseurl' => "http://nginx.org/packages/mainline/#{facts[:operatingsystem] == 'CentOS' ? 'centos' : 'rhel'}/#{facts[:operatingsystemmajrelease]}/$basearch/"
+                'baseurl' => "https://nginx.org/packages/mainline/#{facts[:operatingsystem] == 'CentOS' ? 'centos' : 'rhel'}/#{facts[:operatingsystemmajrelease]}/$basearch/"
               )
             end
             it do


### PR DESCRIPTION
#### Pull Request (PR) description
Use HTTPS instead of HTTP for yum repositories

#### This Pull Request (PR) fixes the following issues
None. I actually implemented it because I use this module from a location where only HTTPS is required, but it's good practice to use HTTPS when available anyway!