### PR TITLE
Allow setting unquoted or custom flags on add_headers

### DIFF
--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -404,17 +404,20 @@ describe 'nginx::resource::location' do
             let(:params) do
               default_params.merge(
                 'add_header' => {
-                  'X-Frame-Options' => 'SAMEORIGIN',
-                  'X-Powered-By'    => 'Puppet'
+                  'header 1' => 'test value 1',
+                  'header 2' => { 'test value 2' => 'tv2' },
+                  'header 3' => { '' => '\'test value 3\' tv3' }
                 }
               )
             end
 
-            it 'contains both add_header lines' do
+            it 'contains 3 add_header lines' do
               is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('location')).
-                with_content(%r{^\s+add_header\s+"X-Frame-Options"\s+"SAMEORIGIN";$})
+                with_content(%r{^\s+add_header\s+"header 1"\s+"test value 1";$})
               is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('location')).
-                with_content(%r{^\s+add_header\s+"X-Powered-By"\s+"Puppet";$})
+                with_content(%r{^\s+add_header\s+"header 2"\s+"test value 2" tv2;$})
+              is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest('location')).
+                with_content(%r{^\s+add_header\s+"header 3"\s+'test value 3' tv3;$})
             end
           end
         end

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -1333,24 +1333,24 @@ describe 'nginx::resource::server' do
 
           context 'when add_header is set' do
             let :params do
-              default_params.merge(add_header: { 'header3' => 'test value 3', 'header2' => 'test value 2', 'header1' => 'test value 1' })
+              default_params.merge(add_header: { 'header3' => { '' => '\'test value 3\' tv3' }, 'header2' => { 'test value 2' => 'tv2' }, 'header1' => 'test value 1' })
             end
 
             it 'has correctly ordered entries in the config' do
-              is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+add_header\s+"header1" "test value 1";\n\s+add_header\s+"header2" "test value 2";\n\s+add_header\s+"header3" "test value 3";\n})
+              is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+add_header\s+"header1" "test value 1";\n\s+add_header\s+"header2" "test value 2" tv2;\n\s+add_header\s+"header3"  'test value 3' tv3;\n})
             end
           end
 
           context 'when add_header is set and ssl => true' do
             let :params do
-              default_params.merge(add_header: { 'header3' => 'test value 3', 'header2' => 'test value 2', 'header1' => 'test value 1' },
+              default_params.merge(add_header: { 'header3' => { '' => '\'test value 3\' tv3' }, 'header2' => { 'test value 2' => 'tv2' }, 'header1' => 'test value 1' },
                                    ssl: true,
                                    ssl_key: 'dummy.key',
                                    ssl_cert: 'dummy.cert')
             end
 
             it 'has correctly ordered entries in the config' do
-              is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{\s+add_header\s+"header1" "test value 1";\n\s+add_header\s+"header2" "test value 2";\n\s+add_header\s+"header3" "test value 3";\n})
+              is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{\s+add_header\s+"header1" "test value 1";\n\s+add_header\s+"header2" "test value 2" tv2;\n\s+add_header\s+"header3"  'test value 3' tv3;\n})
             end
           end
         end

--- a/templates/server/locations/headers.erb
+++ b/templates/server/locations/headers.erb
@@ -1,3 +1,11 @@
 <%- @add_header.keys.sort.each do |key| -%>
+    <%- if @add_header[key] -%>
+      <%- if @add_header[key].is_a?(Hash) -%>
+        <%- @add_header[key].each do |sk, sv| -%>
+    add_header "<%= key %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
+        <%- end -%>
+      <%- else -%>
     add_header "<%= key %>" "<%= @add_header[key] %>";
+      <%- end -%>
+    <%- end -%>
 <%- end -%>

--- a/templates/server/locations/headers.erb
+++ b/templates/server/locations/headers.erb
@@ -1,11 +1,11 @@
-<%- @add_header.keys.sort.each do |key| -%>
-    <%- if @add_header[key] -%>
-      <%- if @add_header[key].is_a?(Hash) -%>
-        <%- @add_header[key].each do |sk, sv| -%>
-    add_header "<%= key %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
+<%- @add_header.sort.each do |header, value| -%>
+    <%- if value -%>
+      <%- if value.is_a?(Hash) -%>
+        <%- value.each do |sk, sv| -%>
+    add_header "<%= header %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
         <%- end -%>
       <%- else -%>
-    add_header "<%= key %>" "<%= @add_header[key] %>";
+    add_header "<%= header %>" "<%= value %>";
       <%- end -%>
     <%- end -%>
 <%- end -%>

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -117,7 +117,15 @@ server {
 <% end -%>
 <% if @add_header -%>
   <%- @add_header.keys.sort.each do |key| -%>
+    <%- if @add_header[key] -%>
+      <%- if @add_header[key].is_a?(Hash) -%>
+        <%- @add_header[key].each do |sk, sv| -%>
+  add_header              "<%= key %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
+        <%- end -%>
+      <%- else -%>
   add_header              "<%= key %>" "<%= @add_header[key] %>";
+      <%- end -%>
+    <%- end -%>
   <%- end -%>
 <% end -%>
 <% if @maintenance -%>

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -115,19 +115,7 @@ server {
 <% if Array(@resolver).count > 0 -%>
   resolver                  <% Array(@resolver).each do |r| %> <%= r %><% end %>;
 <% end -%>
-<% if @add_header -%>
-  <%- @add_header.keys.sort.each do |key| -%>
-    <%- if @add_header[key] -%>
-      <%- if @add_header[key].is_a?(Hash) -%>
-        <%- @add_header[key].each do |sk, sv| -%>
-  add_header              "<%= key %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
-        <%- end -%>
-      <%- else -%>
-  add_header              "<%= key %>" "<%= @add_header[key] %>";
-      <%- end -%>
-    <%- end -%>
-  <%- end -%>
-<% end -%>
+<%= scope.function_template(["nginx/server/locations/headers.erb"]) %>
 <% if @maintenance -%>
   <%= @maintenance_value %>;
 <% end -%>

--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -146,6 +146,14 @@ server {
 <% end -%>
 <% if @add_header -%>
   <%- @add_header.keys.sort.each do |key| -%>
+    <%- if @add_header[key] -%>
+      <%- if @add_header[key].is_a?(Hash) -%>
+        <%- @add_header[key].each do |sk, sv| -%>
+  add_header              "<%= key %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
+        <%- end -%>
+      <%- else -%>
   add_header              "<%= key %>" "<%= @add_header[key] %>";
+      <%- end -%>
+    <%- end -%>
   <%- end -%>
 <% end -%>

--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -144,16 +144,4 @@ server {
 <% Array(@passenger_env_var).each do |key,value| -%>
   passenger_env_var  <%= key %> <%= value %>;
 <% end -%>
-<% if @add_header -%>
-  <%- @add_header.keys.sort.each do |key| -%>
-    <%- if @add_header[key] -%>
-      <%- if @add_header[key].is_a?(Hash) -%>
-        <%- @add_header[key].each do |sk, sv| -%>
-  add_header              "<%= key %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
-        <%- end -%>
-      <%- else -%>
-  add_header              "<%= key %>" "<%= @add_header[key] %>";
-      <%- end -%>
-    <%- end -%>
-  <%- end -%>
-<% end -%>
+<%= scope.function_template(["nginx/server/locations/headers.erb"]) %>


### PR DESCRIPTION
Allows any combination of add_headers quoting.
_This solves issues highlighted in #991 #992 #1020_ 

**Double Quotes:**
```
add_header => {
    'Access-Control-Allow-Origin'      => '*' , 
}
```
would produce
`  add_header              "Access-Control-Allow-Origin" "*";`


**Double Quotes and Unquoted**
```
add_header => {
    'Access-Control-Allow-Origin'      => {'*' => 'always'}, 
}
```
would produce
`  add_header              "Access-Control-Allow-Origin" "*" always;`


**Custom Quotes**
```
add_header => {
    'Access-Control-Allow-Origin'      => {'' => '\'*\' always'}, 
}
```
would produce
`  add_header              "Access-Control-Allow-Origin" '*' always;`
