### PR TITLE
Strip line endings in mime.types

### DIFF
--- a/templates/conf.d/mime.types.epp
+++ b/templates/conf.d/mime.types.epp
@@ -1,6 +1,6 @@
 # MANAGED BY PUPPET
 types {
-<% $nginx::mime_types.each |$key, $value| { %>
+<% $nginx::mime_types.each |$key, $value| { -%>
     <%= $key %> <%= $value %>;
-<% } %>
+<% } -%>
 }


### PR DESCRIPTION
This ensures there are no empty lines in the file.