### PR TITLE
Introduce two new optional proxy parameters

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -93,6 +93,7 @@ class nginx::config {
   $nginx_cfg_prepend              = $nginx::nginx_cfg_prepend
   $proxy_buffers                  = $nginx::proxy_buffers
   $proxy_buffer_size              = $nginx::proxy_buffer_size
+  $proxy_busy_buffers_size        = $nginx::proxy_busy_buffers_size
   $proxy_cache_inactive           = $nginx::proxy_cache_inactive
   $proxy_cache_keys_zone          = $nginx::proxy_cache_keys_zone
   $proxy_cache_levels             = $nginx::proxy_cache_levels
@@ -105,6 +106,7 @@ class nginx::config {
   $proxy_connect_timeout          = $nginx::proxy_connect_timeout
   $proxy_headers_hash_bucket_size = $nginx::proxy_headers_hash_bucket_size
   $proxy_http_version             = $nginx::proxy_http_version
+  $proxy_max_temp_file_size       = $nginx::proxy_max_temp_file_size
   $proxy_read_timeout             = $nginx::proxy_read_timeout
   $proxy_redirect                 = $nginx::proxy_redirect
   $proxy_send_timeout             = $nginx::proxy_send_timeout

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,6 +127,8 @@ class nginx (
   Array $proxy_hide_header                                   = [],
   Array $proxy_pass_header                                   = [],
   Array $proxy_ignore_header                                 = [],
+  Optional[Nginx::Size] $proxy_max_temp_file_size            = undef,
+  Optional[Nginx::Size] $proxy_busy_buffers_size             = undef,
   Enum['on', 'off'] $sendfile                                = 'on',
   Enum['on', 'off'] $server_tokens                           = 'on',
   Enum['on', 'off'] $spdy                                    = 'off',

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -93,6 +93,9 @@
 #   [*proxy_set_body*]        - If defined, sets the body passed to the backend.
 #   [*proxy_buffering*]       - If defined, sets the proxy_buffering to the passed
 #     value.
+#   [*proxy_max_temp_file_size*] - Sets the maximum size of the temporary buffer file.
+#   [*proxy_busy_buffers_size*] - Sets the total size of buffers that can be
+#     busy sending a response to the client while the response is not yet fully read.
 #   [*absolute_redirect*]     - Enables or disables the absolute redirect functionality of nginx
 #   [*auth_basic*]            - This directive includes testing name and password
 #     with HTTP Basic Authentication.
@@ -224,6 +227,8 @@ define nginx::resource::location (
   Optional[String] $proxy_http_version                 = undef,
   Optional[String] $proxy_set_body                     = undef,
   Optional[Enum['on', 'off']] $proxy_buffering         = undef,
+  Optional[Nginx::Size] $proxy_max_temp_file_size      = undef,
+  Optional[Nginx::Size] $proxy_busy_buffers_size       = undef,
   Optional[Enum['on', 'off']] $absolute_redirect       = undef,
   Optional[String] $auth_basic                         = undef,
   Optional[String] $auth_basic_user_file               = undef,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -28,6 +28,9 @@
 #   [*proxy_send_timeout*]         - Override the default proxy send timeout value of 90 seconds
 #   [*proxy_redirect*]             - Override the default proxy_redirect value of off.
 #   [*proxy_buffering*]            - If defined, sets the proxy_buffering to the passed value.
+#   [*proxy_max_temp_file_size*]   - Sets the maximum size of the temporary buffer file.
+#   [*proxy_busy_buffers_size*]    - Sets the total size of buffers that can be
+#     busy sending a response to the client while the response is not yet fully read.
 #   [*resolver*]                   - Array: Configures name servers used to resolve names of upstream servers into addresses.
 #   [*fastcgi*]                    - location of fastcgi (host:port)
 #   [*fastcgi_param*]              - Set additional custom fastcgi_params
@@ -203,6 +206,8 @@ define nginx::resource::server (
   Optional[String] $proxy_http_version                                           = undef,
   Optional[String] $proxy_set_body                                               = undef,
   Optional[String] $proxy_buffering                                              = undef,
+  Optional[Nginx::Size] $proxy_max_temp_file_size                                = undef,
+  Optional[Nginx::Size] $proxy_busy_buffers_size                                 = undef,
   Array $resolver                                                                = [],
   Optional[String] $fastcgi                                                      = undef,
   Optional[String] $fastcgi_index                                                = undef,
@@ -373,6 +378,8 @@ define nginx::resource::server (
       proxy_set_body              => $proxy_set_body,
       proxy_cache_bypass          => $proxy_cache_bypass,
       proxy_buffering             => $proxy_buffering,
+      proxy_busy_buffers_size     => $proxy_busy_buffers_size,
+      proxy_max_temp_file_size    => $proxy_max_temp_file_size,
       fastcgi                     => $fastcgi,
       fastcgi_index               => $fastcgi_index,
       fastcgi_param               => $fastcgi_param,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -854,6 +854,18 @@ describe 'nginx' do
                 attr: 'proxy_temp_path',
                 value: '/path/to/proxy_temp',
                 match: '  proxy_temp_path         /path/to/proxy_temp;'
+              },
+              {
+                title: 'should set proxy_max_temp_file_size',
+                attr: 'proxy_max_temp_file_size',
+                value: '1024m',
+                match: '  proxy_max_temp_file_size 1024m;'
+              },
+              {
+                title: 'should set proxy_busy_buffers_size',
+                attr: 'proxy_busy_buffers_size',
+                value: '16k',
+                match: '  proxy_busy_buffers_size 16k;'
               }
             ].each do |param|
               context "when #{param[:attr]} is #{param[:value]}" do

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -920,6 +920,18 @@ describe 'nginx::resource::location' do
               attr: 'proxy_buffering',
               value: 'on',
               match: %r{\s+proxy_buffering\s+on;}
+            },
+            {
+              title: 'should set proxy_max_temp_file_size',
+              attr: 'proxy_max_temp_file_size',
+              value: '1024m',
+              match: %r{\s+proxy_max_temp_file_size\s+1024m;}
+            },
+            {
+              title: 'should set proxy_busy_buffers_size',
+              attr: 'proxy_busy_buffers_size',
+              value: '16k',
+              match: %r{\s+proxy_busy_buffers_size\s+16k;}
             }
           ].each do |param|
             context "when #{param[:attr]} is #{param[:value]}" do

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -160,6 +160,12 @@ http {
 <% if @proxy_buffer_size -%>
   proxy_buffer_size       <%= @proxy_buffer_size %>;
 <% end -%>
+<% if @proxy_busy_buffers_size -%>
+  proxy_busy_buffers_size <%= @proxy_busy_buffers_size %>;
+<% end -%>
+<% if @proxy_max_temp_file_size -%>
+  proxy_max_temp_file_size <%= @proxy_max_temp_file_size %>;
+<% end -%>
 <% if @proxy_http_version -%>
   proxy_http_version      <%= @proxy_http_version %>;
 <% end -%>

--- a/templates/server/locations/proxy.erb
+++ b/templates/server/locations/proxy.erb
@@ -18,6 +18,12 @@
 <% if @proxy_buffering -%>
     proxy_buffering       <%= @proxy_buffering %>;
 <% end -%>
+<% if @proxy_busy_buffers_size -%>
+    proxy_busy_buffers_size  <%= @proxy_busy_buffers_size %>;
+<% end -%>
+<% if @proxy_max_temp_file_size -%>
+    proxy_max_temp_file_size <%= @proxy_max_temp_file_size %>;
+<% end -%>
 <% unless @proxy_set_header.nil? -%>
     <%- @proxy_set_header.each do |header| -%>
     proxy_set_header      <%= header %>;


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
We want to be able to manage the following (optional) configuration values:

[proxy_busy_buffers_size](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_busy_buffers_size)
[proxy_max_temp_file_size](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_max_temp_file_size)

With this PR user can modify the above values inside the location-block and also in the main nginx.conf.

#### This Pull Request (PR) fixes the following issues

Fixes #1176

