### PR TITLE
add the log_user with proper value to OpenBSD override section.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -160,6 +160,7 @@ class nginx::params {
         'daemon_user' => 'www',
         'root_group'  => 'wheel',
         'log_dir'     => '/var/www/logs',
+        'log_user'    => 'www',
         'log_group'   => 'wheel',
         'run_dir'     => '/var/www',
       }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Seems about a week ago, $log_user parameter got added, and that broke OpenBSD, since no user 'nginx' exists. Log user is 'www', same as $daemon_user.
Therefore add $log_user to the module_os_overrides section for OpenBSD.


#### This Pull Request (PR) fixes the following issues

Fixes #1259


