### PR TITLE
Archlinux: Set default log user to http

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -101,6 +101,7 @@ class nginx::params {
       $_module_os_overrides = {
         'pid'          => false,
         'daemon_user'  => 'http',
+        'log_user'     => 'http',
         'log_group'    => 'log',
         'package_name' => 'nginx-mainline',
       }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR sets the default log user for Archlinux to `http`, the same user the daemon is running with.

#### This Pull Request (PR) fixes the following issues
The log user being set to `nginx` by default on Archlinux. That user does not exist (contrary to `http`), therefore Puppet wail fail to apply the ownership of the log directory. 