### PR TITLE
Improve example of quick install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This module manages NGINX configuration.
 ### Install and bootstrap an NGINX instance
 
 ```puppet
-class { 'nginx': }
+include nginx
 ```
 
 ### A simple reverse proxy


### PR DESCRIPTION
#### Pull Request (PR) description

Change the example of declaring the nginx class in the README to use `include`.

#### This Pull Request (PR) fixes the following issues
There's really no reason to use the resource-like declaration when
you're not specifying any class parameters. It's cleaner and safer to
use `include`.
