### PR TITLE
allow setting resolver at the http level

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -111,6 +111,7 @@ class nginx::config {
   $proxy_set_header               = $nginx::proxy_set_header
   $proxy_hide_header              = $nginx::proxy_hide_header
   $proxy_pass_header              = $nginx::proxy_pass_header
+  $resolver                       = $nginx::resolver
   $sendfile                       = $nginx::sendfile
   $server_tokens                  = $nginx::server_tokens
   $spdy                           = $nginx::spdy

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,6 +127,7 @@ class nginx (
   Array $proxy_hide_header                                   = [],
   Array $proxy_pass_header                                   = [],
   Array $proxy_ignore_header                                 = [],
+  Optional[Nginx::Resolver] $resolver                        = undef,
   Enum['on', 'off'] $sendfile                                = 'on',
   Enum['on', 'off'] $server_tokens                           = 'on',
   Enum['on', 'off'] $spdy                                    = 'off',

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -574,10 +574,16 @@ describe 'nginx' do
                 match: %r{^\s+resolver 127.0.0.1;}
               },
               {
+                title: 'should set resolver with ipv6 address',
+                attr: 'resolver',
+                value: { 'addresses' => ['FF01::101'] },
+                match: %r{^\s+resolver \[FF01::101\];}
+              },
+              {
                 title: 'should set resolver with setting for ipv6',
                 attr: 'resolver',
-                value: { 'addresses' => ['127.0.0.1'], 'ipv6' => 'on' },
-                match: %r{^\s+resolver 127.0.0.1 ipv6=on;}
+                value: { 'addresses' => ['127.0.0.1'], 'ipv6' => 'off' },
+                match: %r{^\s+resolver 127.0.0.1 ipv6=off;}
               },
               {
                 title: 'should set resolver with setting for valid',
@@ -591,6 +597,13 @@ describe 'nginx' do
                 value: { 'addresses' => [['127.0.0.1', 53]] },
                 match: %r{^\s+resolver 127.0.0.1:53;}
               },
+
+              {
+                title: 'should set resolver with ipv6 address with port',
+                attr: 'resolver',
+                value: { 'addresses' => [['FF01::101', 5353]] },
+                match: %r{^\s+resolver \[FF01::101\]:5353;}
+              },
               {
                 title: 'should set multiple resolvers',
                 attr: 'resolver',
@@ -600,8 +613,8 @@ describe 'nginx' do
               {
                 title: 'should set mixed resolvers with port',
                 attr: 'resolver',
-                value: { 'addresses' => ['127.0.0.1', ['127.0.0.2', 53]] },
-                match: %r{^\s+resolver 127.0.0.1 127.0.0.2:53;}
+                value: { 'addresses' => ['::1', ['127.0.0.1', 54]] },
+                match: %r{^\s+resolver \[::1\] 127.0.0.1:54;}
               },
               {
                 title: 'should set sendfile',

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -562,6 +562,48 @@ describe 'nginx' do
                 match: '  access_log /var/log/nginx/access.log mycustomformat;'
               },
               {
+                title: 'should not set resolver',
+                attr: 'resolver',
+                value: :undef,
+                notmatch: %r{resolver}
+              },
+              {
+                title: 'should set resolver',
+                attr: 'resolver',
+                value: { 'addresses' => ['127.0.0.1'] },
+                match: %r{^\s+resolver 127.0.0.1;}
+              },
+              {
+                title: 'should set resolver with setting for ipv6',
+                attr: 'resolver',
+                value: { 'addresses' => ['127.0.0.1'], 'ipv6' => 'on' },
+                match: %r{^\s+resolver 127.0.0.1 ipv6=on;}
+              },
+              {
+                title: 'should set resolver with setting for valid',
+                attr: 'resolver',
+                value: { 'addresses' => ['127.0.0.1'], 'valid' => '30s' },
+                match: %r{^\s+resolver 127.0.0.1 valid=30s;}
+              },
+              {
+                title: 'should set resolver with port',
+                attr: 'resolver',
+                value: { 'addresses' => [['127.0.0.1', 53]] },
+                match: %r{^\s+resolver 127.0.0.1:53;}
+              },
+              {
+                title: 'should set multiple resolvers',
+                attr: 'resolver',
+                value: { 'addresses' => ['127.0.0.1', 'resolver.example.com'] },
+                match: %r{^\s+resolver 127.0.0.1 resolver.example.com;}
+              },
+              {
+                title: 'should set mixed resolvers with port',
+                attr: 'resolver',
+                value: { 'addresses' => ['127.0.0.1', ['127.0.0.2', 53]] },
+                match: %r{^\s+resolver 127.0.0.1 127.0.0.2:53;}
+              },
+              {
                 title: 'should set sendfile',
                 attr: 'sendfile',
                 value: 'on',

--- a/spec/type_aliases/resolver_spec.rb
+++ b/spec/type_aliases/resolver_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'Nginx::Resolver' do
+  describe 'accepts valid options' do
+    [
+      { 'addresses' => ['localhost'] },
+      { 'addresses' => [['localhost', 443]] },
+      { 'addresses' => ['127.0.0.1', ['localhost', 443]] },
+      { 'addresses' => ['localhost'], 'ipv6' => 'on' },
+      { 'addresses' => ['localhost'], 'valid' => '30s' },
+      { 'addresses' => ['localhost'], 'valid' => '30s', 'ipv6' => 'on' }
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'rejects invalid options' do
+    [
+      '127.0.0.1',
+      {},
+      { 'ipv6' => 'other' },
+      { 'addresses' => [['localhost']] },
+      { 'addresses' => ['localhost'], 'ipv6' => 'other' },
+      { 'addresses' => ['localhost'], 'valid' => 'yes' },
+      :undef
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.not_to allow_value(value) }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/resolveraddress_spec.rb
+++ b/spec/type_aliases/resolveraddress_spec.rb
@@ -6,7 +6,9 @@ describe 'Nginx::ResolverAddress' do
       'localhost',
       '127.0.0.1',
       '8.8.8.8',
-      'www.example.com'
+      'www.example.com',
+      '::1',
+      'FF01::101'
     ].each do |value|
       describe value.inspect do
         it { is_expected.to allow_value(value) }
@@ -19,6 +21,7 @@ describe 'Nginx::ResolverAddress' do
       'localhost:80',
       '1.2.3.4:80',
       '127.0.0.1/32',
+      'FF01:0:0:0:0:0:0:101/32',
       :undef
     ].each do |value|
       describe value.inspect do

--- a/spec/type_aliases/resolveraddress_spec.rb
+++ b/spec/type_aliases/resolveraddress_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'Nginx::ResolverAddress' do
+  describe 'accepts valid options' do
+    [
+      'localhost',
+      '127.0.0.1',
+      '8.8.8.8',
+      'www.example.com'
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'rejects invalid options' do
+    [
+      'localhost:80',
+      '1.2.3.4:80',
+      '127.0.0.1/32',
+      :undef
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.not_to allow_value(value) }
+      end
+    end
+  end
+end

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -92,7 +92,9 @@ http {
   <%- end -%>
 <% end -%>
 <% if @resolver -%>
-  resolver<% @resolver['addresses'].each do |address,port| %> <%= address %><% if port %>:<%= port %><% end %><% end %><% if @resolver['valid'] %> valid=<%= @resolver['valid'] %><% end %><% if @resolver['ipv6'] %> ipv6=<%= @resolver['ipv6'] %><% end %>;
+  resolver<% @resolver['addresses'].each do |address,port| %> <% if address =~ /:/ %>[<%= address %>]<% else %><%= address %><% end %><% if port %>:<%= port %><% end %><% end -%>
+<% if @resolver['valid'] %> valid=<%= @resolver['valid'] %><% end -%>
+<% if @resolver['ipv6'] %> ipv6=<%= @resolver['ipv6'] %><% end %>;
 <% end -%>
   server_tokens <%= @server_tokens %>;
 

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -91,6 +91,9 @@ http {
   tcp_nopush on;
   <%- end -%>
 <% end -%>
+<% if @resolver -%>
+  resolver<% @resolver['addresses'].each do |address,port| %> <%= address %><% if port %>:<%= port %><% end %><% end %><% if @resolver['valid'] %> valid=<%= @resolver['valid'] %><% end %><% if @resolver['ipv6'] %> ipv6=<%= @resolver['ipv6'] %><% end %>;
+<% end -%>
   server_tokens <%= @server_tokens %>;
 
   types_hash_max_size <%= @types_hash_max_size %>;

--- a/types/resolver.pp
+++ b/types/resolver.pp
@@ -1,0 +1,5 @@
+type Nginx::Resolver = Struct[{
+  'addresses' => Array[Variant[Nginx::ResolverAddress,Tuple[Nginx::ResolverAddress, Stdlib::Port]]],
+  'ipv6'      => Optional[Enum['on', 'off']],
+  'valid'     => Optional[Nginx::Time],
+}]

--- a/types/resolveraddress.pp
+++ b/types/resolveraddress.pp
@@ -1,0 +1,4 @@
+type Nginx::ResolverAddress = Variant[
+  Stdlib::Fqdn,
+  Stdlib::IP::Address::V4::Nosubnet, # TODO: add validation/templating support for IPv6
+]

--- a/types/resolveraddress.pp
+++ b/types/resolveraddress.pp
@@ -1,4 +1,4 @@
 type Nginx::ResolverAddress = Variant[
   Stdlib::Fqdn,
-  Stdlib::IP::Address::V4::Nosubnet, # TODO: add validation/templating support for IPv6
+  Stdlib::IP::Address::Nosubnet,
 ]


### PR DESCRIPTION
#### Pull Request (PR) description
Adding support for the resolver directive at the http level.
http://nginx.org/en/docs/http/ngx_http_core_module.html#resolver

#### This Pull Request (PR) fixes the following issues
n/a
