### PR TITLE
Fix the condition for upstream members

### DIFF
--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -134,7 +134,7 @@ define nginx::resource::upstream (
     }),
   }
 
-  if $members != undef {
+  if ! empty($members) {
     $members.each |$member,$values| {
       $member_values = merge($member_defaults,$values,{'upstream' => $name,'context' => $context})
 


### PR DESCRIPTION

#### Pull Request (PR) description
The condition which decides if we have upstream members configurred or
if we import from PuppetDB was wrong. Even if no upstream members are
defined the condition was true. As a result, you couldn't import upstream
members no matter what you configured. Sorry for that

#### This Pull Request (PR) fixes the following issues
Fixes GH-1274
