### PR TITLE
Allow multiple servers per location

### DIFF
--- a/spec/acceptance/nginx_location_spec.rb
+++ b/spec/acceptance/nginx_location_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper_acceptance'
+
+describe 'nginx::resource::location define:' do
+  it 'runs successfully' do
+    pp = "
+    class { 'nginx': }
+    nginx::resource::server { 'www.puppetlabs.com':
+      ensure   => present,
+      www_root => '/var/www/www.puppetlabs.com',
+    }
+    nginx::resource::server { 'stage.puppetlabs.com':
+      ensure   => present,
+      www_root => '/var/www/stage.puppetlabs.com',
+    }
+
+    nginx::resource::location { 'static-production':
+      ensure      => present,
+      server      => 'www.puppetlabs.com',
+      location    => '/media',
+      www_root    => '/var/www/staticfiles/production',
+    }
+    nginx::resource::location { 'static-stage':
+      ensure      => present,
+      server      => 'stage.puppetlabs.com',
+      location    => '/media',
+      www_root    => '/var/www/staticfiles/stage',
+    }
+    nginx::resource::location { 'letsencrypt':
+      ensure      => present,
+      server      => ['www.puppetlabs.com', 'stage.puppetlabs.com'],
+      location    => '/.well-known/acme-challenge/',
+      www_root    => '/var/www/letsencrypt',
+    }
+    "
+    apply_manifest(pp, catch_failures: true)
+  end
+
+  describe file('/etc/nginx/sites-available/www.puppetlabs.com.conf') do
+    it { is_expected.to be_file }
+    it { is_expected.to contain '# MANAGED BY PUPPET' }
+    it { is_expected.to contain '  root      /var/www/www.puppetlabs.com;' }
+    it { is_expected.to contain '  location /media {' }
+    it { is_expected.to contain '    root      /var/www/staticfiles/production;' }
+    it { is_expected.not_to contain '    root      /var/www/staticfiles/stage;' }
+    it { is_expected.to contain '  location /.well-known/acme-challenge/ {' }
+    it { is_expected.to contain '    root      /var/www/letsencrypt;' }
+  end
+  describe file('/etc/nginx/sites-available/stage.puppetlabs.com.conf') do
+    it { is_expected.to be_file }
+    it { is_expected.to contain '# MANAGED BY PUPPET' }
+    it { is_expected.to contain '  root      /var/www/stage.puppetlabs.com;' }
+    it { is_expected.to contain '  location /media {' }
+    it { is_expected.to contain '    root      /var/www/staticfiles/stage;' }
+    it { is_expected.not_to contain '    root      /var/www/staticfiles/production;' }
+    it { is_expected.to contain '  location /.well-known/acme-challenge/ {' }
+    it { is_expected.to contain '    root      /var/www/letsencrypt;' }
+  end
+
+  describe service('nginx') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+
+  describe port(80) do
+    it { is_expected.to be_listening }
+  end
+end

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -33,6 +33,23 @@ describe 'nginx::resource::location' do
           it { is_expected.not_to contain_file('/etc/nginx/rspec-test_htpasswd') }
         end
 
+        describe 'server/location configuration files' do
+          context 'when we have one location and one server' do
+            let(:params) { { location: 'my_location', proxy: 'proxy_value', server: 'server1' } }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest(params[:location].to_s)) }
+            it { is_expected.not_to contain_concat__fragment('server2-500-' + Digest::MD5.hexdigest(params[:location].to_s)) }
+          end
+          context 'when we have one location and two server' do
+            let(:params) { { location: 'my_location', proxy: 'proxy_value', server: %w[server1 server2] } }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_concat__fragment('server1-500-' + Digest::MD5.hexdigest(params[:location].to_s)) }
+            it { is_expected.to contain_concat__fragment('server2-500-' + Digest::MD5.hexdigest(params[:location].to_s)) }
+          end
+        end
+
         describe 'server/location_header template content' do
           [
             {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
By changing the data type, you can now specify multiple servers for
a location. These are then rolled out in a loop. This doesn't break existing installations.

#### This Pull Request (PR) fixes the following issues
Fixes GH-1187
