### PR TITLE
dont deploy "ssl on" on nginx 1.15 or newer (for mailhost)

### DIFF
--- a/spec/acceptance/nginx_mail_spec.rb
+++ b/spec/acceptance/nginx_mail_spec.rb
@@ -25,6 +25,7 @@ describe 'nginx::resource::mailhost define:' do
   describe file('/etc/nginx/conf.mail.d/domain1.example.conf') do
     it { is_expected.to be_file }
     it { is_expected.to contain 'auth_http             localhost/cgi-bin/auth;' }
+    it { is_expected.to contain 'listen                *:465 ssl;' }
   end
 
   describe port(587) do

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -485,7 +485,7 @@ describe 'nginx::resource::mailhost' do
               title: 'should set the IPv4 SSL listen port',
               attr: 'ssl_port',
               value: 45,
-              match: '  listen                *:45;'
+              match: '  listen                *:45 ssl;'
             },
             {
               title: 'should enable IPv6',

--- a/templates/mailhost/mailhost.erb
+++ b/templates/mailhost/mailhost.erb
@@ -38,7 +38,9 @@ server {
 <%- end -%>
 <%= scope.function_template(["nginx/mailhost/mailhost_common.erb"]) -%>
 
+<% if @add_listen_directive -%>
   ssl                   off;
+<% end -%>
   starttls              <%= @starttls %>;
 
 <% if @starttls == 'on' || @starttls == 'only' %>

--- a/templates/mailhost/mailhost_ssl.erb
+++ b/templates/mailhost/mailhost_ssl.erb
@@ -20,10 +20,10 @@ server {
 <% end -%>
 <%- if @listen_ip.is_a?(Array) then -%>
   <%- @listen_ip.each do |ip| -%>
-  listen       <%= ip %>:<%= @ssl_port %>;
+  listen       <%= ip %>:<%= @ssl_port %><% unless @add_listen_directive -%> ssl<% end -%>;
   <%- end -%>
 <%- else -%>
-  listen                <%= @listen_ip %>:<%= @ssl_port %>;
+  listen                <%= @listen_ip %>:<%= @ssl_port %><% unless @add_listen_directive -%> ssl<% end -%>;
 <%- end -%>
 <%# check to see if ipv6 support exists in the kernel before applying -%>
 <%# FIXME this logic is duplicated all over the place -%>
@@ -38,7 +38,9 @@ server {
 <%- end -%>
 <%= scope.function_template(["nginx/mailhost/mailhost_common.erb"]) -%>
 
+<% if @add_listen_directive -%>
   ssl                   on;
+<% end -%>
   starttls              off;
 
 <%= scope.function_template(["nginx/mailhost/mailhost_ssl_settings.erb"]) -%>


### PR DESCRIPTION
#### Pull Request (PR) description
The `ssl` on syntax is deprecated since nginx 1.15.
This PR fixes it for mailhost.

#### This Pull Request (PR) fixes the following issues
fixes #1284