### PR TITLE
remove port from upstream member when service is defined

### DIFF
--- a/manifests/resource/upstream/member.pp
+++ b/manifests/resource/upstream/member.pp
@@ -75,7 +75,7 @@ define nginx::resource::upstream::member (
     default  => "${nginx::config::conf_dir}/conf.d",
   }
 
-  $_server = ($server =~ Pattern[/^unix:\/([^\/\0]+\/*)*$/]) ? {
+  $_server = ($server =~ Pattern[/^unix:\/([^\/\0]+\/*)*$/] or $service != undef) ? {
     true  => $server,
     false => "${server}:${port}",
   }

--- a/spec/defines/resource_upstream_spec.rb
+++ b/spec/defines/resource_upstream_spec.rb
@@ -334,7 +334,7 @@ describe 'nginx::resource::upstream' do
               },
               {
                 value: { member1: { service: 'member1.backend' } },
-                match: 'member1:80 service=member1.backend;'
+                match: 'member1 service=member1.backend;'
               },
               {
                 value: { member1: { slow_start: '20s' } },


### PR DESCRIPTION
The `service`  parameter of the upstream member enables port discovery
via DNS SRV records. When it is used, a server port must not be
specified or nginx will fail with the following error:
```
nginx: [emerg] service upstream may not have port
```
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The PR removes the port from the server directive when the `service`parameter is set and updates the corresponding unit test.

#### This Pull Request (PR) fixes the following issues

Fixes #1282
