### PR TITLE
fix cookie name in http_upstream sticky directive

### DIFF
--- a/spec/defines/resource_upstream_spec.rb
+++ b/spec/defines/resource_upstream_spec.rb
@@ -215,7 +215,7 @@ describe 'nginx::resource::upstream' do
               },
               {
                 value: { sticky: { cookie: { name: 'srv_id', expires: '1h', domain: '.example.com', httponly: true, secure: true, path: '/' } } },
-                match: 'sticky cookie name=srv_id expires=1h domain=.example.com httponly secure path=/'
+                match: 'sticky cookie srv_id expires=1h domain=.example.com httponly secure path=/'
               },
               {
                 value: { sticky: { route: '$route_cookie $route_uri' } },

--- a/templates/upstream/upstream_footer.epp
+++ b/templates/upstream/upstream_footer.epp
@@ -38,7 +38,9 @@
 <% if $sticky { -%>
   <%- $sticky.each |$type,$values| { -%>
     <%- if $type != 'route' { -%>
-  sticky <%= $type %><% $values.each |$key,$value| { %> <%= $key %><% if $value != true { %>=<%= $value %><% } %><% } %>;
+  sticky <%= $type %><%- $values.each |$key,$value| { -%>
+      <%- if $type == 'cookie' and $key == 'name'{ %> <%= $value %><% } else { %> <%= $key %><%- if $value != true { %>=<%= $value %><% } } -%>
+      <%- } -%>;
     <%- } else { -%>
   sticky <%= $type %> <%= $values %>;
     <%- } -%>


### PR DESCRIPTION
#### Pull Request (PR) description
The syntax for the cookie method of the sticky directive in
the ngx_http_upstream_module is:

  sticky cookie name [expires=time] [domain=domain] ...

The cookie name parameter must be specified without 'name=' prefix.

#### This Pull Request (PR) fixes the following issues

Fixes #1285
