### PR TITLE
Update smartos support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,9 +151,21 @@ class nginx::params {
       }
     }
     'Solaris': {
-      $_module_os_overrides = {
-        'daemon_user'  => 'webservd',
-        'package_name' => undef,
+      case $facts['os']['name'] {
+        'SmartOS': {
+          $_module_os_overrides = {
+            'conf_dir'    => '/usr/local/etc/nginx',
+            'daemon_user' => 'www',
+            'log_user'    => 'www',
+            'log_group'   => 'root',
+          }
+        }
+        default: {
+          $_module_os_overrides = {
+            'daemon_user'  => 'webservd',
+            'package_name' => undef,
+          }
+        }
       }
     }
     'OpenBSD': {
@@ -179,12 +191,6 @@ class nginx::params {
     default: {
       ## For cases not covered in $::osfamily
       case $facts['os']['name'] {
-        'SmartOS': {
-          $_module_os_overrides = {
-            'conf_dir'    => '/usr/local/etc/nginx',
-            'daemon_user' => 'www',
-          }
-        }
         default: { $_module_os_overrides = {} }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -154,7 +154,7 @@ class nginx::params {
       case $facts['os']['name'] {
         'SmartOS': {
           $_module_os_overrides = {
-            'conf_dir'    => '/usr/local/etc/nginx',
+            'conf_dir'    => '/opt/local/etc/nginx',
             'daemon_user' => 'www',
             'log_user'    => 'www',
             'log_group'   => 'root',


### PR DESCRIPTION
#### Pull Request (PR) description
Update SmartOS support, which is in the Solaris family.

```
facter -p os
{"name"=>"SmartOS", "family"=>"Solaris", "release"=>{"minor"=>"11", "full"=>"5.11"}}
```

#### This Pull Request (PR) fixes the following issues

SmartOS is in the Solaris family, so was never reaching the `$facts['os']['family']` default case, but instead landing in Solaris.

In addition, `/usr` is read-only on SmartOS, but not Solaris.

Tested on a Base-64 17.4.0-LTS zone, initially setup by 0.9.0 version of this module.
