### PR TITLE
Automatically require SSL cert files in the server

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -445,7 +445,8 @@ define nginx::resource::server (
   if $ssl {
     # Access and error logs are named differently in ssl template
 
-    concat::fragment { "${name_sanitized}-ssl-header":
+    File <| title == $ssl_cert or path == $ssl_cert or title == $ssl_key or path == $ssl_key |>
+    -> concat::fragment { "${name_sanitized}-ssl-header":
       target  => $config_file,
       content => template('nginx/server/server_ssl_header.erb'),
       order   => '700',

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -464,6 +464,18 @@ describe 'nginx::resource::server' do
 
               it { is_expected.to contain_concat__fragment("#{title}-ssl-header").without_content(%r{  ssl on;}) }
             end
+
+            context 'with ssl cert and key definitions' do
+              let(:pre_condition) do
+                <<-PUPPET
+                file { ['/tmp/dummy.key', '/tmp/dummy.crt']: }
+                include nginx
+                PUPPET
+              end
+
+              it { is_expected.to contain_file('/tmp/dummy.key').with_path('/tmp/dummy.key') }
+              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").that_requires(['File[/tmp/dummy.key]', 'File[/tmp/dummy.crt]']) }
+            end
           end
 
           [

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -451,12 +451,12 @@ describe 'nginx::resource::server' do
                 facts[:nginx_version] ? facts.delete(:nginx_version) : facts
               end
 
-              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").without_content(%r{  ssl on;}) }
+              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{  ssl on;}) }
             end
             context 'with fact nginx_version=1.14.1' do
               let(:facts) { facts.merge(nginx_version: '1.14.1') }
 
-              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").without_content(%r{  ssl on;}) }
+              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{  ssl on;}) }
             end
 
             context 'with fact nginx_version=1.15.1' do

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -437,49 +437,35 @@ describe 'nginx::resource::server' do
         end
 
         describe 'server_ssl_header template content' do
-          context 'without a value for the nginx_version fact do' do
-            let :facts do
-              facts[:nginx_version] ? facts.delete(:nginx_version) : facts
-            end
+          context 'with ssl' do
             let :params do
               default_params.merge(
                 ssl: true,
-                ssl_key: 'dummy.key',
-                ssl_cert: 'dummy.crt'
+                ssl_key: '/tmp/dummy.key',
+                ssl_cert: '/tmp/dummy.crt'
               )
             end
 
-            it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{  ssl on;}) }
-          end
-          context 'with fact nginx_version=1.14.1' do
-            let :facts do
-              facts.merge(nginx_version: '1.14.1')
+            context 'without a value for the nginx_version fact do' do
+              let :facts do
+                facts[:nginx_version] ? facts.delete(:nginx_version) : facts
+              end
+
+              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").without_content(%r{  ssl on;}) }
             end
-            let :params do
-              default_params.merge(
-                ssl: true,
-                ssl_key: 'dummy.key',
-                ssl_cert: 'dummy.crt'
-              )
+            context 'with fact nginx_version=1.14.1' do
+              let(:facts) { facts.merge(nginx_version: '1.14.1') }
+
+              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").without_content(%r{  ssl on;}) }
             end
 
-            it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{  ssl on;}) }
+            context 'with fact nginx_version=1.15.1' do
+              let(:facts) { facts.merge(nginx_version: '1.15.1') }
+
+              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").without_content(%r{  ssl on;}) }
+            end
           end
 
-          context 'with fact nginx_version=1.15.1' do
-            let :facts do
-              facts.merge(nginx_version: '1.15.1')
-            end
-            let :params do
-              default_params.merge(
-                ssl: true,
-                ssl_key: 'dummy.key',
-                ssl_cert: 'dummy.crt'
-              )
-            end
-
-            it { is_expected.not_to contain_concat__fragment("#{title}-ssl-header").with_content(%r{  ssl on;}) }
-          end
           [
             {
               title: 'should not contain www to non-www rewrite',


### PR DESCRIPTION
#### Pull Request (PR) description
If you define a file to create the SSL key and/or cert then these should
be in place before nginx uses them. This prevents writing out a
configuration that will not start.

#### This Pull Request (PR) fixes the following issues
Fixes #1295