### PR TITLE
add repo_source for custom Debian repo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -154,6 +154,7 @@ class nginx (
   Boolean $mime_types_preserve_defaults                      = false,
   Optional[String] $repo_release                             = undef,
   $passenger_package_ensure                                  = 'present',
+  $repo_source                                               = undef,
   ### END Package Configuration ###
 
   ### START Service Configuation ###

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -154,7 +154,7 @@ class nginx (
   Boolean $mime_types_preserve_defaults                      = false,
   Optional[String] $repo_release                             = undef,
   $passenger_package_ensure                                  = 'present',
-  $repo_source                                               = undef,
+  Optional[Stdlib::HTTPUrl] $repo_source                     = undef,
   ### END Package Configuration ###
 
   ### START Service Configuation ###

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -22,6 +22,7 @@ class nginx::package::debian {
   $passenger_package_ensure = $nginx::passenger_package_ensure
   $manage_repo              = $nginx::manage_repo
   $release                  = $nginx::repo_release
+  $repo_source              = $nginx::repo_source
 
   $distro = downcase($facts['os']['name'])
 
@@ -36,24 +37,27 @@ class nginx::package::debian {
 
     case $package_source {
       'nginx', 'nginx-stable': {
+        $stable_repo_source = $repo_source ? { undef => "https://nginx.org/packages/${distro}", default => $repo_source }
         apt::source { 'nginx':
-          location => "https://nginx.org/packages/${distro}",
+          location => $stable_repo_source,
           repos    => 'nginx',
           key      => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'},
           release  => $release,
         }
       }
       'nginx-mainline': {
+        $mainline_repo_source = $repo_source ? { undef => "https://nginx.org/packages/mainline/${distro}", default => $repo_source }
         apt::source { 'nginx':
-          location => "https://nginx.org/packages/mainline/${distro}",
+          location => $mainline_repo_source,
           repos    => 'nginx',
           key      => {'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62'},
           release  => $release,
         }
       }
       'passenger': {
+        $passenger_repo_source = $repo_source ? { undef => 'https://oss-binaries.phusionpassenger.com/apt/passenger', default => $repo_source }
         apt::source { 'nginx':
-          location => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
+          location => $passenger_repo_source,
           repos    => 'main',
           key      => {'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7'},
         }

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -37,7 +37,10 @@ class nginx::package::debian {
 
     case $package_source {
       'nginx', 'nginx-stable': {
-        $stable_repo_source = $repo_source ? { undef => "https://nginx.org/packages/${distro}", default => $repo_source }
+        $stable_repo_source = $repo_source ? {
+          undef => "https://nginx.org/packages/${distro}",
+          default => $repo_source,
+        }
         apt::source { 'nginx':
           location => $stable_repo_source,
           repos    => 'nginx',
@@ -46,7 +49,10 @@ class nginx::package::debian {
         }
       }
       'nginx-mainline': {
-        $mainline_repo_source = $repo_source ? { undef => "https://nginx.org/packages/mainline/${distro}", default => $repo_source }
+        $mainline_repo_source = $repo_source ? {
+          undef => "https://nginx.org/packages/mainline/${distro}",
+          default => $repo_source,
+        }
         apt::source { 'nginx':
           location => $mainline_repo_source,
           repos    => 'nginx',
@@ -55,7 +61,10 @@ class nginx::package::debian {
         }
       }
       'passenger': {
-        $passenger_repo_source = $repo_source ? { undef => 'https://oss-binaries.phusionpassenger.com/apt/passenger', default => $repo_source }
+        $passenger_repo_source = $repo_source ? {
+          undef => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
+          default => $repo_source,
+        }
         apt::source { 'nginx':
           location => $passenger_repo_source,
           repos    => 'main',

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 6.0.0"
+      "version_requirement": ">= 5.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/concat",

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -152,6 +152,16 @@ describe 'nginx' do
             end
           end
 
+          context 'repo_source' do
+            let(:params) { { repo_source: 'https://example.com/nginx' } }
+
+            it do
+              is_expected.to contain_apt__source('nginx').with(
+                'location' => 'https://example.com/nginx'
+              )
+            end
+          end
+
           context 'package_source => nginx-mainline' do
             let(:params) { { package_source: 'nginx-mainline' } }
 


### PR DESCRIPTION
#### Pull Request (PR) description
repo_source enables you to set a custom url for the Debian repo.
Unit

This allows you to use your own repo to install Nginx or to use http and cache the packages on your local network.