### PR TITLE
Fix `$nginx_upstream_defaults` type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -180,7 +180,7 @@ class nginx (
   Hash $nginx_streamhosts                                 = {},
   Hash $nginx_streamhosts_defaults                        = {},
   Hash $nginx_upstreams                                   = {},
-  Nginx::UpstreamMemberDefaults $nginx_upstreams_defaults = {},
+  Nginx::UpstreamDefaults $nginx_upstreams_defaults       = {},
   Boolean $purge_passenger_repo                           = true,
   Boolean $add_listen_directive                           = $nginx::params::add_listen_directive,
 


### PR DESCRIPTION
#### Pull Request (PR) description
In my understanding, $nginx_upstream_defaults should be of type UpstreamDefaults, not UpstreamMemberDefaults

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Class[Nginx]: parameter 'nginx_upstream_defaults' unrecognized key 'member_defaults' at /etc/puppetlabs/code/environments/production/private_modules/profile/manifests/nginx.pp:53:3 on node host.example.com
```