### PR TITLE
Param server might also be a default upstream param

### DIFF
--- a/types/upstreammemberdefaults.pp
+++ b/types/upstreammemberdefaults.pp
@@ -1,4 +1,5 @@
 type Nginx::UpstreamMemberDefaults = Struct[{
+  server         => Optional[Nginx::UpstreamMemberServer],
   port           => Optional[Stdlib::Port],
   weight         => Optional[Integer[1]],
   max_conns      => Optional[Integer[1]],


### PR DESCRIPTION
#### Pull Request (PR) description
I don't see a reason, why server shouldn't be a parameter which gets set within member_defaults, e.g. if only the port is changing, this makes the manifest a little bit easier.
