### PR TITLE
overwrite FreeBSD and DragonFlyBSD log_user

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -131,6 +131,7 @@ class nginx::params {
         'daemon_user' => 'www',
         'root_group'  => 'wheel',
         'log_group'   => 'wheel',
+        'log_user'    => 'root',
       }
     }
     'Gentoo': {


### PR DESCRIPTION
Fixes for:
Error: Could not find user nginx
Error: /Stage[main]/Nginx::Config/File[/var/log/nginx]/owner: change from root to nginx failed: Could not find user nginx

On FreeBSD/DFLY default log owner is root
