### PR TITLE
Fix `upstream_context` parameter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ nginx::nginx_streamhosts:
 
 nginx::nginx_upstreams:
   'syslog':
-    upstream_context: 'stream'
+    context: 'stream'
     members:
       '10.0.0.1:514'
         server: '10.0.0.1'


### PR DESCRIPTION
https://github.com/voxpupuli/puppet-nginx/pull/1233 was a breaking
change that amongst other things, renamed this parameter.

Fixes #1316