### PR TITLE
Allow setting a custom path for mime.types

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -82,6 +82,7 @@ class nginx::config {
   $keepalive_requests             = $nginx::keepalive_requests
   $log_format                     = $nginx::log_format
   $mail                           = $nginx::mail
+  $mime_types_path                = $nginx::mime_types_path
   $stream                         = $nginx::stream
   $mime_types                     = $nginx::mime_types_preserve_defaults ? {
     true    => merge($nginx::params::mime_types,$nginx::mime_types),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,6 +96,7 @@ class nginx (
   $keepalive_requests                                        = '100',
   $log_format                                                = {},
   Boolean $mail                                              = false,
+  Variant[String, Boolean] $mime_types_path                  = 'mime.types',
   Boolean $stream                                            = false,
   String $multi_accept                                       = 'off',
   Integer $names_hash_bucket_size                            = 64,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -974,9 +974,15 @@ describe 'nginx' do
           context 'when conf_dir is /path/to/nginx' do
             let(:params) { { conf_dir: '/path/to/nginx' } }
 
-            it { is_expected.to contain_file('/path/to/nginx/nginx.conf').with_content(%r{include       /path/to/nginx/mime\.types;}) }
+            it { is_expected.to contain_file('/path/to/nginx/nginx.conf').with_content(%r{include       mime\.types;}) }
             it { is_expected.to contain_file('/path/to/nginx/nginx.conf').with_content(%r{include /path/to/nginx/conf\.d/\*\.conf;}) }
             it { is_expected.to contain_file('/path/to/nginx/nginx.conf').with_content(%r{include /path/to/nginx/sites-enabled/\*;}) }
+          end
+
+          context 'when mime_types_path is /path/to/mime.types' do
+            let(:params) { { mime_types_path: '/path/to/mime.types' } }
+
+            it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(%r{include       /path/to/mime\.types;}) }
           end
 
           context 'when confd_purge true' do

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -59,7 +59,9 @@ http {
   <%- end -%>
   <%- end -%>
 <% end -%>
-  include       <%= @conf_dir %>/mime.types;
+<% if @mime_types_path.is_a? String and @mime_types_path.empty? == false -%>
+  include       <%= @mime_types_path %>;
+<% end -%>
   default_type  application/octet-stream;
 <% if @log_format -%>
 <% @log_format.sort_by{|k,v| k}.each do |key,value| -%>


### PR DESCRIPTION
In certain environment the user may wish to use mime.types file from
a path other than $conf_dir.

For example when using `conf_dir => '/mnt/gluster/nginx'` and mounting the path into a container at `/etc/nginx`.
The module needs to know the 'real' configuration path because it has to write the files there, but at the same time it can't use this path to substitute the absolute path of the mime.types file, because it is at a different location in the container (here: `/mnt/gluster/nginx/mime.types` vs. `/etc/nginx/mime.types`)