### PR TITLE
Added support for new feature: port ranges

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -5,7 +5,7 @@
 # Parameters:
 #   [*ensure*]                     - Enables or disables the specified server (present|absent)
 #   [*listen_ip*]                  - Default IP Address for NGINX to listen with this server on. Defaults to all interfaces (*)
-#   [*listen_port*]                - Default IP Port for NGINX to listen with this server on. Defaults to TCP 80
+#   [*listen_port*]                - Default IP Port for NGINX to listen with this server on. Defaults to TCP 80. It can be a port or a port range (eg. '8081-8085').
 #   [*listen_options*]             - Extra options for listen directive like 'default_server' to catchall. Undef by default.
 #   [*listen_unix_socket_enable*]  - BOOL value to enable/disable UNIX socket listening support (false|true).
 #   [*listen_unix_socket*]         - Default unix socket for NGINX to listen with this server on. Defaults to UNIX /var/run/nginx.sock
@@ -147,7 +147,7 @@
 define nginx::resource::server (
   Enum['absent', 'present'] $ensure                                              = 'present',
   Variant[Array, String] $listen_ip                                              = '*',
-  Integer $listen_port                                                           = 80,
+  Variant[Integer, String] $listen_port                                          = 80,
   Optional[String] $listen_options                                               = undef,
   Boolean $listen_unix_socket_enable                                             = false,
   Variant[Array[Stdlib::Absolutepath], Stdlib::Absolutepath] $listen_unix_socket = '/var/run/nginx.sock',
@@ -157,7 +157,7 @@ define nginx::resource::server (
   Array $location_deny                                                           = [],
   Boolean $ipv6_enable                                                           = false,
   Variant[Array, String] $ipv6_listen_ip                                         = '::',
-  Integer $ipv6_listen_port                                                      = 80,
+  Variant[Integer, String] $ipv6_listen_port                                     = 80,
   String $ipv6_listen_options                                                    = 'default ipv6only=on',
   Hash $add_header                                                               = {},
   Boolean $ssl                                                                   = false,
@@ -442,7 +442,7 @@ define nginx::resource::server (
   }
 
   # Create SSL File Stubs if SSL is enabled
-  if $ssl {
+  if $ssl and $listen_port !~ String {
     # Access and error logs are named differently in ssl template
 
     File <| title == $ssl_cert or path == $ssl_cert or title == $ssl_key or path == $ssl_key |>

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -8,7 +8,8 @@
 #   [*listen_ip*]           - Default IP Address for NGINX to listen with this
 #     streamhost on. Defaults to all interfaces (*)
 #   [*listen_port*]         - Default IP Port for NGINX to listen with this
-#     streamhost on. Defaults to TCP 80
+#     streamhost on. Defaults to TCP 80. It can be a port or a port range
+#     (eg. '8081-8085').
 #   [*listen_options*]      - Extra options for listen directive like
 #     'default' to catchall. Undef by default.
 #   [*ipv6_enable*]         - BOOL value to enable/disable IPv6 support
@@ -47,23 +48,23 @@
 #    ensure   => present,
 #  }
 define nginx::resource::streamhost (
-  Enum['absent', 'present'] $ensure       = 'present',
-  Variant[Array, String] $listen_ip       = '*',
-  Integer $listen_port                    = 80,
-  Optional[String] $listen_options        = undef,
-  Boolean $ipv6_enable                    = false,
-  Variant[Array, String] $ipv6_listen_ip  = '::',
-  Integer $ipv6_listen_port               = 80,
-  String $ipv6_listen_options             = 'default ipv6only=on',
-  $proxy                                  = undef,
-  String $proxy_read_timeout              = $nginx::proxy_read_timeout,
-  $proxy_connect_timeout                  = $nginx::proxy_connect_timeout,
-  Array $resolver                         = [],
-  $raw_prepend                            = undef,
-  $raw_append                             = undef,
-  String $owner                           = $nginx::global_owner,
-  String $group                           = $nginx::global_group,
-  String $mode                            = $nginx::global_mode,
+  Enum['absent', 'present'] $ensure          = 'present',
+  Variant[Array, String] $listen_ip          = '*',
+  Variant[Integer, String] $listen_port      = 80,
+  Optional[String] $listen_options           = undef,
+  Boolean $ipv6_enable                       = false,
+  Variant[Array, String] $ipv6_listen_ip     = '::',
+  Variant[Integer, String] $ipv6_listen_port = 80,
+  String $ipv6_listen_options                = 'default ipv6only=on',
+  $proxy                                     = undef,
+  String $proxy_read_timeout                 = $nginx::proxy_read_timeout,
+  $proxy_connect_timeout                     = $nginx::proxy_connect_timeout,
+  Array $resolver                            = [],
+  $raw_prepend                               = undef,
+  $raw_append                                = undef,
+  String $owner                              = $nginx::global_owner,
+  String $group                              = $nginx::global_group,
+  String $mode                               = $nginx::global_mode,
 ) {
 
   if ! defined(Class['nginx']) {


### PR DESCRIPTION
#### Pull Request (PR) description
Updated listen_port data type from Integer to Variant[String, Integer] in 'nginx::resource::server' and 'nginx::resource::streamhost' as newer versions of Nginx support port range at listen port.
Please check the release notes from 26th of March: 
- http://nginx.org/en/CHANGES
- https://www.nginx.com/blog/nginx-plus-r18-released#port-ranges
```
Changes with nginx 1.15.10                                       26 Mar 2019

    *) Change: when using a hostname in the "listen" directive nginx now
       creates listening sockets for all addresses the hostname resolves to
       (previously, only the first address was used).

    *) Feature: port ranges in the "listen" directive.
...
```
