### PR TITLE
Enable SSL when requested

### DIFF
--- a/templates/server/server_ssl_settings.erb
+++ b/templates/server/server_ssl_settings.erb
@@ -1,4 +1,4 @@
-<% if @add_listen_directive -%>
+<% if @ssl -%>
   ssl on;
 <% end -%>
 <% if @ssl_cert -%>


### PR DESCRIPTION
Without this change, a true value on nignx::resource::server::ssl does not
result in the 'ssl on' directive necessary to enable SSL in some cases, like
IPv6.  Here we include a fix to adhere to the user request to enable SSL for the
given nginx server.