### PR TITLE
Install libnginx-mod-http-passenger on newer systems

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -127,6 +127,7 @@ class nginx::config {
   $ssl_prefer_server_ciphers      = $nginx::ssl_prefer_server_ciphers
   $ssl_protocols                  = $nginx::ssl_protocols
   $ssl_ciphers                    = $nginx::ssl_ciphers
+  $include_modules_enabled        = $nginx::include_modules_enabled
 
   # Non-configurable settings
   $conf_template                  = 'nginx/conf.d/nginx.conf.erb'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,7 +165,7 @@ class nginx (
   Boolean $mime_types_preserve_defaults                      = false,
   Optional[String] $repo_release                             = undef,
   $passenger_package_ensure                                  = 'present',
-  $passenger_package_name                                    = $nginx::params::passenger_package_name,
+  String $passenger_package_name                             = $nginx::params::passenger_package_name,
   Optional[Stdlib::HTTPUrl] $repo_source                     = undef,
   ### END Package Configuration ###
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class nginx (
   Boolean $super_user                                        = $nginx::params::super_user,
   $temp_dir                                                  = $nginx::params::temp_dir,
   Boolean $server_purge                                      = false,
+  Boolean $include_modules_enabled                           = $nginx::params::include_modules_enabled,
 
   # Primary Templates
   $conf_template                                             = 'nginx/conf.d/nginx.conf.erb',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,6 +165,7 @@ class nginx (
   Boolean $mime_types_preserve_defaults                      = false,
   Optional[String] $repo_release                             = undef,
   $passenger_package_ensure                                  = 'present',
+  $passenger_package_name                                    = $nginx::params::passenger_package_name,
   Optional[Stdlib::HTTPUrl] $repo_source                     = undef,
   ### END Package Configuration ###
 

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -71,9 +71,19 @@ class nginx::package::debian {
           key      => {'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7'},
         }
 
-        package { 'passenger':
-          ensure  => $passenger_package_ensure,
-          require => Exec['apt_update'],
+        # From Ubuntu 18.04/Debian 9 libnginx-mod-http-passenger is needed
+        # libnginx-mod-http-passenger will install passenger as a dependency
+        if ( ($::operatingsystem == 'Ubuntu') and ($facts['os']['release']['major'] >='18')) or
+           ( ($::operatingsystem == 'Debian') and ($facts['os']['release']['major'] >='9')) {
+              package { 'libnginx-mod-http-passenger':
+                ensure  => $passenger_package_ensure,
+                require => Exec['apt_update'],
+              }
+        } else {
+            package { 'passenger':
+              ensure  => $passenger_package_ensure,
+              require => Exec['apt_update'],
+            }
         }
 
         if $package_name != 'nginx-extras' {

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -20,6 +20,7 @@ class nginx::package::debian {
   $package_ensure           = $nginx::package_ensure
   $package_flavor           = $nginx::package_flavor
   $passenger_package_ensure = $nginx::passenger_package_ensure
+  $passenger_package_name   = $nginx::passenger_package_name
   $manage_repo              = $nginx::manage_repo
   $release                  = $nginx::repo_release
   $repo_source              = $nginx::repo_source
@@ -71,19 +72,9 @@ class nginx::package::debian {
           key      => {'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7'},
         }
 
-        # From Ubuntu 18.04/Debian 9 libnginx-mod-http-passenger is needed
-        # libnginx-mod-http-passenger will install passenger as a dependency
-        if ( ($::operatingsystem == 'Ubuntu') and ($facts['os']['release']['major'] >='18')) or
-           ( ($::operatingsystem == 'Debian') and ($facts['os']['release']['major'] >='9')) {
-              package { 'libnginx-mod-http-passenger':
-                ensure  => $passenger_package_ensure,
-                require => Exec['apt_update'],
-              }
-        } else {
-            package { 'passenger':
-              ensure  => $passenger_package_ensure,
-              require => Exec['apt_update'],
-            }
+        package { $passenger_package_name:
+          ensure  => $passenger_package_ensure,
+          require => Exec['apt_update'],
         }
 
         if $package_name != 'nginx-extras' {

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -46,7 +46,7 @@ class nginx::package::redhat {
         }
 
         if $purge_passenger_repo {
-          yumrepo { $passenger_package_name:
+          yumrepo { 'passenger':
             ensure => absent,
             before => Package['nginx'],
           }
@@ -64,7 +64,7 @@ class nginx::package::redhat {
         }
 
         if $purge_passenger_repo {
-          yumrepo { $passenger_package_name:
+          yumrepo { 'passenger':
             ensure => absent,
             before => Package['nginx'],
           }

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -20,6 +20,7 @@ class nginx::package::redhat {
   $package_ensure           = $nginx::package_ensure
   $package_flavor           = $nginx::package_flavor
   $passenger_package_ensure = $nginx::passenger_package_ensure
+  $passenger_package_name   = $nginx::passenger_package_name
   $manage_repo              = $nginx::manage_repo
   $purge_passenger_repo     = $nginx::purge_passenger_repo
 
@@ -45,7 +46,7 @@ class nginx::package::redhat {
         }
 
         if $purge_passenger_repo {
-          yumrepo { 'passenger':
+          yumrepo { $passenger_package_name:
             ensure => absent,
             before => Package['nginx'],
           }
@@ -63,7 +64,7 @@ class nginx::package::redhat {
         }
 
         if $purge_passenger_repo {
-          yumrepo { 'passenger':
+          yumrepo { $passenger_package_name:
             ensure => absent,
             before => Package['nginx'],
           }
@@ -87,7 +88,7 @@ class nginx::package::redhat {
             before => Package['nginx'],
           }
 
-          package { 'passenger':
+          package { $passenger_package_name:
             ensure  => $passenger_package_ensure,
             require => Yumrepo['passenger'],
           }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -233,7 +233,7 @@ class nginx::params {
   $nginx_error_log_file   = 'error.log'
   $root_group             = $_module_parameters['root_group']
   $package_name           = $_module_parameters['package_name']
-  $passanger_package_name = $_module_parameters['passenger_package_name']
+  $passenger_package_name = $_module_parameters['passenger_package_name']
   $proxy_temp_path        = "${run_dir}/proxy_temp"
   $sites_available_owner  = 'root'
   $sites_available_group  = $_module_parameters['root_group']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,19 +7,20 @@ class nginx::params {
   ### Operating System Configuration
   ## This is my hacky... no hiera system. Oh well. :)
   $_module_defaults = {
-    'conf_dir'               => '/etc/nginx',
-    'daemon_user'            => 'nginx',
-    'pid'                    => '/var/run/nginx.pid',
-    'root_group'             => 'root',
-    'log_dir'                => '/var/log/nginx',
-    'log_user'               => 'nginx',
-    'log_group'              => 'root',
-    'log_mode'               => '0750',
-    'run_dir'                => '/var/nginx',
-    'package_name'           => 'nginx',
-    'passenger_package_name' => 'passenger',
-    'manage_repo'            => false,
-    'mime_types'             => {
+    'conf_dir'                => '/etc/nginx',
+    'daemon_user'             => 'nginx',
+    'pid'                     => '/var/run/nginx.pid',
+    'root_group'              => 'root',
+    'log_dir'                 => '/var/log/nginx',
+    'log_user'                => 'nginx',
+    'log_group'               => 'root',
+    'log_mode'                => '0750',
+    'run_dir'                 => '/var/nginx',
+    'package_name'            => 'nginx',
+    'passenger_package_name'  => 'passenger',
+    'manage_repo'             => false,
+    'include_modules_enabled' => false,
+    'mime_types'              => {
       'text/html'                                                                 => 'html htm shtml',
       'text/css'                                                                  => 'css',
       'text/xml'                                                                  => 'xml',
@@ -111,12 +112,13 @@ class nginx::params {
       if ($facts['os']['name'] == 'ubuntu' and $facts['lsbdistcodename'] in ['bionic'])
       or ($facts['os']['name'] == 'debian' and $facts['os']['release']['major'] in ['9']) {
         $_module_os_overrides = {
-          'manage_repo'            => true,
-          'daemon_user'            => 'www-data',
-          'log_user'               => 'root',
-          'log_group'              => 'adm',
-          'log_mode'               => '0755',
-          'passenger_package_name' => 'libnginx-mod-http-passenger',
+          'manage_repo'             => true,
+          'daemon_user'             => 'www-data',
+          'log_user'                => 'root',
+          'log_group'               => 'adm',
+          'log_mode'                => '0755',
+          'passenger_package_name'  => 'libnginx-mod-http-passenger',
+          'include_modules_enabled' => true,
         }
       } elsif ($facts['os']['name'] == 'ubuntu' and $facts['lsbdistcodename'] in ['lucid', 'precise', 'trusty', 'xenial'])
       or ($facts['os']['name'] == 'debian' and $facts['os']['release']['major'] in ['6', '7', '8']) {
@@ -212,32 +214,33 @@ class nginx::params {
   ### END Operating System Configuration
 
   ### Referenced Variables
-  $conf_dir               = $_module_parameters['conf_dir']
-  $snippets_dir           = "${conf_dir}/snippets"
-  $log_dir                = $_module_parameters['log_dir']
-  $log_user               = $_module_parameters['log_user']
-  $log_group              = $_module_parameters['log_group']
-  $log_mode               = $_module_parameters['log_mode']
-  $run_dir                = $_module_parameters['run_dir']
-  $temp_dir               = '/tmp'
-  $pid                    = $_module_parameters['pid']
+  $conf_dir                = $_module_parameters['conf_dir']
+  $snippets_dir            = "${conf_dir}/snippets"
+  $log_dir                 = $_module_parameters['log_dir']
+  $log_user                = $_module_parameters['log_user']
+  $log_group               = $_module_parameters['log_group']
+  $log_mode                = $_module_parameters['log_mode']
+  $run_dir                 = $_module_parameters['run_dir']
+  $temp_dir                = '/tmp'
+  $pid                     = $_module_parameters['pid']
+  $include_modules_enabled = $_module_parameters['include_modules_enabled']
 
-  $client_body_temp_path  = "${run_dir}/client_body_temp"
-  $daemon_user            = $_module_parameters['daemon_user']
-  $global_owner           = 'root'
-  $global_group           = $_module_parameters['root_group']
-  $global_mode            = '0644'
-  $http_access_log_file   = 'access.log'
-  $manage_repo            = $_module_parameters['manage_repo']
-  $mime_types             = $_module_parameters['mime_types']
-  $nginx_error_log_file   = 'error.log'
-  $root_group             = $_module_parameters['root_group']
-  $package_name           = $_module_parameters['package_name']
-  $passenger_package_name = $_module_parameters['passenger_package_name']
-  $proxy_temp_path        = "${run_dir}/proxy_temp"
-  $sites_available_owner  = 'root'
-  $sites_available_group  = $_module_parameters['root_group']
-  $sites_available_mode   = '0644'
-  $super_user             = true
+  $client_body_temp_path   = "${run_dir}/client_body_temp"
+  $daemon_user             = $_module_parameters['daemon_user']
+  $global_owner            = 'root'
+  $global_group            = $_module_parameters['root_group']
+  $global_mode             = '0644'
+  $http_access_log_file    = 'access.log'
+  $manage_repo             = $_module_parameters['manage_repo']
+  $mime_types              = $_module_parameters['mime_types']
+  $nginx_error_log_file    = 'error.log'
+  $root_group              = $_module_parameters['root_group']
+  $package_name            = $_module_parameters['package_name']
+  $passenger_package_name  = $_module_parameters['passenger_package_name']
+  $proxy_temp_path         = "${run_dir}/proxy_temp"
+  $sites_available_owner   = 'root'
+  $sites_available_group   = $_module_parameters['root_group']
+  $sites_available_mode    = '0644'
+  $super_user              = true
   ### END Referenced Variables
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -212,31 +212,32 @@ class nginx::params {
   ### END Operating System Configuration
 
   ### Referenced Variables
-  $conf_dir              = $_module_parameters['conf_dir']
-  $snippets_dir          = "${conf_dir}/snippets"
-  $log_dir               = $_module_parameters['log_dir']
-  $log_user              = $_module_parameters['log_user']
-  $log_group             = $_module_parameters['log_group']
-  $log_mode              = $_module_parameters['log_mode']
-  $run_dir               = $_module_parameters['run_dir']
-  $temp_dir              = '/tmp'
-  $pid                   = $_module_parameters['pid']
+  $conf_dir               = $_module_parameters['conf_dir']
+  $snippets_dir           = "${conf_dir}/snippets"
+  $log_dir                = $_module_parameters['log_dir']
+  $log_user               = $_module_parameters['log_user']
+  $log_group              = $_module_parameters['log_group']
+  $log_mode               = $_module_parameters['log_mode']
+  $run_dir                = $_module_parameters['run_dir']
+  $temp_dir               = '/tmp'
+  $pid                    = $_module_parameters['pid']
 
-  $client_body_temp_path = "${run_dir}/client_body_temp"
-  $daemon_user           = $_module_parameters['daemon_user']
-  $global_owner          = 'root'
-  $global_group          = $_module_parameters['root_group']
-  $global_mode           = '0644'
-  $http_access_log_file  = 'access.log'
-  $manage_repo           = $_module_parameters['manage_repo']
-  $mime_types            = $_module_parameters['mime_types']
-  $nginx_error_log_file  = 'error.log'
-  $root_group            = $_module_parameters['root_group']
-  $package_name          = $_module_parameters['package_name']
-  $proxy_temp_path       = "${run_dir}/proxy_temp"
-  $sites_available_owner = 'root'
-  $sites_available_group = $_module_parameters['root_group']
-  $sites_available_mode  = '0644'
-  $super_user            = true
+  $client_body_temp_path  = "${run_dir}/client_body_temp"
+  $daemon_user            = $_module_parameters['daemon_user']
+  $global_owner           = 'root'
+  $global_group           = $_module_parameters['root_group']
+  $global_mode            = '0644'
+  $http_access_log_file   = 'access.log'
+  $manage_repo            = $_module_parameters['manage_repo']
+  $mime_types             = $_module_parameters['mime_types']
+  $nginx_error_log_file   = 'error.log'
+  $root_group             = $_module_parameters['root_group']
+  $package_name           = $_module_parameters['package_name']
+  $passanger_package_name = $_module_parameters['passenger_package_name']
+  $proxy_temp_path        = "${run_dir}/proxy_temp"
+  $sites_available_owner  = 'root'
+  $sites_available_group  = $_module_parameters['root_group']
+  $sites_available_mode   = '0644'
+  $super_user             = true
   ### END Referenced Variables
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,18 +7,19 @@ class nginx::params {
   ### Operating System Configuration
   ## This is my hacky... no hiera system. Oh well. :)
   $_module_defaults = {
-    'conf_dir'     => '/etc/nginx',
-    'daemon_user'  => 'nginx',
-    'pid'          => '/var/run/nginx.pid',
-    'root_group'   => 'root',
-    'log_dir'      => '/var/log/nginx',
-    'log_user'     => 'nginx',
-    'log_group'    => 'root',
-    'log_mode'     => '0750',
-    'run_dir'      => '/var/nginx',
-    'package_name' => 'nginx',
-    'manage_repo'  => false,
-    'mime_types'   => {
+    'conf_dir'               => '/etc/nginx',
+    'daemon_user'            => 'nginx',
+    'pid'                    => '/var/run/nginx.pid',
+    'root_group'             => 'root',
+    'log_dir'                => '/var/log/nginx',
+    'log_user'               => 'nginx',
+    'log_group'              => 'root',
+    'log_mode'               => '0750',
+    'run_dir'                => '/var/nginx',
+    'package_name'           => 'nginx',
+    'passenger_package_name' => 'passenger',
+    'manage_repo'            => false,
+    'mime_types'             => {
       'text/html'                                                                 => 'html htm shtml',
       'text/css'                                                                  => 'css',
       'text/xml'                                                                  => 'xml',
@@ -107,8 +108,18 @@ class nginx::params {
       }
     }
     'Debian': {
-      if ($facts['os']['name'] == 'ubuntu' and $facts['lsbdistcodename'] in ['lucid', 'precise', 'trusty', 'xenial', 'bionic'])
-      or ($facts['os']['name'] == 'debian' and $facts['os']['release']['major'] in ['6', '7', '8', '9']) {
+      if ($facts['os']['name'] == 'ubuntu' and $facts['lsbdistcodename'] in ['bionic'])
+      or ($facts['os']['name'] == 'debian' and $facts['os']['release']['major'] in ['9']) {
+        $_module_os_overrides = {
+          'manage_repo'            => true,
+          'daemon_user'            => 'www-data',
+          'log_user'               => 'root',
+          'log_group'              => 'adm',
+          'log_mode'               => '0755',
+          'passenger_package_name' => 'libnginx-mod-http-passenger',
+        }
+      } elsif ($facts['os']['name'] == 'ubuntu' and $facts['lsbdistcodename'] in ['lucid', 'precise', 'trusty', 'xenial'])
+      or ($facts['os']['name'] == 'debian' and $facts['os']['release']['major'] in ['6', '7', '8']) {
         $_module_os_overrides = {
           'manage_repo' => true,
           'daemon_user' => 'www-data',

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -8,7 +8,7 @@ describe 'nginx class:' do
     pkg_match = %r{passenger}
   when 'Debian'
     pkg_cmd = 'dpkg -s nginx | grep ^Maintainer'
-    pkg_remove_cmd = 'apt-get -y remove nginx nginx-common'
+    pkg_remove_cmd = 'apt-get -y purge nginx nginx-common'
     pkg_match = case fact('operatingsystemmajrelease')
                 when '9'
                   %r{Debian Nginx Maintainers}

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -20,6 +20,9 @@ worker_rlimit_nofile <%= @worker_rlimit_nofile %>;
 <% if @pid -%>
 pid        <%= @pid %>;
 <% end -%>
+<% if @include_modules_enabled -%>
+include /etc/nginx/modules-enabled/*.conf;
+<% end -%>
 <% if @nginx_cfg_prepend -%>
 
 <%- field_width = @nginx_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>


### PR DESCRIPTION
#### Pull Request (PR) description
On Debian 9 & Ubuntu 18.04 libnginx-mod-http-passenger needs to be
installed instead of passenger according to the installation guide by
passenger. libnginx-mod-http-passenger has a dependency on passenger, so
it will be installed. Without libnginx-mod-http-passenger nginx will not
be able to handle passenger.

Installation guide:
https://www.phusionpassenger.com/docs/tutorials/deploy_to_production/installations/oss/ownserver/ruby/nginx/


#### This Pull Request (PR) fixes the following issues
Fixes #1340 
