### PR TITLE
Add ssl_password_file directive to support encrypted ssl keys

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -188,7 +188,7 @@ define nginx::resource::server (
   Optional[String] $ssl_session_ticket_key                                       = undef,
   Optional[String] $ssl_trusted_cert                                             = undef,
   Optional[Integer] $ssl_verify_depth                                            = undef,
-  Optional[String] $ssl_password_file                                            = undef,
+  Optional[Stdlib::Absolutepath] $ssl_password_file                              = undef,
   Enum['on', 'off'] $spdy                                                        = $nginx::spdy,
   Enum['on', 'off'] $http2                                                       = $nginx::http2,
   Optional[String] $proxy                                                        = undef,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -71,6 +71,7 @@
 #   [*ssl_trusted_cert*]           - String: Specifies a file with trusted CA certificates in the PEM format used to verify client
 #     certificates and OCSP responses if ssl_stapling is enabled.
 #   [*ssl_verify_depth*]           - Integer: Sets the verification depth in the client certificates chain.
+#   [*ssl_password_file*]          - String: File containing the password for the SSL Key file.
 #   [*spdy*]                       - Toggles SPDY protocol.
 #   [*http2*]                      - Toggles HTTP/2 protocol.
 #   [*server_name*]                - List of servernames for which this server will respond. Default [$name].
@@ -187,6 +188,7 @@ define nginx::resource::server (
   Optional[String] $ssl_session_ticket_key                                       = undef,
   Optional[String] $ssl_trusted_cert                                             = undef,
   Optional[Integer] $ssl_verify_depth                                            = undef,
+  Optional[String] $ssl_password_file                                            = undef,
   Enum['on', 'off'] $spdy                                                        = $nginx::spdy,
   Enum['on', 'off'] $http2                                                       = $nginx::http2,
   Optional[String] $proxy                                                        = undef,

--- a/spec/acceptance/nginx_server_spec.rb
+++ b/spec/acceptance/nginx_server_spec.rb
@@ -134,7 +134,7 @@ describe 'nginx::resource::server define:' do
 
     describe file('/etc/nginx/sites-available/www.puppetlabs.com.conf') do
       it { is_expected.to be_file }
-      it { is_expected.to_contain 'ssl_password_file         /etc/pki/tls/private/crypted.pass;' }
+      it { is_expected.to contain 'ssl_password_file         /etc/pki/tls/private/crypted.pass;' }
     end
 
     describe service('nginx') do

--- a/spec/acceptance/nginx_server_spec.rb
+++ b/spec/acceptance/nginx_server_spec.rb
@@ -134,7 +134,7 @@ describe 'nginx::resource::server define:' do
 
     describe file('/etc/nginx/sites-available/www.puppetlabs.com.conf') do
       it { is_expected.to be_file }
-      it { is_expected.to_contain 'ssl_password_file         /etc/pki/tls/private/crypted.pass;'}
+      it { is_expected.to_contain 'ssl_password_file         /etc/pki/tls/private/crypted.pass;' }
     end
 
     describe service('nginx') do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -67,7 +67,11 @@ HLw/FDCzntkdq3G4em15CdFlO9BTY4HXiHU=
 
       # put the keys in a directory with the correct SELinux context
       on host, 'cp /tmp/blah.cert /etc/pki/tls/certs/blah.cert'
+      on host, 'cp /tmp/blah.cert /etc/pki/tls/certs/crypted.cert'
       on host, 'cp /tmp/blah.key /etc/pki/tls/private/blah.key'
+      on host, 'openssl rsa -in /tmp/blah.key -out /etc/pki/tls/private/crypted.key -passout pass:Sup3r_S3cr3t_Passw0rd'
+      on host, 'echo Sup3r_S3cr3t_Passw0rd >/etc/pki/tls/private/crypted.pass'
+      on host, 'chmod 0600 /etc/pki/tls/private/crypted.pass'
     end
   end
 end

--- a/templates/server/server_ssl_settings.erb
+++ b/templates/server/server_ssl_settings.erb
@@ -53,4 +53,7 @@
   <%- if @ssl_verify_depth -%>
   ssl_verify_depth          <%= @ssl_verify_depth %>;
   <%- end -%>
+  <%- if @ssl_password_file -%>
+  ssl_password_file         <%= @ssl_password_file %>;
+  <%- end -%>
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
This pull request adds support for the ssl_password_file directive of nginx. This directive is needed, if the ssl key file is password encrypted (should be standard nowadays).

#### This Pull Request (PR) fixes the following issues
n/a (I didn't create an issue first but tried to not only raise a request but also deliver the solution)