### PR TITLE
Move ssl_redirect into a location

### DIFF
--- a/spec/acceptance/nginx_server_spec.rb
+++ b/spec/acceptance/nginx_server_spec.rb
@@ -159,4 +159,89 @@ describe 'nginx::resource::server define:' do
       end
     end
   end
+
+  context 'should run successfully with ssl_redirect' do
+    it 'configures a nginx SSL server' do
+      pp = "
+      class { 'nginx': }
+      nginx::resource::server { 'www.puppetlabs.com':
+        ensure       => present,
+        ssl          => true,
+        ssl_cert     => '/etc/pki/tls/certs/blah.cert',
+        ssl_key      => '/etc/pki/tls/private/blah.key',
+        ssl_redirect => true,
+        www_root     => '/var/www/www.puppetlabs.com',
+      }
+      nginx::resource::location { 'letsencrypt':
+        location    => '^~ /.well-known/acme-challenge',
+        www_root    => '/var/www/letsencrypt',
+        index_files => [],
+        ssl         => false,
+        server      => ['www.puppetlabs.com'],
+      }
+      host { 'www.puppetlabs.com': ip => '127.0.0.1', }
+      file { ['/var/www','/var/www/www.puppetlabs.com','/var/www/letsencrypt','/var/www/letsencrypt/.well-known','/var/www/letsencrypt/.well-known/acme-challenge']: ensure => directory }
+      file { '/var/www/www.puppetlabs.com/index.html': ensure  => file, content => 'Hello from www\n', }
+      file { '/var/www/letsencrypt/.well-known/acme-challenge/fb9bd98604be3d0c7d589fcc7561cb41': ensure  => file, content => 'LetsEncrypt\n', }
+      "
+
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    describe file('/etc/nginx/sites-available/www.puppetlabs.com.conf') do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'return 301 https://$host$request_uri;' }
+    end
+
+    describe service('nginx') do
+      it { is_expected.to be_running }
+    end
+
+    describe port(80) do
+      it { is_expected.to be_listening }
+    end
+
+    describe port(443) do
+      it { is_expected.to be_listening }
+    end
+
+    it 'answers to http://www.puppetlabs.com with redirect to HTTPS' do
+      shell('/usr/bin/curl -I http://www.puppetlabs.com:80') do |r|
+        expect(r.stdout).to contain('301 Moved Permanently')
+      end
+    end
+
+    it 'answers to http://www.puppetlabs.com with redirect to HTTPS' do
+      shell('/usr/bin/curl -I http://www.puppetlabs.com:80') do |r|
+        expect(r.stdout).to contain('Location: https://www.puppetlabs.com')
+      end
+    end
+
+    it 'answers to http://www.puppetlabs.com without error' do
+      shell('/usr/bin/curl --fail http://www.puppetlabs.com:80') do |r|
+        expect(r.exit_code).to eq(0)
+      end
+    end
+
+    it 'answers to https://www.puppetlabs.com with "Hello from www"' do
+      # use --insecure because it's a self-signed cert
+      shell('/usr/bin/curl --insecure https://www.puppetlabs.com:443') do |r|
+        expect(r.stdout).to eq("Hello from www\n")
+      end
+    end
+
+    it 'answers to http://www.puppetlabs.com/.well-known/acme-challenge/fb9bd98604be3d0c7d589fcc7561cb41 with "LetsEncrypt"' do
+      # use --insecure because it's a self-signed cert
+      shell('/usr/bin/curl http://www.puppetlabs.com:80/.well-known/acme-challenge/fb9bd98604be3d0c7d589fcc7561cb41') do |r|
+        expect(r.stdout).to eq("LetsEncrypt\n")
+      end
+    end
+
+    it 'answers to https://www.puppetlabs.com/.well-known/acme-challenge/fb9bd98604be3d0c7d589fcc7561cb41 with "LetsEncrypt"' do
+      # use --insecure because it's a self-signed cert
+      shell('/usr/bin/curl --insecure https://www.puppetlabs.com:443/.well-known/acme-challenge/fb9bd98604be3d0c7d589fcc7561cb41') do |r|
+        expect(r.stdout).to contain('404 Not Found')
+      end
+    end
+  end
 end

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -1097,7 +1097,7 @@ describe 'nginx::resource::server' do
             let(:params) { { ssl_redirect: true } }
 
             it { is_expected.to contain_concat__fragment("#{title}-header").without_content(%r{^\s*index\s+}) }
-            it { is_expected.to contain_concat__fragment("#{title}-header").without_content(%r{^\s*location\s+}) }
+            it { is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{    return 301 https://\$host\$request_uri;}) }
           end
 
           context 'ssl_redirect with alternate port' do

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -134,9 +134,6 @@ server {
 <% if @maintenance -%>
   <%= @maintenance_value %>;
 <% end -%>
-<% if @ssl_redirect -%>
-  return 301 https://$host<% if @_ssl_redirect_port.to_i != 443 %>:<%= @_ssl_redirect_port %><% end %>$request_uri;
-<% end -%>
 <% if @index_files and @index_files.count > 0 and not @ssl_only -%>
   index <% Array(@index_files).each do |i| %> <%= i %><% end %>;
 <% end -%>
@@ -179,4 +176,10 @@ server {
   <%- @error_pages.keys.sort.each do |key| -%>
   error_page  <%= key %> <%= @error_pages[key] %>;
   <%- end -%>
+<% end -%>
+<% if @ssl_redirect -%>
+
+  location / {
+    return 301 https://$host<% if @_ssl_redirect_port.to_i != 443 %>:<%= @_ssl_redirect_port %><% end %>$request_uri;
+  }
 <% end -%>


### PR DESCRIPTION
Fixes GH-1347

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This makes it possible to define locations that are accepted over HTTP and only forward everything else to HTTPS. This allows, for example, to configure something like this:
```
nginx::resource::server { 'www.puppetlabs.com':
  ensure       => present,
  ssl          => true,
  ssl_cert     => '/etc/pki/tls/certs/blah.cert',
  ssl_key      => '/etc/pki/tls/private/blah.key',
  ssl_redirect => true,
  www_root     => '/var/www/www.puppetlabs.com',
}

nginx::resource::location { 'letsencrypt':
  location    => '^~ /.well-known/acme-challenge/',
  www_root    => '/var/www/letsencrypt',
  index_files => [],
  ssl         => false,
  server      => ['www.puppetlabs.com'],
}
```

Which results in a server accepting LetsEncrypt Challanges on HTTP and redirect everything else to HTTPS.

#### This Pull Request (PR) fixes the following issues
Fixes #1347
