### PR TITLE
Debian run_dir should be in /var/run/nginx

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -115,6 +115,7 @@ class nginx::params {
           'log_user'    => 'root',
           'log_group'   => 'adm',
           'log_mode'    => '0755',
+          'run_dir'     => '/run/nginx',
         }
       } else {
         $_module_os_overrides = {
@@ -122,6 +123,7 @@ class nginx::params {
           'log_user'    => 'root',
           'log_group'   => 'adm',
           'log_mode'    => '0755',
+          'run_dir'     => '/run/nginx',
         }
       }
     }

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -299,26 +299,54 @@ describe 'nginx' do
             )
           end
           it do
-            is_expected.to contain_file('/var/nginx').with(
-              ensure: 'directory',
-              owner: 'root',
-              group: 'root',
-              mode: '0644'
-            )
+            case facts[:osfamily]
+            when 'Debian'
+              is_expected.to contain_file('/run/nginx').with(
+                ensure: 'directory',
+                owner: 'root',
+                group: 'root',
+                mode: '0644'
+              )
+            else
+              is_expected.to contain_file('/var/nginx').with(
+                ensure: 'directory',
+                owner: 'root',
+                group: 'root',
+                mode: '0644'
+              )
+            end
           end
           it do
-            is_expected.to contain_file('/var/nginx/client_body_temp').with(
-              ensure: 'directory',
-              group: 'root',
-              mode: '0644'
-            )
+            case facts[:osfamily]
+            when 'Debian'
+              is_expected.to contain_file('/run/nginx/client_body_temp').with(
+                ensure: 'directory',
+                group: 'root',
+                mode: '0644'
+              )
+            else
+              is_expected.to contain_file('/var/nginx/client_body_temp').with(
+                ensure: 'directory',
+                group: 'root',
+                mode: '0644'
+              )
+            end
           end
           it do
-            is_expected.to contain_file('/var/nginx/proxy_temp').with(
-              ensure: 'directory',
-              group: 'root',
-              mode: '0644'
-            )
+            case facts[:osfamily]
+            when 'Debian'
+              is_expected.to contain_file('/run/nginx/proxy_temp').with(
+                ensure: 'directory',
+                group: 'root',
+                mode: '0644'
+              )
+            else
+              is_expected.to contain_file('/var/nginx/proxy_temp').with(
+                ensure: 'directory',
+                group: 'root',
+                mode: '0644'
+              )
+            end
           end
           it do
             is_expected.to contain_file('/etc/nginx/nginx.conf').with(
@@ -364,8 +392,8 @@ describe 'nginx' do
               )
             end
           when 'Debian'
-            it { is_expected.to contain_file('/var/nginx/client_body_temp').with(owner: 'www-data') }
-            it { is_expected.to contain_file('/var/nginx/proxy_temp').with(owner: 'www-data') }
+            it { is_expected.to contain_file('/run/nginx/client_body_temp').with(owner: 'www-data') }
+            it { is_expected.to contain_file('/run/nginx/proxy_temp').with(owner: 'www-data') }
             it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content %r{^user www-data;} }
             it do
               is_expected.to contain_file('/var/log/nginx').with(
@@ -1146,8 +1174,14 @@ describe 'nginx' do
           context 'when daemon_user = www-data' do
             let(:params) { { daemon_user: 'www-data' } }
 
-            it { is_expected.to contain_file('/var/nginx/client_body_temp').with(owner: 'www-data') }
-            it { is_expected.to contain_file('/var/nginx/proxy_temp').with(owner: 'www-data') }
+            case facts[:osfamily]
+            when 'Debian'
+              it { is_expected.to contain_file('/run/nginx/client_body_temp').with(owner: 'www-data') }
+              it { is_expected.to contain_file('/run/nginx/proxy_temp').with(owner: 'www-data') }
+            else
+              it { is_expected.to contain_file('/var/nginx/client_body_temp').with(owner: 'www-data') }
+              it { is_expected.to contain_file('/var/nginx/proxy_temp').with(owner: 'www-data') }
+            end
             it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content %r{^user www-data;} }
           end
 


### PR DESCRIPTION
I am not sure if it's correct anywhere else, but at the very least on
Debian, the "run dir" is *not* /var/nginx, but /var/run/nginx. That
seems like a better default everywhere, but I'm just going to scratch
that itch for now.

Ideally, this would actually be in /run/nginx since that's the new
standard (and the default in the Debian package), but I suspect this
will not work properly in older Debian releases (e.g. 7) still marked
as supported here.

This is important because /var is a real, on-disk, filesystem while /var/run points to /run which is a tmpfs, and therefore much faster.

This is a WIP because I suspect tests will fail with just this naive commit, but gotta start the conversation somewhere.