### PR TITLE
CentOS: Add it back to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -42,6 +42,13 @@
       ]
     },
     {
+      "operatingsystem": "CentOS",
+        "operatingsystemrelease": [
+          "6",
+          "7"
+        ]
+    },
+    {
       "operatingsystem": "SLES"
     },
     {


### PR DESCRIPTION
Somewhere in the refactoring we lost this. This module always supported
CentOS6/7.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
