### PR TITLE
Mock facter version based on puppet version & unit tests: print puppet/facter version

### DIFF
--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nginx' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
       let(:facts) do
         facts
       end

--- a/spec/defines/resource_geo_spec.rb
+++ b/spec/defines/resource_geo_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nginx::resource::geo' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
       let(:facts) do
         facts
       end

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -3,7 +3,7 @@ require 'digest/md5'
 
 describe 'nginx::resource::location' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
       let(:facts) do
         facts
       end

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nginx::resource::mailhost' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
       let(:facts) do
         facts
       end

--- a/spec/defines/resource_map_spec.rb
+++ b/spec/defines/resource_map_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nginx::resource::map' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
       let(:facts) do
         facts
       end

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nginx::resource::server' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
       let(:facts) do
         facts
       end

--- a/spec/defines/resource_snippet_spec.rb
+++ b/spec/defines/resource_snippet_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nginx::resource::snippet' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
       let(:facts) do
         facts
       end

--- a/spec/defines/resource_stream_spec.rb
+++ b/spec/defines/resource_stream_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nginx::resource::streamhost' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
       let(:facts) do
         facts
       end

--- a/spec/defines/resource_upstream_spec.rb
+++ b/spec/defines/resource_upstream_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'nginx::resource::upstream' do
   on_supported_os.each do |os, facts|
-    context "on #{os}" do
+    context "on #{os} with Facter #{facts[:facterversion]} and Puppet #{facts[:puppetversion]}" do
       let(:facts) do
         facts
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,18 @@ if Dir.exist?(File.expand_path('../../lib', __FILE__))
 end
 
 RSpec.configure do |c|
+  # getting the correct facter version is tricky. We use facterdb as a source to mock facts
+  # see https://github.com/camptocamp/facterdb
+  # people might provide a specific facter version. In that case we use it.
+  # Otherwise we need to match the correct facter version to the used puppet version.
+  # as of 2019-10-31, puppet 5 ships facter 3.11 and puppet 6 ships facter 3.14
+  # https://puppet.com/docs/puppet/5.5/about_agent.html
+  c.default_facter_version = if ENV['FACTERDB_FACTS_VERSION']
+                               ENV['FACTERDB_FACTS_VERSION']
+                             else
+                               Gem::Dependency.new('', ENV['PUPPET_VERSION']).match?('', '5') ? '3.11.0' : '3.14.0'
+                             end
+
   # Coverage generation
   c.after(:suite) do
     RSpec::Puppet::Coverage.report!


### PR DESCRIPTION
Getting the correct facter version is tricky. We use facterdb as a source to mock facts see https://github.com/camptocamp/facterdb. People might provide a specific facter version.  In that case we use it. Otherwise we need to match the correct facter version to the used puppet version. As of 2019-10-31, puppet 5 ships facter 3.11 and puppet 6 ships facter 3.14 (see https://puppet.com/docs/puppet/5.5/about_agent.html).