### PR TITLE
Fix rewrite_non_www_to_www when using SSL

### DIFF
--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -389,7 +389,7 @@ describe 'nginx::resource::server' do
             end
           end
 
-          context 'with a naked domain title' do
+          context 'with a naked domain title over http' do
             let(:title) { 'rspec.example.com' }
 
             [
@@ -441,6 +441,64 @@ describe 'nginx::resource::server' do
                   end
                   Array(param[:notmatch]).each do |item|
                     is_expected.to contain_concat__fragment("#{title}-header").without_content(item)
+                  end
+                end
+              end
+            end
+          end
+
+          context 'with a naked domain title over https' do
+            let(:title) { 'rspec.example.com' }
+
+            [
+              {
+                title: 'should not contain non-www to www rewrite',
+                attr: 'rewrite_non_www_to_www',
+                value: false,
+                notmatch: %r{
+                ^
+                \s+server_name\s+rspec\.example\.com;\n
+                \s+return\s+301\s+https://www\.rspec\.example\.com\$request_uri;
+                }x
+              },
+              {
+                title: 'should contain non-www to www rewrite',
+                attr: 'rewrite_non_www_to_www',
+                value: true,
+                match: %r{
+                ^
+                \s+server_name\s+rspec\.example\.com;\n
+                \s+return\s+301\s+https://www\.rspec\.example\.com\$request_uri;
+                }x
+              },
+              {
+                title: 'should rewrite non-www servername to www',
+                attr: 'rewrite_non_www_to_www',
+                value: true,
+                match: %r{\s+server_name\s+www.rspec.example.com;}
+              },
+              {
+                title: 'should not rewrite non-www servername to www',
+                attr: 'rewrite_non_www_to_www',
+                value: false,
+                notmatch: %r{\s+server_name\s+www.rspec.example.com;}
+              }
+            ].each do |param|
+              context "when #{param[:attr]} is #{param[:value]}" do
+                let(:params) { default_params.merge(param[:attr].to_sym => param[:value], ssl: true, ssl_cert: '/tmp/dummy.crt', ssl_key: '/tmp/dummy.key', listen_port: 443) }
+
+                it { is_expected.to contain_concat__fragment("#{title}-ssl-header") }
+                it param[:title] do
+                  matches = Array(param[:match])
+
+                  if matches.all? { |m| m.is_a? Regexp }
+                    matches.each { |item| is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(item) }
+                  else
+                    lines = catalogue.resource('concat::fragment', "#{title}-ssl-header").send(:parameters)[:content].split("\n")
+                    expect(lines & Array(param[:match])).to eq(Array(param[:match]))
+                  end
+                  Array(param[:notmatch]).each do |item|
+                    is_expected.to contain_concat__fragment("#{title}-ssl-header").without_content(item)
                   end
                 end
               end

--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -33,7 +33,13 @@ server {
   listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
   <%- end -%>
 <%= scope.function_template(["nginx/server/server_ssl_ipv6_listen.erb"]) %>
-  server_name  <%= @rewrite_www_to_non_www ? @server_name.join("  ").gsub(/(^| )(www\.)?(?=[a-z0-9])/, '') : @server_name.join(" ") %>;
+<%- if @rewrite_www_to_non_www -%>
+  server_name  <%= @server_name.join("  ").gsub(/(^| )(www\.)?(?=[a-z0-9])/, '') %>;
+<%- elsif @rewrite_non_www_to_www -%>
+  server_name  <%= @server_name.join("  ").gsub(/(^| )(?=[a-z0-9])/, 'www.') %>;
+<%- else %>
+  server_name  <%= @server_name.join(" ") %>;
+<%- end -%>
 
 <%= scope.function_template(["nginx/server/server_ssl_settings.erb"]) %>
 <% if @maintenance -%>


### PR DESCRIPTION
#### Pull Request (PR) description

This part seems to be missing from the original patch to add support for `rewrite_non_www_to_www` (4b2b108c28d778b5250bf126b5f8aacef6b98858).

It was added to the non-SSL template but missing from the SSL template.

#### This Pull Request (PR) fixes the following issues
n/a (no issue reported)