### PR TITLE
Add support for limit_req_zone in main nginx config and limit_req: Fixes #1134

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,6 +28,7 @@ class nginx::config {
   $global_owner                   = $nginx::global_owner
   $global_group                   = $nginx::global_group
   $global_mode                    = $nginx::global_mode
+  $limit_req_zone                 = $nginx::limit_req_zone
   $log_dir                        = $nginx::log_dir
   $log_user                       = $nginx::log_user
   $log_group                      = $nginx::log_group

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class nginx (
   $global_owner                                              = $nginx::params::global_owner,
   $global_group                                              = $nginx::params::global_group,
   $global_mode                                               = $nginx::params::global_mode,
+  Optional[Variant[String, Array[String]]] $limit_req_zone   = undef,
   Stdlib::Absolutepath $log_dir                              = $nginx::params::log_dir,
   String[1] $log_user                                        = $nginx::params::log_user,
   String[1] $log_group                                       = $nginx::params::log_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,7 +45,7 @@ class nginx (
   $global_owner                                              = $nginx::params::global_owner,
   $global_group                                              = $nginx::params::global_group,
   $global_mode                                               = $nginx::params::global_mode,
-  Optional[Variant[String, Array[String]]] $limit_req_zone   = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $limit_req_zone = undef,
   Stdlib::Absolutepath $log_dir                              = $nginx::params::log_dir,
   String[1] $log_user                                        = $nginx::params::log_user,
   String[1] $log_group                                       = $nginx::params::log_group,

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -67,6 +67,8 @@
 #   [*raw_append*]           - A single string, or an array of strings to
 #     append to the location directive (after custom_cfg directives). NOTE:
 #     YOU are responsible for a semicolon on each line that requires one.
+#   [*limit_zone*]           - Apply a limit_req_zone to the location. Expects a string indicating a
+#     previously defined limit_req_zone in the main nginx configuration
 #   [*location_custom_cfg*]  - Expects a hash with custom directives, cannot
 #     be used with other location types (proxy, fastcgi, root, or stub_status)
 #   [*location_cfg_prepend*] - Expects a hash with extra directives to put
@@ -214,6 +216,7 @@ define nginx::resource::location (
   Boolean $ssl                                                     = false,
   Boolean $ssl_only                                                = false,
   Optional[String] $location_alias                                 = undef,
+  Optional[String] $limit_zone                                     = undef,
   Optional[Enum['any', 'all']] $location_satisfy                   = undef,
   Optional[Array] $location_allow                                  = undef,
   Optional[Array] $location_deny                                   = undef,

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -216,7 +216,7 @@ define nginx::resource::location (
   Boolean $ssl                                                     = false,
   Boolean $ssl_only                                                = false,
   Optional[String] $location_alias                                 = undef,
-  Optional[String] $limit_zone                                     = undef,
+  Optional[String[1]] $limit_zone                                  = undef,
   Optional[Enum['any', 'all']] $location_satisfy                   = undef,
   Optional[Array] $location_allow                                  = undef,
   Optional[Array] $location_deny                                   = undef,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -489,6 +489,18 @@ describe 'nginx' do
                 match: '  error_log /var/log/nginx/error.log warn;'
               },
               {
+                title: 'should set limit_req_zone',
+                attr: 'limit_req_zone',
+                value: [
+                  '$binary_remote_addr zone=myzone1:10m rate=5r/s',
+                  '$binary_remote_addr zone=myzone2:10m rate=5r/s'
+                ],
+                match: [
+                  '  limit_req_zone $binary_remote_addr zone=myzone1:10m rate=5r/s;',
+                  '  limit_req_zone $binary_remote_addr zone=myzone2:10m rate=5r/s;'
+                ]
+              },
+              {
                 title: 'should set pid',
                 attr: 'pid',
                 value: '/path/to/pid',

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -101,6 +101,12 @@ describe 'nginx::resource::location' do
               match: '    satisfy any;'
             },
             {
+              title: 'should set limit_zone',
+              attr: 'limit_zone',
+              value: 'myzone1',
+              match: '    limit_req zone=myzone1;'
+            },
+            {
               title: 'should set expires',
               attr: 'expires',
               value: '33d',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -87,6 +87,16 @@ http {
   error_log <%= @nginx_error_log %> <%= @nginx_error_log_severity %>;
 <% end -%>
 
+<% if @limit_req_zone -%>
+  <% if @limit_req_zone.is_a?(Array) -%>
+    <%- @limit_req_zone.each do |limit_req_zone_item| -%>
+    limit_req_zone <%= limit_req_zone_item %>;
+    <%- end -%>
+  <% else -%>
+    limit_req_zone <%= @limit_req_zone %>;
+  <% end -%>
+<% end -%>
+
 <% if @sendfile == 'on' -%>
   sendfile on;
   <%- if @http_tcp_nopush == 'on' -%>

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -88,13 +88,13 @@ http {
 <% end -%>
 
 <% if @limit_req_zone -%>
-  <% if @limit_req_zone.is_a?(Array) -%>
-    <%- @limit_req_zone.each do |limit_req_zone_item| -%>
-    limit_req_zone <%= limit_req_zone_item %>;
-    <%- end -%>
-  <% else -%>
-    limit_req_zone <%= @limit_req_zone %>;
-  <% end -%>
+<% if @limit_req_zone.is_a?(Array) -%>
+<%- @limit_req_zone.each do |limit_req_zone_item| -%>
+  limit_req_zone <%= limit_req_zone_item %>;
+<% end -%>
+<% else -%>
+  limit_req_zone <%= @limit_req_zone %>;
+<% end -%>
 <% end -%>
 
 <% if @sendfile == 'on' -%>

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -77,3 +77,6 @@
     rewrite <%= rewrite_rule %>;
     <%- end -%>
 <% end -%>
+<% if @limit_zone -%>
+    limit_req zone=<%= @limit_zone %>;
+<% end -%>


### PR DESCRIPTION
Add support for `limit_req_zone` in main nginx config and `limit_req`
for `nginx::resource::location`.

In init.pp
`limit_req_zone` can be a String, or an array of String

In resource/location.pp
`limit_zone` can be a String and should point to a zone defined from
`limit_req_zone` in init.pp

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
