### PR TITLE
Enforce Usage Of Managed Repository

### DIFF
--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -31,6 +31,11 @@ class nginx::package::redhat {
     'VirtuozzoLinux' => 'centos',
     default          => 'rhel'
   }
+  
+  $_package_install_options ? {
+     $manage_repo => '--repo=nginx-release',
+     default      => '',
+  }
 
   if $manage_repo {
     case $package_source {
@@ -104,8 +109,9 @@ class nginx::package::redhat {
   }
 
   package { 'nginx':
-    ensure => $package_ensure,
-    name   => $package_name,
+    ensure          => $package_ensure,
+    name            => $package_name,
+    install_options => $_package_install_options,
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This change enforce the usage of the managed repository to work around the AppStream of CentOS and RedHat, which will take precedence over none module based repositories.
#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
