### PR TITLE
Ensured file mode permissions are more consistent

### DIFF
--- a/manifests/resource/geo.pp
+++ b/manifests/resource/geo.pp
@@ -78,7 +78,7 @@ define nginx::resource::geo (
   File {
     owner => 'root',
     group => $root_group,
-    mode  => '0644',
+    mode  => $nginx::global_mode,
   }
 
   file { "${conf_dir}/${name}-geo.conf":

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -263,7 +263,7 @@ define nginx::resource::location (
   File {
     owner  => 'root',
     group  => $root_group,
-    mode   => '0644',
+    mode   => $nginx::global_mode,
     notify => Class['::nginx::service'],
   }
 
@@ -294,7 +294,7 @@ define nginx::resource::location (
   ) {
     file { $fastcgi_params:
       ensure  => 'present',
-      mode    => '0644',
+      mode    => $nginx::global_mode,
       content => template('nginx/server/fastcgi.conf.erb'),
     }
   }
@@ -302,7 +302,7 @@ define nginx::resource::location (
   if $ensure == 'present' and $uwsgi != undef and !defined(File[$uwsgi_params]) and $uwsgi_params == "${nginx::conf_dir}/uwsgi_params" {
     file { $uwsgi_params:
       ensure  => 'present',
-      mode    => '0644',
+      mode    => $nginx::global_mode,
       content => template('nginx/server/uwsgi_params.erb'),
     }
   }

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -132,7 +132,7 @@ define nginx::resource::mailhost (
   File {
     owner => 'root',
     group => $root_group,
-    mode  => '0644',
+    mode  => $nginx::global_mode,
   }
 
   $config_dir  = "${nginx::conf_dir}/conf.mail.d"
@@ -154,7 +154,7 @@ define nginx::resource::mailhost (
   concat { $config_file:
     owner   => 'root',
     group   => $root_group,
-    mode    => '0644',
+    mode    => $nginx::global_mode,
     notify  => Class['::nginx::service'],
     require => File[$config_dir],
   }

--- a/manifests/resource/map.pp
+++ b/manifests/resource/map.pp
@@ -94,7 +94,7 @@ define nginx::resource::map (
   File {
     owner => 'root',
     group => $root_group,
-    mode  => '0644',
+    mode  => $nginx::global_mode,
   }
 
   file { "${nginx::conf_dir}/conf.d/${name}-map.conf":

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -430,7 +430,7 @@ define nginx::resource::server (
   if $fastcgi != undef and !defined(File[$fastcgi_params]) and $fastcgi_params == "${nginx::conf_dir}/fastcgi.conf" {
     file { $fastcgi_params:
       ensure  => present,
-      mode    => '0644',
+      mode    => $nginx::global_mode,
       content => template('nginx/server/fastcgi.conf.erb'),
     }
   }
@@ -438,7 +438,7 @@ define nginx::resource::server (
   if $uwsgi != undef and !defined(File[$uwsgi_params]) and $uwsgi_params == "${nginx::conf_dir}/uwsgi_params" {
     file { $uwsgi_params:
       ensure  => present,
-      mode    => '0644',
+      mode    => $nginx::global_mode,
       content => template('nginx/server/uwsgi_params.erb'),
     }
   }

--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -116,7 +116,7 @@ define nginx::resource::upstream (
   Concat {
     owner => 'root',
     group => $nginx::root_group,
-    mode  => '0644',
+    mode  => $nginx::global_mode,
   }
 
   concat { "${conf_dir}/${name}-upstream.conf":


### PR DESCRIPTION
#### Pull Request (PR) description
Changed the 'file' resources mode to use $nginx::global_mode to keep permissions consistent and secure

#### This Pull Request (PR) fixes the following issues
n/a
