### PR TITLE
Actually use the ensure parameter for mailhost resource to provide absent support

### DIFF
--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -152,6 +152,7 @@ define nginx::resource::mailhost (
   }
 
   concat { $config_file:
+    ensure  => $ensure,
     owner   => 'root',
     group   => $root_group,
     mode    => $nginx::global_mode,

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -30,6 +30,13 @@ describe 'nginx::resource::mailhost' do
           it { is_expected.not_to contain_concat__fragment("#{title}-ssl") }
         end
 
+        describe 'absent assumption' do
+          let(:params) { default_params.merge('ensure'.to_sym => 'absent') }
+
+          it { is_expected.to contain_class('nginx') }
+          it { is_expected.to contain_concat("/etc/nginx/conf.mail.d/#{title}.conf").with('ensure' => 'absent') }
+        end
+
         describe 'mailhost template content' do
           [
             {


### PR DESCRIPTION
## Pull Request (PR) description
Apply the mailhost resource parameter ensure to the concat resource.

#### This Pull Request (PR) fixes the following issues
Fixes #1394

