### PR TITLE
nginx isnt allowed to write into tmp directories, due to permissions …

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -200,6 +200,7 @@ class nginx::config {
 
   file { $run_dir:
     ensure => directory,
+    mode   => '0644',
   }
 
   if $nginx::manage_snippets_dir {


### PR DESCRIPTION
#### Pull Request (PR) description
on centos 7 (and perhaps other os-es) the run dir parent directory isnt open enough to allow the nginx process to write into the underlying directories.