### PR TITLE
Fix permission denied while reading upstream Error

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -197,6 +197,7 @@ class nginx::config {
 
   file {$run_dir:
     ensure => directory,
+    owner  => $daemon_user
   }
 
   if $nginx::manage_snippets_dir {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
To fix 'permission denied while reading upstream' Erros, the run_dir needs to be accessable by the nginx worker.
Explantation:
Typically this is a problem of saving the buffered data from the proxy server and sending it back. When the upstream server response returns large number of bytes then nginx keeps the part of data at the disk and start sending the first received bytes to browser. So for that it uses a certain directory to maintain the data at the configured directory, which is "/run/nginx" in my case. So you just need to give access to that directory to worker user of nginx.

I think the easiest way is to set the owner to the $daemon_user.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
-->
