### PR TITLE
Adding resolver entries to streamhost.erb

### DIFF
--- a/spec/defines/resource_stream_spec.rb
+++ b/spec/defines/resource_stream_spec.rb
@@ -102,6 +102,12 @@ describe 'nginx::resource::streamhost' do
               match: %r{\s+listen\s+\[::\]:80 spdy;}
             },
             {
+              title: 'should set resolver(s)',
+              attr: 'resolver',
+              value: ['203.0.113.1', '203.0.113.2'],
+              match: %r{\s+resolver\s+203.0.113.1 203.0.113.2;}
+            },
+            {
               title: 'should contain raw_prepend directives',
               attr: 'raw_prepend',
               value: [

--- a/templates/streamhost/streamhost.erb
+++ b/templates/streamhost/streamhost.erb
@@ -18,6 +18,9 @@ server {
   listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
   <%- end -%>
 <%- end -%>
+<%- unless @resolver.empty? -%>
+  resolver              <% @resolver.each do |res| %> <%= res %><% end %>;
+<%- end -%>
 
   <% Array(@raw_prepend).each do |line| -%>
     <%= line %>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
When declaring nginx::resource::streamhost, there is the ability to add a "resolver" option, but this is not actually honoured in the configuration, a section to test the existence of that Variable and define it in the configuration erb file is needed.

```
nginx::resource::streamhost {'test':
  ...
  resolver => ['255.255.255.255'],
  ...
}
```
should create a file in /etc/nginx/conf.stream.d/XXX-test.conf

which contains
```
server {
  ...
  resolver 255.255.255.255;
  ...
}
```
but currently does not, this code ensures this entry is present.

#### This Pull Request (PR) fixes the following issues
When declaring the parameter resolver as per
```
#   [*resolver*]            - Array: Configures name servers used to resolve
#     names of upstream servers into addresses.
```
for a streamhost, nothing is actually configured.
