### PR TITLE
Update passenger rpm gpg key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,11 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'voxpupuli-test', '>= 1.4.0',  :require => false
+  gem 'voxpupuli-test', '< 2.0.0',   :require => false
   gem 'coveralls',                   :require => false
   gem 'simplecov-console',           :require => false
-  gem 'rspec-puppet-facts',          :require => false, :git => 'https://github.com/mcanevet/rspec-puppet-facts', :ref => '9541292d4fc35db3be1badace673c1108154b571'
+  gem 'rspec-puppet-facts', '2.0.0', :require => false
+  gem 'facterdb', '1.4.0',           :require => false
 end
 
 group :development do

--- a/manifests/package/redhat.pp
+++ b/manifests/package/redhat.pp
@@ -73,6 +73,11 @@ class nginx::package::redhat {
       }
       'passenger': {
         if ($facts['os']['name'] in ['RedHat', 'CentOS', 'VirtuozzoLinux']) and ($facts['os']['release']['major'] in ['6', '7']) {
+          # 2019-11: Passenger changed their gpg key from: `https://packagecloud.io/phusion/passenger/gpgkey`
+          # to: `https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt`
+          # Find the latest key by opening: https://oss-binaries.phusionpassenger.com/yum/definitions/el-passenger.repo
+
+          # Also note: Since 6.0.5 there are no nginx packages in the phusion EL7 repository, and nginx packages are expected to come from epel instead
           yumrepo { 'passenger':
             baseurl       => "https://oss-binaries.phusionpassenger.com/yum/passenger/el/${facts['os']['release']['major']}/\$basearch",
             descr         => 'passenger repo',
@@ -80,7 +85,7 @@ class nginx::package::redhat {
             gpgcheck      => '0',
             repo_gpgcheck => '1',
             priority      => '1',
-            gpgkey        => 'https://packagecloud.io/phusion/passenger/gpgkey',
+            gpgkey        => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt',
             before        => Package['nginx'],
           }
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -5,7 +5,12 @@ describe 'nginx class:' do
   when 'RedHat'
     pkg_cmd = 'yum info nginx | grep "^From repo"'
     pkg_remove_cmd = 'yum -y remove nginx nginx-filesystem passenger'
-    pkg_match = %r{passenger}
+    pkg_match = case fact('operatingsystemmajrelease')
+                when '7' # https://blog.phusion.nl/2020/05/29/passenger-6-0-5/
+                  %r{epel}
+                else
+                  %r{passenger}
+                end
   when 'Debian'
     pkg_cmd = 'dpkg -s nginx | grep ^Maintainer'
     pkg_remove_cmd = 'apt-get -y purge nginx nginx-common'

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -103,7 +103,7 @@ describe 'nginx' do
                 'baseurl'       => "https://oss-binaries.phusionpassenger.com/yum/passenger/el/#{facts[:operatingsystemmajrelease]}/$basearch",
                 'gpgcheck'      => '0',
                 'repo_gpgcheck' => '1',
-                'gpgkey'        => 'https://packagecloud.io/phusion/passenger/gpgkey'
+                'gpgkey'        => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt'
               )
             end
             it do


### PR DESCRIPTION
without this change, we see the following error since november 2019:

```
passenger/7/x86_64/
Retrieving key from https://packagecloud.io/phusion/passenger/gpgkey
passenger/7/x86_64/
https://oss-binaries.phusionpassenger.com/yum/passenger/el/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml signature could not be verified for passenger
Trying other mirror.
```