### PR TITLE
Refactor to remove some `File` defaults

### DIFF
--- a/manifests/resource/geo.pp
+++ b/manifests/resource/geo.pp
@@ -73,16 +73,12 @@ define nginx::resource::geo (
     default  => 'file',
   }
 
-  File {
-    owner => 'root',
-    group => $root_group,
-    mode  => $nginx::global_mode,
-  }
-
   file { "${conf_dir}/${name}-geo.conf":
     ensure  => $ensure_real,
+    owner   => 'root',
+    group   => $root_group,
+    mode    => $nginx::global_mode,
     content => template('nginx/conf.d/geo.erb'),
     notify  => Class['nginx::service'],
-    require => File[$conf_dir],
   }
 }

--- a/manifests/resource/map.pp
+++ b/manifests/resource/map.pp
@@ -95,16 +95,12 @@ define nginx::resource::map (
     default  => 'file',
   }
 
-  File {
-    owner => 'root',
-    group => $root_group,
-    mode  => $nginx::global_mode,
-  }
-
   file { "${conf_dir}/${name}-map.conf":
     ensure  => $ensure_real,
+    owner   => 'root',
+    group   => $root_group,
+    mode    => $nginx::global_mode,
     content => template('nginx/conf.d/map.erb'),
     notify  => Class['nginx::service'],
-    require => File[$conf_dir],
   }
 }

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -84,20 +84,9 @@ define nginx::resource::streamhost (
   $name_sanitized = regsubst($name, ' ', '_', 'G')
   $config_file = "${streamhost_dir}/${name_sanitized}.conf"
 
-  File {
-    ensure => $ensure ? {
-      'absent' => absent,
-      default  => 'file',
-    },
-    notify => Class['nginx::service'],
-    owner  => $owner,
-    group  => $group,
-    mode   => $mode,
-  }
-
   # Add IPv6 Logic Check - Nginx service will not start if ipv6 is enabled
   # and support does not exist for it in the kernel.
-  if ($ipv6_enable == true) and (!$facts['networking']['ip6']) {
+  if $ipv6_enable and !$facts['networking']['ip6'] {
     warning('nginx: IPv6 support is not enabled or configured properly')
   }
 
@@ -121,7 +110,10 @@ define nginx::resource::streamhost (
       ensure  => $streamhost_symlink_ensure,
       path    => "${streamhost_enable_dir}/${name_sanitized}.conf",
       target  => $config_file,
-      require => [Concat[$config_file], File[$streamhost_enable_dir]],
+      owner   => $owner,
+      group   => $group,
+      mode    => $mode,
+      require => Concat[$config_file],
       notify  => Class['nginx::service'],
     }
   }


### PR DESCRIPTION
Resource defaults outside of site.pp are not recommended.
https://puppet.com/docs/puppet/6.18/lang_defaults.html

In these cases, there was only a single file resource in each manifest.