### PR TITLE
Simplify service class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,7 +199,7 @@ class nginx (
   ### END Package Configuration ###
 
   ### START Service Configuation ###
-  $service_ensure                                            = running,
+  Stdlib::Ensure::Service $service_ensure                    = 'running',
   $service_enable                                            = true,
   $service_flags                                             = undef,
   $service_restart                                           = undef,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,54 +1,14 @@
-# Class: nginx::service
-#
-# This module manages NGINX service management and server rebuild
-#
-# Parameters:
-#
-# There are no default parameters for this class.
-#
-# Actions:
-#
-# Requires:
-#
-# Sample Usage:
-#
-# This class file is not called directly
-class nginx::service (
-  $service_restart = $nginx::service_restart,
-  $service_ensure  = $nginx::service_ensure,
-  $service_enable  = $nginx::service_enable,
-  $service_name    = $nginx::service_name,
-  $service_flags   = $nginx::service_flags,
-  $service_manage  = $nginx::service_manage,
-) {
+# @summary Manage NGINX service management
+# @api private
+class nginx::service {
   assert_private()
 
-  if $service_manage {
-    case $facts['os']['name'] {
-      'OpenBSD': {
-        service { $service_name:
-          ensure     => $service_ensure,
-          enable     => $service_enable,
-          flags      => $service_flags,
-          hasstatus  => true,
-          hasrestart => true,
-        }
-      }
-      default: {
-        service { $service_name:
-          ensure     => $service_ensure,
-          enable     => $service_enable,
-          hasstatus  => true,
-          hasrestart => true,
-        }
-      }
-    }
-  }
-
-  # Allow overriding of 'restart' of Service resource; not used by default
-  if $service_restart {
-    Service[$service_name] {
-      restart => $service_restart,
+  if $nginx::service_manage {
+    service { $nginx::service_name:
+      ensure  => $nginx::service_ensure,
+      enable  => $nginx::service_enable,
+      flags   => $nginx::service_flags,
+      restart => $nginx::service_restart,
     }
   }
 }

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -221,9 +221,7 @@ describe 'nginx' do
           it do
             is_expected.to contain_service('nginx').with(
               ensure: 'running',
-              enable: true,
-              hasstatus: true,
-              hasrestart: true
+              enable: true
             )
           end
 


### PR DESCRIPTION
It's valid to pass in undef values. That makes the OpenBSD check redundant. The same goes for the restart command. That removes pretty much all logic so there is no more benefit to having class parameters. That's why it now uses all the variables directly from the nginx class. The has{status,restart} parameters default to true since Puppet 2.7 so they can be removed.

Replaces https://github.com/voxpupuli/puppet-nginx/pull/1209