### PR TITLE
implement config check on config change before service restart

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -167,6 +167,7 @@ class nginx::config {
   file { "${conf_dir}/conf.d":
     ensure => directory,
   }
+
   if $confd_purge {
     # Err on the side of caution - make sure *both* $server_purge and
     # $confd_purge are set if $confd_only is set, before purging files
@@ -177,6 +178,7 @@ class nginx::config {
         recurse => true,
         notify  => Class['nginx::service'],
       }
+
       File["${conf_dir}/conf.stream.d"] {
         purge   => true,
         recurse => true,
@@ -188,6 +190,7 @@ class nginx::config {
   file { "${conf_dir}/conf.mail.d":
     ensure => directory,
   }
+
   if $confd_purge == true {
     File["${conf_dir}/conf.mail.d"] {
       purge   => true,
@@ -233,22 +236,26 @@ class nginx::config {
       group  => $sites_available_group,
       mode   => $sites_available_mode,
     }
+
     file { "${conf_dir}/sites-enabled":
       ensure => directory,
       owner  => $sites_available_owner,
       group  => $sites_available_group,
       mode   => $sites_available_mode,
     }
+
     if $server_purge {
       File["${conf_dir}/sites-available"] {
         purge   => true,
         recurse => true,
       }
+
       File["${conf_dir}/sites-enabled"] {
         purge   => true,
         recurse => true,
       }
     }
+
     # No real reason not to make these even if $stream is not enabled.
     file { "${conf_dir}/streams-enabled":
       ensure => directory,
@@ -256,12 +263,14 @@ class nginx::config {
       group  => $sites_available_group,
       mode   => $sites_available_mode,
     }
+
     file { "${conf_dir}/streams-available":
       ensure => directory,
       owner  => $sites_available_owner,
       group  => $sites_available_group,
       mode   => $sites_available_mode,
     }
+
     if $server_purge {
       File["${conf_dir}/streams-enabled"] {
         purge   => true,
@@ -273,11 +282,13 @@ class nginx::config {
   file { "${conf_dir}/nginx.conf":
     ensure  => file,
     content => template($conf_template),
+    tag     => 'nginx_config_file',
   }
 
   file { "${conf_dir}/mime.types":
     ensure  => file,
     content => epp($mime_template),
+    tag     => 'nginx_config_file',
   }
 
   file { "${temp_dir}/nginx.d":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,5 @@
-# Class: nginx
-#
-# This module manages NGINX.
+# @summary
+#   This module manages NGINX.
 #
 # Parameters:
 #
@@ -44,6 +43,10 @@
 # @param debug_connections
 #   Configures nginx `debug_connection` lines in the `events` section of the nginx config.
 #   See http://nginx.org/en/docs/ngx_core_module.html#debug_connection
+#
+# @param service_config_check
+#  whether to en- or disable the config check via nginx -t on config changes
+#
 class nginx (
   ### START Nginx Configuration ###
   Variant[Stdlib::Absolutepath, Boolean] $client_body_temp_path = $nginx::params::client_body_temp_path,
@@ -205,6 +208,7 @@ class nginx (
   $service_restart                                           = undef,
   $service_name                                              = 'nginx',
   $service_manage                                            = true,
+  Boolean $service_config_check                              = false,
   ### END Service Configuration ###
 
   ### START Hiera Lookups ###

--- a/manifests/resource/geo.pp
+++ b/manifests/resource/geo.pp
@@ -80,5 +80,6 @@ define nginx::resource::geo (
     mode    => $nginx::global_mode,
     content => template('nginx/conf.d/geo.erb'),
     notify  => Class['nginx::service'],
+    tag     => 'nginx_config_file',
   }
 }

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -301,6 +301,7 @@ define nginx::resource::location (
       ensure  => 'file',
       mode    => $nginx::global_mode,
       content => template('nginx/server/fastcgi.conf.erb'),
+      tag     => 'nginx_config_file',
     }
   }
 
@@ -309,6 +310,7 @@ define nginx::resource::location (
       ensure  => 'file',
       mode    => $nginx::global_mode,
       content => template('nginx/server/uwsgi_params.erb'),
+      tag     => 'nginx_config_file',
     }
   }
 

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -147,6 +147,7 @@ define nginx::resource::mailhost (
     mode    => $nginx::global_mode,
     notify  => Class['nginx::service'],
     require => File[$config_dir],
+    tag     => 'nginx_config_file',
   }
 
   if $ssl_port == undef or $listen_port != $ssl_port {

--- a/manifests/resource/map.pp
+++ b/manifests/resource/map.pp
@@ -102,5 +102,6 @@ define nginx::resource::map (
     mode    => $nginx::global_mode,
     content => template('nginx/conf.d/map.erb'),
     notify  => Class['nginx::service'],
+    tag     => 'nginx_config_file',
   }
 }

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -349,6 +349,7 @@ define nginx::resource::server (
     mode    => $mode,
     notify  => Class['nginx::service'],
     require => File[$server_dir],
+    tag     => 'nginx_config_file',
   }
 
   # This deals with a situation where the listen directive for SSL doesn't match

--- a/manifests/resource/snippet.pp
+++ b/manifests/resource/snippet.pp
@@ -27,6 +27,7 @@ define nginx::resource::snippet (
     mode    => $mode,
     notify  => Class['nginx::service'],
     require => File[$nginx::snippets_dir],
+    tag     => 'nginx_config_file',
   }
 
   concat::fragment { "snippet-${name_sanitized}-header":

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -97,6 +97,7 @@ define nginx::resource::streamhost (
     mode    => $mode,
     notify  => Class['nginx::service'],
     require => File[$streamhost_dir],
+    tag     => 'nginx_config_file',
   }
 
   concat::fragment { "${name_sanitized}-header":

--- a/manifests/resource/upstream.pp
+++ b/manifests/resource/upstream.pp
@@ -122,6 +122,7 @@ define nginx::resource::upstream (
     ensure  => $ensure,
     notify  => Class['nginx::service'],
     require => File[$conf_dir],
+    tag     => 'nginx_config_file',
   }
 
   concat::fragment { "${name}_upstream_header":

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,14 +1,40 @@
 # @summary Manage NGINX service management
+#
 # @api private
+#
 class nginx::service {
   assert_private()
 
+  if $nginx::service_config_check {
+    exec { 'nginx_config_check':
+      command     => 'nginx -t',
+      refreshonly => true,
+      path        => [
+        '/usr/local/sbin',
+        '/usr/local/bin',
+        '/usr/sbin',
+        '/usr/bin',
+        '/sbin',
+        '/bin',
+      ],
+    }
+
+    File <| tag == 'nginx_config_file' |> ~> Exec['nginx_config_check']
+    Concat <| tag == 'nginx_config_file' |> ~> Exec['nginx_config_check']
+  }
+
   if $nginx::service_manage {
+    $service_require = $nginx::service_config_check ? {
+      true  => Exec['nginx_config_check'],
+      false => undef,
+    }
+
     service { $nginx::service_name:
       ensure  => $nginx::service_ensure,
       enable  => $nginx::service_enable,
       flags   => $nginx::service_flags,
       restart => $nginx::service_restart,
+      require => $service_require,
     }
   }
 }

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -31,4 +31,35 @@ describe 'nginx class' do
       it { is_expected.to be_listening }
     end
   end
+
+  context 'with service_config_check true' do
+    # Using puppet_apply as a helper
+    it 'works idempotently with no errors' do
+      pp = "class { 'nginx': service_config_check => true, }"
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    # do some basic checks
+    pkg = case fact('os.family')
+          when 'Archlinux'
+            'nginx-mainline'
+          else
+            'nginx'
+          end
+    describe package(pkg) do
+      it { is_expected.to be_installed }
+    end
+
+    describe service('nginx') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    describe port(80) do
+      it { is_expected.to be_listening }
+    end
+  end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This implements a switch to enable the nginx config check via `nginx -t` on all config file changes. If the config check is enabled (disabled by default) and fails, the service refresh of nginx will be unscheduled b puppet.

#### This Pull Request (PR) fixes the following issues
No issue created, started directly with the feature.
