### PR TITLE
Add `.flatten` to `location_allow` to enable using nested arrays

### DIFF
--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -113,12 +113,23 @@ describe 'nginx::resource::location' do
               match: '    expires 33d;'
             },
             {
-              title: 'should set location_allow',
+              title: 'should set location_allow (flat array)',
               attr: 'location_allow',
               value: %w[127.0.0.1 10.0.0.1],
               match: [
                 '    allow 127.0.0.1;',
                 '    allow 10.0.0.1;'
+              ]
+            },
+            {
+              title: 'should set location_allow (nested array)',
+              attr: 'location_allow',
+              value: %w[127.0.0.1 10.0.0.1 [127.0.0.2 10.0.0.2]],
+              match: [
+                '    allow 127.0.0.1;',
+                '    allow 10.0.0.1;'
+                '    allow 127.0.0.2;',
+                '    allow 10.0.0.2;'
               ]
             },
             {

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -16,7 +16,7 @@
     expires <%= @expires %>;
 <% end -%>
 <% if @location_allow -%>
-    <%- @location_allow.each do |allow_rule| -%>
+    <%- @location_allow.flatten.each do |allow_rule| -%>
     allow <%= allow_rule %>;
     <%- end -%>
 <% end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->


Enabling defining 'location_allow's content as nested arrays.

Mostly useful when using Hiera to merge arrays from different hierarchy levels.



