### PR TITLE
Fix indention for add_header at template calls

### DIFF
--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -133,7 +133,7 @@ server {
 <% if Array(@resolver).count > 0 -%>
   resolver                  <% Array(@resolver).each do |r| %> <%= r %><% end %>;
 <% end -%>
-<%= scope.function_template(["nginx/server/locations/headers.erb"]) %>
+  <%= scope.function_template(["nginx/server/locations/headers.erb"]) %>
 <% if @maintenance -%>
   <%= @maintenance_value %>;
 <% end -%>

--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -169,4 +169,4 @@ server {
 <% Array(@passenger_env_var).each do |key,value| -%>
   passenger_env_var  <%= key %> <%= value %>;
 <% end -%>
-<%= scope.function_template(["nginx/server/locations/headers.erb"]) %>
+  <%= scope.function_template(["nginx/server/locations/headers.erb"]) %>


### PR DESCRIPTION
#### Pull Request (PR) description
Introduced in !1417. The template server/locations/headers.erb is included in several other templates. At those templates the indention of the call is incorrect and leads to:

```
         allow 10.129.14.49;
         deny all;
         gzip off;
    -    add_header "Content-Type" "text/html";
    -    add_header "Status" "406";
    +  add_header "Content-Type" "text/html";
    +  add_header "Status" "406";
         root      /var/www/maintenance/scripts;
         return 406 "[406] request is not acceptable
``` 

