### PR TITLE
Revert "Indentation fix" from #1417

### DIFF
--- a/templates/server/locations/headers.erb
+++ b/templates/server/locations/headers.erb
@@ -2,10 +2,10 @@
     <%- if value -%>
       <%- if value.is_a?(Hash) -%>
         <%- value.each do |sk, sv| -%>
-  add_header "<%= header %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
+    add_header "<%= header %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
         <%- end -%>
       <%- else -%>
-  add_header "<%= header %>" "<%= value %>";
+    add_header "<%= header %>" "<%= value %>";
       <%- end -%>
     <%- end -%>
 <%- end -%>


### PR DESCRIPTION
This reverts commit 79fd696271e03a513dd86e77f5a0567f0adb3bef.

#### Pull Request (PR) description
The PR #1417 fixed the indention of `add_header` outside of location, but introduced the wrong indention within the locations. The right source to fix the indention outside of location has been fixed via PR #1424. Therefore we can revert the #1417 changes.

