### PR TITLE
(maint) bump apt to 7.7.0 for performance tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,8 @@
 fixtures:
   repositories:
-    apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
+    apt:
+      repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
+      ref: "v7.7.0"
     concat: "https://github.com/puppetlabs/puppetlabs-concat.git"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     yumrepo_core:


### PR DESCRIPTION
Facter 4 changed how the code from custom facts is evaluated,
this introuced a couple of changes needed for apt module,
more details here: https://github.com/puppetlabs/puppetlabs-apt/commit/6786d506e373c08df8ad0b00c5a9d7275ba0ed1a

Bump apt module to 7.7.0 to resolve performance issues when
running unit tests on Linux


