### PR TITLE
Replace Travis build status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NGINX module for Puppet
 
-[![Build Status](https://travis-ci.org/voxpupuli/puppet-nginx.png?branch=master)](https://travis-ci.org/voxpupuli/puppet-nginx)
+[![Build Status](https://github.com/voxpupuli/puppet-nginx/workflows/CI/badge.svg)](https://github.com/voxpupuli/puppet-nginx/actions?query=workflow%3ACI)
 [![Code Coverage](https://coveralls.io/repos/github/voxpupuli/puppet-nginx/badge.svg?branch=master)](https://coveralls.io/github/voxpupuli/puppet-nginx)
 [![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/nginx.svg)](https://forge.puppetlabs.com/puppet/nginx)
 [![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/nginx.svg)](https://forge.puppetlabs.com/puppet/nginx)


### PR DESCRIPTION
Github Actions is used by this module.
This way, the real build status is shown