### PR TITLE
Drop EL6 & Puppet 5 from and add Puppet 7 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -20,7 +20,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -37,14 +37,12 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },


### PR DESCRIPTION
#### Pull Request (PR) description

This PR drops Red Hat 6 and CentOS 6 from the metadata as those OS's are end of life and their yum repositories have been archived. It also raises the upper bounds of acceptable Puppet versions to include Puppet 7 and raises the lower bounds to Puppet 6.1 since Puppet 5 is also EoL.