### PR TITLE
Use $service_name in nginx config check command

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,7 +7,7 @@ class nginx::service {
 
   if $nginx::service_config_check {
     exec { 'nginx_config_check':
-      command     => 'nginx -t',
+      command     => "${nginx::service_name} -t",
       refreshonly => true,
       path        => [
         '/usr/local/sbin',


### PR DESCRIPTION
#### Pull Request (PR) description
Config check isn't working, if you're running e.g. openresty as the service name is `openresty`, not `nginx`.
