### PR TITLE
makes service_config_check exec command configurable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,9 @@
 # @param service_config_check
 #  whether to en- or disable the config check via nginx -t on config changes
 #
+# @param service_config_check_command
+#  Command to execute to validate the generated configuration.
+#
 class nginx (
   ### START Nginx Configuration ###
   Variant[Stdlib::Absolutepath, Boolean] $client_body_temp_path = $nginx::params::client_body_temp_path,
@@ -195,6 +198,7 @@ class nginx (
   $service_name                                              = 'nginx',
   $service_manage                                            = true,
   Boolean $service_config_check                              = false,
+  String $service_config_check_command                       = 'nginx -t',
   ### END Service Configuration ###
 
   ### START Hiera Lookups ###

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,7 +7,7 @@ class nginx::service {
 
   if $nginx::service_config_check {
     exec { 'nginx_config_check':
-      command     => 'nginx -t',
+      command     => $nginx::service_config_check_command,
       refreshonly => true,
       path        => [
         '/usr/local/sbin',


### PR DESCRIPTION
#### Pull Request (PR) description
Right now, the service_config_check exec command is using `nginx -t` and there's no way to change it.
If you're running e.g. openresty, there's no `nginx` executable and the check will fail.

This PR adds a paramter `$nginx::service_config_check_command` with a default value of `nginx -t`