### PR TITLE
Add focal support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -115,7 +115,7 @@ class nginx::params {
           'log_mode'    => '0755',
           'run_dir'     => '/run/nginx',
         }
-      # The following was designed/tested on Ubuntu 18 and Debian 9/10 but probably works on newer versions as well
+        # The following was designed/tested on Ubuntu 18 and Debian 9/10 but probably works on newer versions as well
       } else {
         $_module_os_overrides = {
           'manage_repo'             => true,

--- a/metadata.json
+++ b/metadata.json
@@ -78,7 +78,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "16.04",
-        "18.04"
+        "18.04",
+        "20.04"
       ]
     }
   ]

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -17,7 +17,7 @@ describe 'nginx class:' do
     pkg_match = case fact('operatingsystemmajrelease')
                 when '9', '10'
                   %r{Debian Nginx Maintainers}
-                when '18.04'
+                when '18.04', '20.04'
                   %r{Ubuntu Developers}
                 else
                   %r{Phusion}

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -177,7 +177,7 @@ describe 'nginx' do
 
             it { is_expected.to contain_package('nginx') }
             if facts[:lsbdistid] == 'Debian' && %w[9 10].include?(facts.dig(:os, 'release', 'major')) ||
-               facts[:lsbdistid] == 'Ubuntu' && %w[bionic].include?(facts[:lsbdistcodename])
+               facts[:lsbdistid] == 'Ubuntu' && %w[bionic focal].include?(facts[:lsbdistcodename])
               it { is_expected.to contain_package('libnginx-mod-http-passenger') }
             else
               it { is_expected.to contain_package('passenger') }


### PR DESCRIPTION
now that we dropped puppet 5 we can add ubuntu 20.04 support