### PR TITLE
use more restrictive mode on temp paths

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -209,6 +209,7 @@ class nginx::config {
     file { $client_body_temp_path:
       ensure => directory,
       owner  => $daemon_user,
+      mode   => '0700',
     }
   }
 
@@ -216,6 +217,7 @@ class nginx::config {
     file { $proxy_temp_path:
       ensure => directory,
       owner  => $daemon_user,
+      mode   => '0700',
     }
   }
 

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -325,13 +325,13 @@ describe 'nginx' do
               is_expected.to contain_file('/run/nginx/client_body_temp').with(
                 ensure: 'directory',
                 group: 'root',
-                mode: '0644'
+                mode: '0700'
               )
             else
               is_expected.to contain_file('/var/nginx/client_body_temp').with(
                 ensure: 'directory',
                 group: 'root',
-                mode: '0644'
+                mode: '0700'
               )
             end
           end
@@ -341,13 +341,13 @@ describe 'nginx' do
               is_expected.to contain_file('/run/nginx/proxy_temp').with(
                 ensure: 'directory',
                 group: 'root',
-                mode: '0644'
+                mode: '0700'
               )
             else
               is_expected.to contain_file('/var/nginx/proxy_temp').with(
                 ensure: 'directory',
                 group: 'root',
-                mode: '0644'
+                mode: '0700'
               )
             end
           end


### PR DESCRIPTION
I get this on each run here:

Notice: /Stage[main]/Nginx::Config/File[/run/nginx/client_body_temp]/mode: mode changed '0700' to '0755'
Notice: /Stage[main]/Nginx::Config/File[/run/nginx/proxy_temp]/mode: mode changed '0700' to '0755'

It seems like nginx and this module have different opinions on the
correct mode for those directories. I believe Nginx is more correct,
and we should therefore follow it.

Note that this might apply to your module only if you have a global
File default resource defined.

Fixes: #1272