### PR TITLE
do not set resource defaults on ssl_cert/ssl_key resources

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -597,17 +597,13 @@ define nginx::resource::server (
     if $ssl_key {
       $ssl_key_real = $ssl_key.flatten
       $ssl_key_real.each | $key | {
-        File <| title == $key or path == $key |> {
-          before => Concat::Fragment["${name_sanitized}-ssl-header"],
-        }
+        File <| title == $key or path == $key |> -> Concat::Fragment["${name_sanitized}-ssl-header"]
       }
     }
     if $ssl_cert {
       $ssl_cert_real = $ssl_cert.flatten
       $ssl_cert_real.each | $cert | {
-        File <| title == $cert or path == $cert |> {
-          before => Concat::Fragment["${name_sanitized}-ssl-header"],
-        }
+        File <| title == $cert or path == $cert |> -> Concat::Fragment["${name_sanitized}-ssl-header"]
       }
     }
     concat::fragment { "${name_sanitized}-ssl-header":


### PR DESCRIPTION
#### Pull Request (PR) description
With the merge of #1446 a change has been introduced, which changes permissions on the `ssl_key` and `ssl_cert` files.
This is due to resource defaults set in https://github.com/voxpupuli/puppet-nginx/blob/d51a170a413410b87124ab5ffb11f409c2727a56/manifests/resource/server.pp#L438-L447 and the way, resource dependency is set up in e.g. https://github.com/voxpupuli/puppet-nginx/blob/d51a170a413410b87124ab5ffb11f409c2727a56/manifests/resource/server.pp#L600-L602

If you're managing certificates and setting different owner and group, they will be changed to the user and group defined within this module, which isn't something expected.

#### This Pull Request (PR) fixes the following issues
None