### PR TITLE
Unify (http_)log_format in nginx class and server resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@ class nginx (
   String[1] $log_group                                       = $nginx::params::log_group,
   Stdlib::Filemode $log_mode                                 = $nginx::params::log_mode,
   Variant[String, Array[String]] $http_access_log            = "${log_dir}/${nginx::params::http_access_log_file}",
-  $http_format_log                                           = undef,
+  Optional[String] $http_format_log                          = undef,
   Variant[String, Array[String]] $nginx_error_log            = "${log_dir}/${nginx::params::nginx_error_log_file}",
   Nginx::ErrorLogSeverity $nginx_error_log_severity          = 'error',
   $pid                                                       = $nginx::params::pid,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -390,7 +390,7 @@ define nginx::resource::server (
   Optional[Array[String]] $include_files                                         = undef,
   Optional[Variant[String, Array]] $access_log                                   = undef,
   Optional[Variant[String, Array]] $error_log                                    = undef,
-  $format_log                                                                    = 'combined',
+  Optional[String] $format_log                                                   = $nginx::http_format_log,
   Optional[Hash] $passenger_cgi_param                                            = undef,
   Optional[Hash] $passenger_set_header                                           = undef,
   Optional[Hash] $passenger_env_var                                              = undef,

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -35,7 +35,7 @@ describe 'nginx::resource::server' do
                                                                                            'group' => 'root',
                                                                                            'mode' => '0644')
           end
-          it { is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{access_log\s+/var/log/nginx/www\.rspec\.example\.com\.access\.log combined;}) }
+          it { is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{access_log\s+/var/log/nginx/www\.rspec\.example\.com\.access\.log;}) }
           it { is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{error_log\s+/var/log/nginx/www\.rspec\.example\.com\.error\.log}) }
           it { is_expected.to contain_concat__fragment("#{title}-footer") }
           it { is_expected.to contain_nginx__resource__location("#{title}-default") }
@@ -294,15 +294,15 @@ describe 'nginx::resource::server' do
               title: 'should set access_log',
               attr: 'access_log',
               value: '/path/to/access.log',
-              match: '  access_log            /path/to/access.log combined;'
+              match: '  access_log            /path/to/access.log;'
             },
             {
               title: 'should set multiple access_log directives',
               attr: 'access_log',
               value: ['/path/to/log/1', 'syslog:server=localhost'],
               match: [
-                '  access_log            /path/to/log/1 combined;',
-                '  access_log            syslog:server=localhost combined;'
+                '  access_log            /path/to/log/1;',
+                '  access_log            syslog:server=localhost;'
               ]
             },
             {
@@ -315,7 +315,7 @@ describe 'nginx::resource::server' do
               title: 'should set access_log to syslog',
               attr: 'access_log',
               value: 'syslog:server=localhost',
-              match: '  access_log            syslog:server=localhost combined;'
+              match: '  access_log            syslog:server=localhost;'
             },
             {
               title: 'should set format_log custom_format',
@@ -905,15 +905,15 @@ describe 'nginx::resource::server' do
               title: 'should set access_log',
               attr: 'access_log',
               value: '/path/to/access.log',
-              match: '  access_log            /path/to/access.log combined;'
+              match: '  access_log            /path/to/access.log;'
             },
             {
               title: 'should set multiple access_log directives',
               attr: 'access_log',
               value: ['/path/to/log/1', 'syslog:server=localhost'],
               match: [
-                '  access_log            /path/to/log/1 combined;',
-                '  access_log            syslog:server=localhost combined;'
+                '  access_log            /path/to/log/1;',
+                '  access_log            syslog:server=localhost;'
               ]
             },
             {
@@ -932,7 +932,7 @@ describe 'nginx::resource::server' do
               title: 'should set access_log to syslog',
               attr: 'access_log',
               value: 'syslog:server=localhost',
-              match: '  access_log            syslog:server=localhost combined;'
+              match: '  access_log            syslog:server=localhost;'
             },
             {
               title: 'should set format_log custom_format',
@@ -1418,7 +1418,7 @@ describe 'nginx::resource::server' do
             end
 
             it { is_expected.to contain_nginx__resource__location("#{title}-default").with_ssl_only(true) }
-            it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{access_log\s+/var/log/nginx/ssl-www\.rspec\.example\.com\.access\.log combined;}) }
+            it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{access_log\s+/var/log/nginx/ssl-www\.rspec\.example\.com\.access\.log;}) }
             it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{error_log\s+/var/log/nginx/ssl-www\.rspec\.example\.com\.error\.log}) }
             it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{ssl_certificate\s+dummy.cert;}) }
             it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{ssl_certificate_key\s+dummy.key;}) }
@@ -1437,7 +1437,7 @@ describe 'nginx::resource::server' do
             end
 
             it { is_expected.to contain_nginx__resource__location("#{title}-default").with_ssl_only(true) }
-            it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{access_log\s+/var/log/nginx/ssl-www\.rspec\.example\.com\.access\.log combined;}) }
+            it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{access_log\s+/var/log/nginx/ssl-www\.rspec\.example\.com\.access\.log;}) }
             it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{error_log\s+/var/log/nginx/ssl-www\.rspec\.example\.com\.error\.log}) }
             it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{ssl_verify_client\s+optional;}) }
           end

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -163,15 +163,15 @@ server {
 <% end -%>
 <% if @access_log.is_a?(Array) -%>
   <%- @access_log.each do |log_item| -%>
-  access_log            <%= log_item %> <%= @format_log %>;
+  access_log            <%= log_item %><% if @format_log %> <%= @format_log%><% end %>;
   <%- end -%>
 <% elsif @access_log == 'absent' -%>
 <% elsif @access_log == 'off' -%>
   access_log            off;
 <% elsif not @access_log -%>
-  access_log            <%= scope['::nginx::config::log_dir'] %>/<%= @name_sanitized %>.access.log <%= @format_log %>;
+  access_log            <%= scope['::nginx::config::log_dir'] %>/<%= @name_sanitized %>.access.log<% if @format_log %> <%= @format_log%><% end %>;
 <% else -%>
-  access_log            <%= @access_log %> <%= @format_log %>;
+  access_log            <%= @access_log %><% if @format_log %> <%= @format_log%><% end %>;
 <% end -%>
 <% if @error_log.is_a?(Array) -%>
   <%- @error_log.each do |log_item| -%>

--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -96,15 +96,15 @@ server {
 <% end -%>
 <% if @access_log.is_a?(Array) -%>
   <%- @access_log.each do |log_item| -%>
-  access_log            <%= log_item %> <%= @format_log %>;
+  access_log            <%= log_item %><% if @format_log %> <%= @format_log%><% end %>;
   <%- end -%>
 <% elsif @access_log == 'absent' -%>
 <% elsif @access_log == 'off' -%>
   access_log            off;
 <% elsif not @access_log -%>
-  access_log            <%= scope['::nginx::config::log_dir'] %>/ssl-<%= @name_sanitized %>.access.log <%= @format_log %>;
+  access_log            <%= scope['::nginx::config::log_dir'] %>/ssl-<%= @name_sanitized %>.access.log<% if @format_log %> <%= @format_log%><% end %>;
 <% else -%>
-  access_log            <%= @access_log %> <%= @format_log %>;
+  access_log            <%= @access_log %><% if @format_log %> <%= @format_log%><% end %>;
 <% end -%>
 <% if @error_log.is_a?(Array) -%>
   <%- @error_log.each do |log_item| -%>


### PR DESCRIPTION
#### Pull Request (PR) description
This PR unifies `nginx::http_log_format` and `nginx::resource::server::log_format` that the later defaults to the generic set default value.

If no generic default value is set nginx itself will default to the "old" default value of "combined" (see http://nginx.org/en/docs/http/ngx_http_log_module.html#access_log)

As there are already tests which test the behavior of `nginx::http_log_format` and `nginx::resource::server::log_format` there were no additional tests added.

#### This Pull Request (PR) fixes the following issues
Relates #773
