### PR TITLE
default ipv6_listen_port to listen_port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   setup_matrix:
     name: 'Setup Test Matrix'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     outputs:
       beaker_setfiles: ${{ steps.get-outputs.outputs.beaker_setfiles }}
       puppet_major_versions: ${{ steps.get-outputs.outputs.puppet_major_versions }}
@@ -31,7 +31,7 @@ jobs:
   unit:
     needs: setup_matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,9 +1,3 @@
 ---
-.travis.yml:
-  secure: "SDpX6jzritODonEQBqy9g0NbOmk2a9dBfAtZLrvHwM8BTpM2W0Y1daqzIbpzxFiqlNX+6r2GSq9SV70N0A9Ko/uPV9aG/XZx7MsBR9DNVjgqjJSl7+aF88VJfRpOv4PAyTM33JMx91nLFxM/ql61YX+2DXGXrhUkBsMZcdBgQnk="
-  docker_sets:
-  - set: ubuntu1604-64
-  - set: ubuntu1804-64
-  - set: centos7-64
-  - set: debian9-64
-  - set: debian10-64
+.github/workflows/ci.yml:
+  timeout_minutes: 60

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -132,7 +132,7 @@ define nginx::resource::mailhost (
   Optional[String] $listen_options               = undef,
   Boolean $ipv6_enable                           = false,
   Variant[Array[String], String] $ipv6_listen_ip = '::',
-  Stdlib::Port $ipv6_listen_port                 = 80,
+  Stdlib::Port $ipv6_listen_port                 = $listen_port,
   String $ipv6_listen_options                    = 'default ipv6only=on',
   Boolean $ssl                                   = false,
   Optional[String] $ssl_cert                     = undef,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -284,7 +284,7 @@
 define nginx::resource::server (
   Enum['absent', 'present'] $ensure                                              = 'present',
   Variant[Array, String] $listen_ip                                              = '*',
-  Integer $listen_port                                                           = 80,
+  Stdlib::Port $listen_port                                                      = 80,
   Optional[String] $listen_options                                               = undef,
   Boolean $listen_unix_socket_enable                                             = false,
   Variant[Array[Stdlib::Absolutepath], Stdlib::Absolutepath] $listen_unix_socket = '/var/run/nginx.sock',
@@ -294,7 +294,7 @@ define nginx::resource::server (
   Array $location_deny                                                           = [],
   Boolean $ipv6_enable                                                           = false,
   Variant[Array, String] $ipv6_listen_ip                                         = '::',
-  Integer $ipv6_listen_port                                                      = 80,
+  Stdlib::Port $ipv6_listen_port                                                 = $listen_port,
   String $ipv6_listen_options                                                    = 'default ipv6only=on',
   Hash $add_header                                                               = {},
   Boolean $ssl                                                                   = false,

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -56,7 +56,7 @@ define nginx::resource::streamhost (
   Optional[String] $listen_options             = undef,
   Boolean $ipv6_enable                         = false,
   Variant[Array, String] $ipv6_listen_ip       = '::',
-  Integer $ipv6_listen_port                    = 80,
+  Integer $ipv6_listen_port                    = $listen_port,
   String $ipv6_listen_options                  = 'default ipv6only=on',
   $proxy                                       = undef,
   String $proxy_read_timeout                   = $nginx::proxy_read_timeout,

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -61,19 +61,19 @@ describe 'nginx::resource::mailhost' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: '  listen                [::]:80 default ipv6only=on;'
+              match: '  listen                [::]:25 default ipv6only=on;'
             },
             {
               title: 'should not enable IPv6',
               attr: 'ipv6_enable',
               value: false,
-              notmatch: %r{  listen                \[::\]:80 default ipv6only=on;}
+              notmatch: %r{  listen                \[::\]:25 default ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: '  listen                [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:80 default ipv6only=on;'
+              match: '  listen                [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:25 default ipv6only=on;'
             },
             {
               title: 'should set the IPv6 listen port',
@@ -85,7 +85,7 @@ describe 'nginx::resource::mailhost' do
               title: 'should set the IPv6 listen options',
               attr: 'ipv6_listen_options',
               value: 'spdy',
-              match: '  listen                [::]:80 spdy;'
+              match: '  listen                [::]:25 spdy;'
             },
             {
               title: 'should set servername(s)',


### PR DESCRIPTION
in 99% of the deployments both ports are identical. to make this easier
for the users we can just tell puppet that the default value for
$ipv6_listen_port is the value of $listen_port. That makes it easier for
people that want their dual stack application to listen on a nonstandard
port. They only need to set it once.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
