### PR TITLE
Add stream log support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,6 +21,7 @@ class nginx::config {
   $log_mode                       = $nginx::log_mode
   $http_access_log                = $nginx::http_access_log
   $http_format_log                = $nginx::http_format_log
+  $stream_access_log              = $nginx::stream_access_log
   $nginx_error_log                = $nginx::nginx_error_log
   $nginx_error_log_severity       = $nginx::nginx_error_log_severity
   $pid                            = $nginx::pid

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,6 +22,7 @@ class nginx::config {
   $http_access_log                = $nginx::http_access_log
   $http_format_log                = $nginx::http_format_log
   $stream_access_log              = $nginx::stream_access_log
+  $stream_custom_format_log       = $nginx::stream_custom_format_log
   $nginx_error_log                = $nginx::nginx_error_log
   $nginx_error_log_severity       = $nginx::nginx_error_log_severity
   $pid                            = $nginx::pid

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -73,6 +73,7 @@ class nginx::config {
   $keepalive_timeout              = $nginx::keepalive_timeout
   $keepalive_requests             = $nginx::keepalive_requests
   $log_format                     = $nginx::log_format
+  $stream_log_format              = $nginx::stream_log_format
   $mail                           = $nginx::mail
   $mime_types_path                = $nginx::mime_types_path
   $stream                         = $nginx::stream

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,6 +66,7 @@ class nginx (
   Variant[String, Array[String]] $http_access_log            = "${log_dir}/${nginx::params::http_access_log_file}",
   Optional[String] $http_format_log                          = undef,
   Variant[String, Array[String]] $stream_access_log          = "${log_dir}/stream-access.log",
+  Optional[String] $stream_custom_format_log                 = undef,
   Variant[String, Array[String]] $nginx_error_log            = "${log_dir}/${nginx::params::nginx_error_log_file}",
   Nginx::ErrorLogSeverity $nginx_error_log_severity          = 'error',
   $pid                                                       = $nginx::params::pid,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,7 @@ class nginx (
   Stdlib::Filemode $log_mode                                 = $nginx::params::log_mode,
   Variant[String, Array[String]] $http_access_log            = "${log_dir}/${nginx::params::http_access_log_file}",
   Optional[String] $http_format_log                          = undef,
+  Variant[String, Array[String]] $stream_access_log          = "${log_dir}/stream-access.log",
   Variant[String, Array[String]] $nginx_error_log            = "${log_dir}/${nginx::params::nginx_error_log_file}",
   Nginx::ErrorLogSeverity $nginx_error_log_severity          = 'error',
   $pid                                                       = $nginx::params::pid,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,6 +124,7 @@ class nginx (
   $keepalive_timeout                                         = '65s',
   $keepalive_requests                                        = '100',
   Hash[String[1], Nginx::LogFormat] $log_format              = {},
+  Hash[String[1], Nginx::LogFormat] $stream_log_format       = {},
   Boolean $mail                                              = false,
   Variant[String, Boolean] $mime_types_path                  = 'mime.types',
   Boolean $stream                                            = false,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -1541,10 +1541,36 @@ describe 'nginx' do
               )
             end
 
-            it do
-              is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(
-                %r{access_log\s/var/log/nginx/stream-access.log;}
-              )
+            context 'when stream_log_format is defined' do
+              let(:params) do
+                super().merge({ stream_log_format: { 'stream_format' => 'STREAM_FORMAT' } })
+              end
+
+              it do
+                is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(
+                  %r{log_format stream_format 'STREAM_FORMAT';}
+                )
+              end
+            end
+
+            context 'when stream_custom_format_log is default' do
+              it do
+                is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(
+                  %r{access_log /var/log/nginx/stream-access.log;}
+                )
+              end
+            end
+
+            context 'when stream_custom_format_log is non-default' do
+              let(:params) do
+                super().merge({ stream_custom_format_log: 'stream_format' })
+              end
+
+              it do
+                is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(
+                  %r{access_log /var/log/nginx/stream-access.log stream_format;}
+                )
+              end
             end
           end
         end

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -1531,6 +1531,22 @@ describe 'nginx' do
               )
             end
           end
+
+          context 'when stream is true' do
+            let(:params) { { stream: true } }
+
+            it do
+              is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(
+                %r{stream\s\{}
+              )
+            end
+
+            it do
+              is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(
+                %r{access_log\s/var/log/nginx/stream-access.log;}
+              )
+            end
+          end
         end
       end
     end

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -339,10 +339,10 @@ stream {
 
 <% if @stream_access_log.is_a?(Array) -%>
   <%- @stream_access_log.each do |log_item| -%>
-  access_log <%= log_item %>;
+  access_log <%= log_item %><% if @stream_custom_format_log %> <%= @stream_custom_format_log%><% end %>;
   <%- end -%>
 <% else -%>
-  access_log <%= @stream_access_log %>;
+  access_log <%= @stream_access_log %><% if @stream_custom_format_log %> <%= @stream_custom_format_log%><% end %>;
 <% end -%>
 }
 <% end -%>

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -330,5 +330,13 @@ stream {
 <% unless @confd_only -%>
   include <%= @conf_dir %>/streams-enabled/*;
 <% end -%>
+
+<% if @stream_access_log.is_a?(Array) -%>
+  <%- @stream_access_log.each do |log_item| -%>
+  access_log <%= log_item %>;
+  <%- end -%>
+<% else -%>
+  access_log <%= @stream_access_log %>;
+<% end -%>
 }
 <% end -%>

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -330,19 +330,15 @@ stream {
 <% unless @confd_only -%>
   include <%= @conf_dir %>/streams-enabled/*;
 <% end -%>
-
 <% unless @stream_log_format.empty? -%>
-<% @stream_log_format.sort_by{|k,v| k}.each do |key,value| -%>
+
+<% @stream_log_format.sort.each do |key,value| -%>
   log_format <%= key %> '<%= value %>';
 <% end -%>
 <% end -%>
 
-<% if @stream_access_log.is_a?(Array) -%>
-  <%- @stream_access_log.each do |log_item| -%>
+<%- Array(@stream_access_log).each do |log_item| -%>
   access_log <%= log_item %><% if @stream_custom_format_log %> <%= @stream_custom_format_log%><% end %>;
-  <%- end -%>
-<% else -%>
-  access_log <%= @stream_access_log %><% if @stream_custom_format_log %> <%= @stream_custom_format_log%><% end %>;
 <% end -%>
 }
 <% end -%>

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -331,6 +331,12 @@ stream {
   include <%= @conf_dir %>/streams-enabled/*;
 <% end -%>
 
+<% unless @stream_log_format.empty? -%>
+<% @stream_log_format.sort_by{|k,v| k}.each do |key,value| -%>
+  log_format <%= key %> '<%= value %>';
+<% end -%>
+<% end -%>
+
 <% if @stream_access_log.is_a?(Array) -%>
   <%- @stream_access_log.each do |log_item| -%>
   access_log <%= log_item %>;


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Following on work from previous PRs to add stream log changes to the module.

Updated changes to fix file conflicts and newer changes in v4.1.0
 
The configuration in Hiera:

```yaml
nginx::stream_access_log: '/var/log/nginx/nginx-stream-access.log'
nginx::stream_custom_format_log: 'basic'
nginx::stream_log_format:
  basic: '$remote_addr [$time_local] $protocol $status $bytes_sent $bytes_received $session_time $server_addr:$server_port $upstream_addr'
```

Adds the following lines to nginx.conf:

```shell
+  log_format basic '$remote_addr [$time_local] $protocol $status $bytes_sent $bytes_received $session_time $server_addr:$server_port $upstream_addr';
 
+  access_log /var/log/nginx/nginx-stream-access.log basic;
```

If `stream_custom_format_log` is not set, nginx will use the built-in `combined` log format for the stream access log.

#### This Pull Request (PR) fixes the following issue

Closes: https://github.com/voxpupuli/puppet-nginx/pull/1439
