### PR TITLE
Add support for log_format escape parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -116,7 +116,7 @@ class nginx (
   Enum['on', 'off'] $http_tcp_nopush                         = 'off',
   $keepalive_timeout                                         = '65s',
   $keepalive_requests                                        = '100',
-  $log_format                                                = {},
+  Hash[String[1],Nginx::Log_format] $log_format              = {},
   Boolean $mail                                              = false,
   Variant[String, Boolean] $mime_types_path                  = 'mime.types',
   Boolean $stream                                            = false,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -562,11 +562,13 @@ describe 'nginx' do
                 attr: 'log_format',
                 value: {
                   'format1' => 'FORMAT1',
-                  'format2' => 'FORMAT2'
+                  'format2' => 'FORMAT2',
+                  'format3' => ['escape=json', '{"auth": "$remote_user"}']
                 },
                 match: [
                   '  log_format format1 \'FORMAT1\';',
-                  '  log_format format2 \'FORMAT2\';'
+                  '  log_format format2 \'FORMAT2\';',
+                  '  log_format format3 \'escape=json\' \'{"auth": "$remote_user"}\';'
                 ]
               },
               {

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -74,7 +74,7 @@ http {
   default_type  application/octet-stream;
 <% if @log_format -%>
 <% @log_format.sort_by{|k,v| k}.each do |key,value| -%>
-  log_format <%= key %> '<%= value %>';
+  log_format <%= key %> <%= [value].flatten.map { |v| "'#{v}'" }.join(' ') %>;
 <% end -%>
 <% end -%>
 

--- a/types/log_format.pp
+++ b/types/log_format.pp
@@ -1,0 +1,11 @@
+type Nginx::Log_format = Variant[
+  String[1],
+  Tuple[
+    Enum[
+      'escape=default',
+      'escape=json',
+      'escape=none',
+    ],
+    String[1],
+  ],
+]


### PR DESCRIPTION
#### Pull Request (PR) description

The [escape parameter] was added to nginx 1.11.8.  This optional
parameter allow 3 values: 'default', 'json' and 'none'.  Setting this
parameter is currently tricky do to the way the configuration snippet is
generated (note the unbalanced quotes in the middle of the log string):

```puppet
class { 'nginx':
  # ...
  log_format => {
    json_combined => "escape=json' '{...}",
    #                            ^ ^
    #                            | `-- start quote of the log string
    #                            `---- end quote of the escape format
  }
}
```

Adjust the data type of the log_format parameter to match the "legacy"
way of only passing a Hash consisting of a name (String) matching a
format string (String), but also accept a Tuple for the escape parameter
(Enum) followed by the format string, allowing a less cluttered Puppet
manifest:

```puppet
class { 'nginx':
  # ...
  log_format => {
    json_combined => [
      'escape=json',
      '{...}',
    ],
  },
}
```

[escape parameter]: https://nginx.org/en/docs/http/ngx_http_log_module.html#log_format

#### This Pull Request (PR) fixes the following issues
n/a