### PR TITLE
add support to access_log, error_log log_not_found per location

### DIFF
--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -319,9 +319,9 @@ define nginx::resource::location (
   Hash $add_header                                                 = {},
   Optional[Enum['on', 'off', 'always']] $gzip_static               = undef,
   Optional[Enum['on', 'off']] $reset_timedout_connection           = undef,
-  Optional[Variant[Array, String]] $access_log                     = undef,
-  Optional[Variant[Array, String]] $error_log                      = undef,
-  Optional[String] $format_log                                     = $nginx::http_format_log,
+  Optional[Variant[Array[String[1], 1], String[1]]] $access_log    = undef,
+  Optional[Variant[Array[String[1], 1], String[1]]] $error_log     = undef,
+  Optional[String[1]] $format_log                                  = $nginx::http_format_log,
   Optional[Enum['on', 'off']] $log_not_found                       = undef,
 ) {
   if !defined(Class['nginx']) {

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -236,6 +236,69 @@ describe 'nginx::resource::location' do
               attr: 'reset_timedout_connection',
               value: 'on',
               match: %r{^\s+reset_timedout_connection\s+on;}
+            },
+            {
+              title: 'access_log undef',
+              attr: 'access_log',
+              value: :undef,
+              notmatch: %r{\s+access_log\s+.+;}
+            },
+            {
+              title: 'disabling access_log ',
+              attr: 'access_log',
+              value: 'off',
+              match: %r{\s+access_log\s+off;}
+            },
+            {
+              title: 'override access_log ',
+              attr: 'access_log',
+              value: '/var/log/nginx/specific-location.log',
+              match: %r{\s+access_log\s+/var/log/nginx/specific-location\.log;}
+            },
+            {
+              title: 'override access_log with an array',
+              attr: 'access_log',
+              value: [
+                '/var/log/nginx/specific-location.log',
+                'syslog:server=10.0.0.1'
+              ],
+              match: [
+                %r{\s+access_log\s+/var/log/nginx/specific-location\.log;},
+                %r{\s+access_log\s+syslog:server=10\.0\.0\.1\s*;}
+              ]
+            },
+            {
+              title: 'enabling logging errors not found',
+              attr: 'log_not_found',
+              value: 'off',
+              match: %r{\s+log_not_found\s+off;}
+            },
+            {
+              title: 'enabling logging errors not found',
+              attr: 'log_not_found',
+              value: 'on',
+              match: %r{\s+log_not_found\s+on;}
+            },
+            {
+              title: 'should set error_log',
+              attr: 'error_log',
+              value: '/path/to/error.log',
+              match: '  error_log             /path/to/error.log;'
+            },
+            {
+              title: 'should allow multiple error_log directives',
+              attr: 'error_log',
+              value: ['/path/to/error.log', 'syslog:server=localhost'],
+              match: [
+                '  error_log             /path/to/error.log;',
+                '  error_log             syslog:server=localhost;'
+              ]
+            },
+            {
+              title: 'should not include error_log in server when set to absent',
+              attr: 'error_log',
+              value: 'absent',
+              notmatch: 'error_log'
             }
           ].each do |param|
             context "when #{param[:attr]} is #{param[:value]}" do
@@ -1002,70 +1065,7 @@ describe 'nginx::resource::location' do
               attr: 'proxy_busy_buffers_size',
               value: '16k',
               match: %r{\s+proxy_busy_buffers_size\s+16k;}
-            },
-            {
-              title: 'access_log undef',
-              attr: 'access_log',
-              value: :undef,
-              notmatch: %r{\s+access_log\s+.+;}
-            },
-            {
-              title: 'disabling access_log ',
-              attr: 'access_log',
-              value: 'off',
-              match: %r{\s+access_log\s+off;}
-            },
-            {
-              title: 'override access_log ',
-              attr: 'access_log',
-              value: '/var/log/nginx/specific-location.log',
-              match: %r{\s+access_log\s+/var/log/nginx/specific-location\.log;}
-            },
-            {
-              title: 'override access_log with an array',
-              attr: 'access_log',
-              value: [
-                '/var/log/nginx/specific-location.log',
-                'syslog:server=10.0.0.1'
-              ],
-              match: [
-                %r{\s+access_log\s+/var/log/nginx/specific-location\.log;},
-                %r{\s+access_log\s+syslog:server=10\.0\.0\.1\s*;}
-              ]
-            },
-            {
-              title: 'enabling logging errors not found',
-              attr: 'log_not_found',
-              value: 'off',
-              match: %r{\s+log_not_found\s+off;}
-            },
-            {
-              title: 'enabling logging errors not found',
-              attr: 'log_not_found',
-              value: 'on',
-              match: %r{\s+log_not_found\s+on;}
-            },
-            {
-              title: 'should set error_log',
-              attr: 'error_log',
-              value: '/path/to/error.log',
-              match: '  error_log             /path/to/error.log;'
-            },
-            {
-              title: 'should allow multiple error_log directives',
-              attr: 'error_log',
-              value: ['/path/to/error.log', 'syslog:server=localhost'],
-              match: [
-                '  error_log             /path/to/error.log;',
-                '  error_log             syslog:server=localhost;'
-              ]
-            },
-            {
-              title: 'should not include error_log in server when set to absent',
-              attr: 'error_log',
-              value: 'absent',
-              notmatch: 'error_log'
-            },
+            }
           ].each do |param|
             context "when #{param[:attr]} is #{param[:value]}" do
               let(:default_params) { { location: 'location', proxy: 'proxy_value', server: 'server1' } }

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -1002,7 +1002,70 @@ describe 'nginx::resource::location' do
               attr: 'proxy_busy_buffers_size',
               value: '16k',
               match: %r{\s+proxy_busy_buffers_size\s+16k;}
-            }
+            },
+            {
+              title: 'access_log undef',
+              attr: 'access_log',
+              value: :undef,
+              notmatch: %r{\s+access_log\s+.+;}
+            },
+            {
+              title: 'disabling access_log ',
+              attr: 'access_log',
+              value: 'off',
+              match: %r{\s+access_log\s+off;}
+            },
+            {
+              title: 'override access_log ',
+              attr: 'access_log',
+              value: '/var/log/nginx/specific-location.log',
+              match: %r{\s+access_log\s+/var/log/nginx/specific-location\.log;}
+            },
+            {
+              title: 'override access_log with an array',
+              attr: 'access_log',
+              value: [
+                '/var/log/nginx/specific-location.log',
+                'syslog:server=10.0.0.1'
+              ],
+              match: [
+                %r{\s+access_log\s+/var/log/nginx/specific-location\.log;},
+                %r{\s+access_log\s+syslog:server=10\.0\.0\.1\s*;}
+              ]
+            },
+            {
+              title: 'enabling logging errors not found',
+              attr: 'log_not_found',
+              value: 'off',
+              match: %r{\s+log_not_found\s+off;}
+            },
+            {
+              title: 'enabling logging errors not found',
+              attr: 'log_not_found',
+              value: 'on',
+              match: %r{\s+log_not_found\s+on;}
+            },
+            {
+              title: 'should set error_log',
+              attr: 'error_log',
+              value: '/path/to/error.log',
+              match: '  error_log             /path/to/error.log;'
+            },
+            {
+              title: 'should allow multiple error_log directives',
+              attr: 'error_log',
+              value: ['/path/to/error.log', 'syslog:server=localhost'],
+              match: [
+                '  error_log             /path/to/error.log;',
+                '  error_log             syslog:server=localhost;'
+              ]
+            },
+            {
+              title: 'should not include error_log in server when set to absent',
+              attr: 'error_log',
+              value: 'absent',
+              notmatch: 'error_log'
+            },
           ].each do |param|
             context "when #{param[:attr]} is #{param[:value]}" do
               let(:default_params) { { location: 'location', proxy: 'proxy_value', server: 'server1' } }

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -83,3 +83,28 @@
 <% if @reset_timedout_connection -%>
   reset_timedout_connection <%= @reset_timedout_connection %>;
 <% end -%>
+<% if @log_not_found -%>
+    log_not_found <%= @log_not_found %>;
+<% end -%>
+<% if @access_log -%>
+    <% if @access_log.is_a?(Array) -%>
+        <%- @access_log.each do |log_item| -%>
+  access_log            <%= log_item %><% unless @format_log.nil? -%> <%= @format_log %><% end -%>;
+        <%- end -%>
+    <% elsif @access_log == 'absent' -%>
+    <% elsif @access_log == 'off' -%>
+  access_log            off;
+    <% else -%>
+    access_log <%= @access_log %><% unless @format_log.nil? -%> <%= @format_log %><% end -%>;
+    <% end -%>
+<% end -%>
+<% if @error_log.is_a?(Array) -%>
+  <%- @error_log.each do |log_item| -%>
+  error_log             <%= log_item %>;
+  <%- end -%>
+<% elsif @error_log == 'absent' -%>
+<% elsif not @error_log -%>
+  error_log             <%= scope['::nginx::config::log_dir'] %>/<%= @name_sanitized %>.error.log;
+<% else -%>
+  error_log             <%= @error_log %>;
+<% end -%>


### PR DESCRIPTION
Hello,
This PR adds the support of the following directives at location level
  
- access_log
- error_log
- log_not_found 

it allows to be more precise in the logging strategy. 

Hope it helps.

