### PR TITLE
Fix CI on CentOS 7

### DIFF
--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -4,7 +4,14 @@ describe 'nginx class' do
   context 'default parameters' do
     # Using puppet_apply as a helper
     it 'works idempotently with no errors' do
-      pp = 'include nginx'
+      pp = "
+      include nginx
+
+      nginx::resource::server { 'example.com':
+        ensure   => present,
+        www_root => '/var/www/html',
+      }
+      "
 
       # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)
@@ -35,7 +42,16 @@ describe 'nginx class' do
   context 'with service_config_check true' do
     # Using puppet_apply as a helper
     it 'works idempotently with no errors' do
-      pp = "class { 'nginx': service_config_check => true, }"
+      pp = "
+      class { 'nginx':
+        service_config_check => true,
+      }
+
+      nginx::resource::server { 'example.com':
+        ensure   => present,
+        www_root => '/var/www/html',
+      }
+      "
 
       # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)

--- a/spec/acceptance/nginx_mail_spec.rb
+++ b/spec/acceptance/nginx_mail_spec.rb
@@ -3,8 +3,18 @@ require 'spec_helper_acceptance'
 describe 'nginx::resource::mailhost define:' do
   it 'runs successfully' do
     pp = "
+    if fact('os.family') == 'RedHat' {
+      package { 'nginx-mod-mail':
+        ensure => installed,
+      }
+    }
+
     class { 'nginx':
-      mail => true,
+      mail            => true,
+      dynamic_modules => fact('os.family') ? {
+        'RedHat' => ['/usr/lib64/nginx/modules/ngx_mail_module.so'],
+        default  => [],
+      }
     }
     nginx::resource::mailhost { 'domain1.example':
       ensure      => present,
@@ -39,9 +49,19 @@ describe 'nginx::resource::mailhost define:' do
   context 'when configured for nginx 1.14' do
     it 'runs successfully' do
       pp = "
+    if fact('os.family') == 'RedHat' {
+      package { 'nginx-mod-mail':
+        ensure => installed,
+      }
+    }
+
     class { 'nginx':
-      mail          => true,
-      nginx_version => '1.14.0',
+      mail            => true,
+      nginx_version   => '1.14.0',
+      dynamic_modules => fact('os.family') ? {
+        'RedHat' => ['/usr/lib64/nginx/modules/ngx_mail_module.so'],
+        default  => [],
+      }
     }
     nginx::resource::mailhost { 'domain1.example':
       ensure      => present,


### PR DESCRIPTION
These commits fix CI on CentOS 7 :tada: 

Management of the mail module can be improved in multiple way, but for now I focused on fixing CI so I just ensure that what is not managed by the module and is required is properly setup in the regression test suite.

The configuration of the mail module in CI now match the configuration I have in place for passenger which the module does not handle on CentOS.  We can probably improve this area in another PR to have the module able to have a similar behavior on CentOS and on Debian.