### PR TITLE
make directory mode configurable for client_body_temp_path and proxy_temp_path

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -82,7 +82,10 @@ The following parameters are available in the `nginx` class:
 * [`reset_timedout_connection`](#-nginx--reset_timedout_connection)
 * [`nginx_snippets`](#-nginx--nginx_snippets)
 * [`nginx_snippets_defaults`](#-nginx--nginx_snippets_defaults)
+* [`proxy_temp_mode`](#-nginx--proxy_temp_mode)
+* [`proxy_temp_path`](#-nginx--proxy_temp_path)
 * [`client_body_temp_path`](#-nginx--client_body_temp_path)
+* [`client_body_temp_mode`](#-nginx--client_body_temp_mode)
 * [`confd_only`](#-nginx--confd_only)
 * [`confd_purge`](#-nginx--confd_purge)
 * [`conf_dir`](#-nginx--conf_dir)
@@ -104,7 +107,6 @@ The following parameters are available in the `nginx` class:
 * [`nginx_error_log`](#-nginx--nginx_error_log)
 * [`nginx_error_log_severity`](#-nginx--nginx_error_log_severity)
 * [`pid`](#-nginx--pid)
-* [`proxy_temp_path`](#-nginx--proxy_temp_path)
 * [`root_group`](#-nginx--root_group)
 * [`sites_available_owner`](#-nginx--sites_available_owner)
 * [`sites_available_group`](#-nginx--sites_available_group)
@@ -326,11 +328,35 @@ Can be used to define default values for the parameter `nginx_snippets`.
 
 Default value: `{}`
 
+##### <a name="-nginx--proxy_temp_mode"></a>`proxy_temp_mode`
+
+Data type: `Optional[Stdlib::Filemode]`
+
+Permissions for the $proxy_temp_path file resource.
+
+Default value: `undef`
+
+##### <a name="-nginx--proxy_temp_path"></a>`proxy_temp_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Directory for storing temporary files with data received from proxied servers.
+
+Default value: `undef`
+
 ##### <a name="-nginx--client_body_temp_path"></a>`client_body_temp_path`
 
 Data type: `Optional[Stdlib::Absolutepath]`
 
+Directory for storing temporary files holding client request bodies.
 
+Default value: `undef`
+
+##### <a name="-nginx--client_body_temp_mode"></a>`client_body_temp_mode`
+
+Data type: `Optional[Stdlib::Filemode]`
+
+Permissions for the $client_body_temp_path file resource.
 
 Default value: `undef`
 
@@ -501,14 +527,6 @@ Data type: `Any`
 
 
 Default value: `$nginx::params::pid`
-
-##### <a name="-nginx--proxy_temp_path"></a>`proxy_temp_path`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-
-
-Default value: `undef`
 
 ##### <a name="-nginx--root_group"></a>`root_group`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -206,7 +206,7 @@ class nginx::config {
     file { $client_body_temp_path:
       ensure => directory,
       owner  => $daemon_user,
-      mode   => '0700',
+      mode   => $nginx::client_body_temp_mode,
     }
   }
 
@@ -214,7 +214,7 @@ class nginx::config {
     file { $proxy_temp_path:
       ensure => directory,
       owner  => $daemon_user,
-      mode   => '0700',
+      mode   => $nginx::proxy_temp_mode,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,9 +44,22 @@
 # @param nginx_snippets_defaults
 #   Can be used to define default values for the parameter `nginx_snippets`.
 #
+# @param proxy_temp_mode
+#   Permissions for the $proxy_temp_path file resource.
+#
+# @param proxy_temp_path
+#   Directory for storing temporary files with data received from proxied servers.
+#
+# @param client_body_temp_path
+#   Directory for storing temporary files holding client request bodies.
+#
+# @param client_body_temp_mode
+#    Permissions for the $client_body_temp_path file resource.
+#
 class nginx (
   ### START Nginx Configuration ###
   Optional[Stdlib::Absolutepath] $client_body_temp_path      = undef,
+  Optional[Stdlib::Filemode] $client_body_temp_mode          = undef,
   Boolean $confd_only                                        = false,
   Boolean $confd_purge                                       = false,
   $conf_dir                                                  = $nginx::params::conf_dir,
@@ -69,6 +82,7 @@ class nginx (
   Nginx::ErrorLogSeverity $nginx_error_log_severity          = 'error',
   $pid                                                       = $nginx::params::pid,
   Optional[Stdlib::Absolutepath] $proxy_temp_path            = undef,
+  Optional[Stdlib::Filemode] $proxy_temp_mode                = undef,
   $root_group                                                = $nginx::params::root_group,
   $sites_available_owner                                     = $nginx::params::sites_available_owner,
   $sites_available_group                                     = $nginx::params::sites_available_group,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -1427,6 +1427,52 @@ describe 'nginx' do
             it { is_expected.to contain_file('/var/log/nginx').with(mode: '0771') }
           end
 
+          context 'when proxy_temp_path is non-default' do
+            let(:params) { { proxy_temp_path: '/tmp/nginx_proxy' } }
+
+            it do
+              is_expected.to contain_file('/tmp/nginx_proxy').
+                without('mode')
+            end
+          end
+
+          context 'when proxy_temp_mode is non-default' do
+            let(:params) do
+              {
+                proxy_temp_path: '/tmp/nginx_proxy',
+                proxy_temp_mode: '0771',
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/tmp/nginx_proxy').
+                with_mode('0771')
+            end
+          end
+
+          context 'when client_body_temp_path is non-default' do
+            let(:params) { { client_body_temp_path: '/tmp/nginx_client' } }
+
+            it do
+              is_expected.to contain_file('/tmp/nginx_client').
+                without('mode')
+            end
+          end
+
+          context 'when client_body_temp_mode is non-default' do
+            let(:params) do
+              {
+                client_body_temp_path: '/tmp/nginx_client',
+                client_body_temp_mode: '0771',
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/tmp/nginx_client').
+                with_mode('0771')
+            end
+          end
+
           context 'when gzip is non-default (on) test gzip defaults' do
             let(:params) { { gzip: 'on' } }
 


### PR DESCRIPTION
#### Pull Request (PR) description
nginx manages the directory permissions on its own,
so the default value is `undef` to avoid conflicts.

#### This Pull Request (PR) fixes the following issues
Related to #1443
