### PR TITLE
Add support for sieve protocol

### DIFF
--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -153,7 +153,7 @@ define nginx::resource::mailhost (
   Optional[String] $ssl_trusted_cert             = undef,
   Optional[Integer] $ssl_verify_depth            = undef,
   Enum['on', 'off', 'only'] $starttls            = 'off',
-  Optional[Enum['imap', 'pop3', 'smtp']] $protocol = undef,
+  Optional[Enum['imap', 'pop3', 'sieve', 'smtp']] $protocol = undef,
   Optional[String] $auth_http                    = undef,
   Optional[String] $auth_http_header             = undef,
   Enum['on', 'off'] $xclient                     = 'on',


### PR DESCRIPTION
This is not in upstream nginx (yet), but is available at
https://github.com/AntagonistHQ/nginx/tree/sieve_v2

#### Pull Request (PR) description
This PR allows the word "sieve" to be used as a protocol. Upstream nginx doesn't support this, so I can understand if this PR gets denied for that. On the other hand, it is a very minor change so I am still hoping it gets accepted.
