### PR TITLE
(1372) Drop run_dir and make client_body_temp_path/proxy_temp_path optional

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,7 +26,6 @@ class nginx::config {
   $pid                            = $nginx::pid
   $proxy_temp_path                = $nginx::proxy_temp_path
   $root_group                     = $nginx::root_group
-  $run_dir                        = $nginx::run_dir
   $sites_available_owner          = $nginx::sites_available_owner
   $sites_available_group          = $nginx::sites_available_group
   $sites_available_mode           = $nginx::sites_available_mode
@@ -187,11 +186,6 @@ class nginx::config {
       purge   => true,
       recurse => true,
     }
-  }
-
-  file { $run_dir:
-    ensure => directory,
-    mode   => '0644',
   }
 
   if $nginx::manage_snippets_dir {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,7 +40,7 @@
 #
 class nginx (
   ### START Nginx Configuration ###
-  Variant[Stdlib::Absolutepath, Boolean] $client_body_temp_path = $nginx::params::client_body_temp_path,
+  Optional[Stdlib::Absolutepath] $client_body_temp_path      = undef,
   Boolean $confd_only                                        = false,
   Boolean $confd_purge                                       = false,
   $conf_dir                                                  = $nginx::params::conf_dir,
@@ -61,9 +61,8 @@ class nginx (
   Variant[String, Array[String]] $nginx_error_log            = "${log_dir}/${nginx::params::nginx_error_log_file}",
   Nginx::ErrorLogSeverity $nginx_error_log_severity          = 'error',
   $pid                                                       = $nginx::params::pid,
-  Variant[Stdlib::Absolutepath, Boolean] $proxy_temp_path    = $nginx::params::proxy_temp_path,
+  Optional[Stdlib::Absolutepath] $proxy_temp_path            = undef,
   $root_group                                                = $nginx::params::root_group,
-  $run_dir                                                   = $nginx::params::run_dir,
   $sites_available_owner                                     = $nginx::params::sites_available_owner,
   $sites_available_group                                     = $nginx::params::sites_available_group,
   $sites_available_mode                                      = $nginx::params::sites_available_mode,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,6 @@ class nginx::params {
     'log_user'                => 'nginx',
     'log_group'               => 'root',
     'log_mode'                => '0750',
-    'run_dir'                 => '/var/nginx',
     'package_name'            => 'nginx',
     'passenger_package_name'  => 'passenger',
     'manage_repo'             => false,
@@ -113,7 +112,6 @@ class nginx::params {
           'log_user'    => 'root',
           'log_group'   => 'adm',
           'log_mode'    => '0755',
-          'run_dir'     => '/run/nginx',
         }
         # The following was designed/tested on Ubuntu 18 and Debian 9/10 but probably works on newer versions as well
       } else {
@@ -123,7 +121,6 @@ class nginx::params {
           'log_user'                => 'root',
           'log_group'               => 'adm',
           'log_mode'                => '0755',
-          'run_dir'                 => '/run/nginx',
           'passenger_package_name'  => 'libnginx-mod-http-passenger',
           'include_modules_enabled' => true,
         }
@@ -180,7 +177,6 @@ class nginx::params {
         'log_dir'     => '/var/www/logs',
         'log_user'    => 'www',
         'log_group'   => 'wheel',
-        'run_dir'     => '/var/www',
       }
     }
     'AIX': {
@@ -190,7 +186,6 @@ class nginx::params {
         'conf_dir'    => '/opt/freeware/etc/nginx/',
         'log_dir'     => '/opt/freeware/var/log/nginx/',
         'log_group'   => 'system',
-        'run_dir'     => '/opt/freeware/share/nginx/html',
       }
     }
     default: {
@@ -211,12 +206,10 @@ class nginx::params {
   $log_user                = $_module_parameters['log_user']
   $log_group               = $_module_parameters['log_group']
   $log_mode                = $_module_parameters['log_mode']
-  $run_dir                 = $_module_parameters['run_dir']
   $temp_dir                = '/tmp'
   $pid                     = $_module_parameters['pid']
   $include_modules_enabled = $_module_parameters['include_modules_enabled']
 
-  $client_body_temp_path   = "${run_dir}/client_body_temp"
   $daemon_user             = $_module_parameters['daemon_user']
   $global_owner            = 'root'
   $global_group            = $_module_parameters['root_group']
@@ -228,7 +221,6 @@ class nginx::params {
   $root_group              = $_module_parameters['root_group']
   $package_name            = $_module_parameters['package_name']
   $passenger_package_name  = $_module_parameters['passenger_package_name']
-  $proxy_temp_path         = "${run_dir}/proxy_temp"
   $sites_available_owner   = 'root'
   $sites_available_group   = $_module_parameters['root_group']
   $sites_available_mode    = '0644'

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -304,51 +304,25 @@ describe 'nginx' do
           it do
             case facts[:osfamily]
             when 'Debian'
-              is_expected.to contain_file('/run/nginx').with(
-                ensure: 'directory',
-                owner: 'root',
-                group: 'root',
-                mode: '0644'
-              )
+              is_expected.not_to contain_file('/run/nginx')
             else
-              is_expected.to contain_file('/var/nginx').with(
-                ensure: 'directory',
-                owner: 'root',
-                group: 'root',
-                mode: '0644'
-              )
+              is_expected.not_to contain_file('/var/nginx')
             end
           end
           it do
             case facts[:osfamily]
             when 'Debian'
-              is_expected.to contain_file('/run/nginx/client_body_temp').with(
-                ensure: 'directory',
-                group: 'root',
-                mode: '0700'
-              )
+              is_expected.not_to contain_file('/run/nginx/client_body_temp')
             else
-              is_expected.to contain_file('/var/nginx/client_body_temp').with(
-                ensure: 'directory',
-                group: 'root',
-                mode: '0700'
-              )
+              is_expected.not_to contain_file('/var/nginx/client_body_temp')
             end
           end
           it do
             case facts[:osfamily]
             when 'Debian'
-              is_expected.to contain_file('/run/nginx/proxy_temp').with(
-                ensure: 'directory',
-                group: 'root',
-                mode: '0700'
-              )
+              is_expected.not_to contain_file('/run/nginx/proxy_temp')
             else
-              is_expected.to contain_file('/var/nginx/proxy_temp').with(
-                ensure: 'directory',
-                group: 'root',
-                mode: '0700'
-              )
+              is_expected.not_to contain_file('/var/nginx/proxy_temp')
             end
           end
           it do
@@ -383,8 +357,8 @@ describe 'nginx' do
           end
           case facts[:osfamily]
           when 'RedHat'
-            it { is_expected.to contain_file('/var/nginx/client_body_temp').with(owner: 'nginx') }
-            it { is_expected.to contain_file('/var/nginx/proxy_temp').with(owner: 'nginx') }
+            it { is_expected.not_to contain_file('/var/nginx/client_body_temp') }
+            it { is_expected.not_to contain_file('/var/nginx/proxy_temp') }
             it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content %r{^user nginx;} }
             it do
               is_expected.to contain_file('/var/log/nginx').with(
@@ -395,8 +369,8 @@ describe 'nginx' do
               )
             end
           when 'Debian'
-            it { is_expected.to contain_file('/run/nginx/client_body_temp').with(owner: 'www-data') }
-            it { is_expected.to contain_file('/run/nginx/proxy_temp').with(owner: 'www-data') }
+            it { is_expected.not_to contain_file('/run/nginx/client_body_temp') }
+            it { is_expected.not_to contain_file('/run/nginx/proxy_temp') }
             it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content %r{^user www-data;} }
             it do
               is_expected.to contain_file('/var/log/nginx').with(
@@ -1378,14 +1352,6 @@ describe 'nginx' do
           context 'when daemon_user = www-data' do
             let(:params) { { daemon_user: 'www-data' } }
 
-            case facts[:osfamily]
-            when 'Debian'
-              it { is_expected.to contain_file('/run/nginx/client_body_temp').with(owner: 'www-data') }
-              it { is_expected.to contain_file('/run/nginx/proxy_temp').with(owner: 'www-data') }
-            else
-              it { is_expected.to contain_file('/var/nginx/client_body_temp').with(owner: 'www-data') }
-              it { is_expected.to contain_file('/var/nginx/proxy_temp').with(owner: 'www-data') }
-            end
             it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content %r{^user www-data;} }
           end
 
@@ -1512,6 +1478,36 @@ describe 'nginx' do
             it do
               is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(
                 %r{  gzip_static       on;}
+              )
+            end
+          end
+
+          context 'when client_body_temp_path is set ' do
+            let(:params) do
+              {
+                proxy_temp_path: '/path/to/nginx/client_body_temp_path'
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/path/to/nginx/client_body_temp_path').with(
+                ensure: 'directory',
+                mode: '0700'
+              )
+            end
+          end
+
+          context 'when proxy_temp_path is set ' do
+            let(:params) do
+              {
+                proxy_temp_path: '/path/to/nginx/proxy_temp_path'
+              }
+            end
+
+            it do
+              is_expected.to contain_file('/path/to/nginx/proxy_temp_path').with(
+                ensure: 'directory',
+                mode: '0700'
               )
             end
           end


### PR DESCRIPTION


This is the same as #1478 however changes the spec tests to check for
 is.expect.not_to instead of removing

Fixes: #1372
