### PR TITLE
proxy set header X-Forwarded-Host

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,6 +145,7 @@ class nginx (
     'Host $host',
     'X-Real-IP $remote_addr',
     'X-Forwarded-For $proxy_add_x_forwarded_for',
+    'X-Forwarded-Host $host',
     'X-Forwarded-Proto $scheme',
     'Proxy ""',
   ],


### PR DESCRIPTION
Set the X-Forwarded-Host header by default when used as a proxy.

from [Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host):
> The X-Forwarded-Host (XFH) header is a de-facto standard header for identifying the original host requested by the client in the Host HTTP request header.
