### PR TITLE
add server/location_acl argument

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -201,10 +201,11 @@ class nginx::config {
   }
 
   file { $log_dir:
-    ensure => directory,
-    mode   => $log_mode,
-    owner  => $log_user,
-    group  => $log_group,
+    ensure  => directory,
+    mode    => $log_mode,
+    owner   => $log_user,
+    group   => $log_group,
+    replace => no, # log_dir can be a symlink
   }
 
   if $client_body_temp_path {

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -17,6 +17,8 @@
 #   Locations to allow connections from.
 # @param location_deny
 #   Locations to deny connections from.
+# @param location_acl
+#   Specifies location ACL name in nginx::conf_dir/conf.d/${location_acl}.acl.
 # @param www_root
 #   Specifies the location on disk for files to be read from. Cannot be set in
 #   conjunction with $proxy
@@ -269,6 +271,7 @@ define nginx::resource::location (
   Optional[Enum['any', 'all']] $location_satisfy                   = undef,
   Optional[Array] $location_allow                                  = undef,
   Optional[Array] $location_deny                                   = undef,
+  Optional[String] $location_acl                                   = undef,
   Optional[Boolean] $stub_status                                   = undef,
   Optional[Variant[String, Array]] $raw_prepend                    = undef,
   Optional[Variant[String, Array]] $raw_append                     = undef,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -18,10 +18,14 @@
 # @param location_satisfy
 #   Allows access if all (all) or at least one (any) of the auth modules allow
 #   access.
+# @param server_acl
+#   Specifies server ACL name in nginx::conf_dir/conf.d/${server_acl}.acl.
 # @param location_allow
 #   Locations to allow connections from.
 # @param location_deny
 #   Locations to deny connections from.
+# @param location_acl
+#   Specifies location ACL name in nginx::conf_dir/conf.d/${location_acl}.acl.
 # @param ipv6_enable
 #   value to enable/disable IPv6 support (false|true). Module will check to see
 #   if IPv6 support exists on your system before enabling.
@@ -290,8 +294,10 @@ define nginx::resource::server (
   Variant[Array[Stdlib::Absolutepath], Stdlib::Absolutepath] $listen_unix_socket = '/var/run/nginx.sock',
   Optional[String] $listen_unix_socket_options                                   = undef,
   Optional[Enum['any', 'all']] $location_satisfy                                 = undef,
+  Optional[String] $server_acl                                                   = undef,
   Array $location_allow                                                          = [],
   Array $location_deny                                                           = [],
+  Optional[String] $location_acl                                                 = undef,
   Boolean $ipv6_enable                                                           = false,
   Variant[Array, String] $ipv6_listen_ip                                         = '::',
   Stdlib::Port $ipv6_listen_port                                                 = $listen_port,
@@ -507,6 +513,7 @@ define nginx::resource::server (
       ssl_only                    => $ssl_only,
       location                    => '/',
       location_satisfy            => $location_satisfy,
+      location_acl                => $location_acl,
       location_allow              => $location_allow,
       location_deny               => $location_deny,
       proxy                       => $proxy,

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -25,6 +25,9 @@
     deny <%= deny_rule %>;
     <%- end -%>
 <% end -%>
+<% if @location_acl -%>
+    include <%= scope['::nginx::config::conf_dir'] %>/conf.d/<%= @location_acl -%>.acl;
+<% end -%>
 <% if @absolute_redirect -%>
   absolute_redirect <%= @absolute_redirect %>;
 <% end -%>

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -16,12 +16,12 @@
     expires <%= @expires %>;
 <% end -%>
 <% if @location_allow -%>
-    <%- @location_allow.flatten.each do |allow_rule| -%>
+    <%- @location_allow.flatten.uniq.each do |allow_rule| -%>
     allow <%= allow_rule %>;
     <%- end -%>
 <% end -%>
 <% if @location_deny -%>
-    <%- @location_deny.each do |deny_rule| -%>
+    <%- @location_deny.uniq.each do |deny_rule| -%>
     deny <%= deny_rule %>;
     <%- end -%>
 <% end -%>

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -112,6 +112,9 @@ server {
 <% Array(@raw_prepend).each do |line| -%>
   <%= line %>
 <% end %>
+<% if @server_acl -%>
+  include <%= scope['::nginx::config::conf_dir'] %>/conf.d/<%= @server_acl -%>.acl;
+<% end -%>
 <% if @root -%>
   root <%= @root %>;
 <% end -%>

--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -157,6 +157,9 @@ server {
 <% Array(@raw_prepend).each do |line| -%>
   <%= line %>
 <% end -%>
+<% if @server_acl -%>
+  include <%= scope['::nginx::config::conf_dir'] %>/conf.d/<%= @server_acl -%>.acl;
+<% end -%>
 <% if @root -%>
   root <%= @root %>;
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
 - add ability to include `conf.d/name.acl` ACLs to server/location blocks to not repeat `allow/deny` rules multiple times
 - allows to combine common allow list (in `.acl` file) with `allow/deny` rules in specific block (`deny` rule will be the last)