### PR TITLE
change log_user on freebsd

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -139,7 +139,7 @@ class nginx::params {
         'daemon_user' => 'www',
         'root_group'  => 'wheel',
         'log_group'   => 'wheel',
-        'log_user'    => 'root',
+        'log_user'    => 'www',
       }
     }
     'Gentoo': {


### PR DESCRIPTION
#### Pull Request (PR) description
Nginx write his own log with the daemon user. As it, log_dir must be set with the correct user name to work on freebsd.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
