### PR TITLE
Move header escaping responsibility from the end user to Puppet

### DIFF
--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -460,7 +460,8 @@ describe 'nginx::resource::location' do
                 'add_header' => {
                   'header 1' => 'test value 1',
                   'header 2' => { 'test value 2' => 'tv2' },
-                  'header 3' => { '' => '\'test value 3\' tv3' }
+                  'header 3' => { '' => '\'test value 3\' tv3' },
+                  'header 4' => '{"foo": "bar"}',
                 }
               )
             end
@@ -472,6 +473,8 @@ describe 'nginx::resource::location' do
                 with_content(%r{^\s+add_header\s+"header 2"\s+"test value 2" tv2;$})
               is_expected.to contain_concat__fragment("server1-500-#{Digest::MD5.hexdigest('location')}").
                 with_content(%r{^\s+add_header\s+"header 3"\s+'test value 3' tv3;$})
+              is_expected.to contain_concat__fragment("server1-500-#{Digest::MD5.hexdigest('location')}").
+                with_content(%r(^\s+add_header\s+"header 4"\s+"{\\"foo\\": \\"bar\\"}";$))
             end
           end
         end

--- a/templates/server/locations/headers.erb
+++ b/templates/server/locations/headers.erb
@@ -2,10 +2,10 @@
     <%- if value -%>
       <%- if value.is_a?(Hash) -%>
         <%- value.each do |sk, sv| -%>
-    add_header "<%= header %>" <% if sk != '' %>"<%= sk %>"<% end %> <%= sv %>;
+    add_header <%= header.inspect %> <% if sk != '' %><%= sk.inspect %><% end %> <%= sv %>;
         <%- end -%>
       <%- else -%>
-    add_header "<%= header %>" "<%= value %>";
+    add_header <%= header.inspect %> <%= value.inspect %>;
       <%- end -%>
     <%- end -%>
 <%- end -%>


### PR DESCRIPTION
#### Pull Request (PR) description

More and more security headers are JSON formatted documents.  With the hardcoded quotes, we have to think hard not to break the generated NGINX configuration.

Rely on Puppet programmatic string representation to avoid the end user to have to worry about escaping quotes.

#### This change is backward incompatible

If you manually escaped header contents before passing them to the module, you need to remove the extra escaping, e.g.:

```diff
diff --git a/site-modules/profile/functions/security_headers.pp b/site-modules/profile/functions/security_headers.pp
index c6087a2..ba6434d 100644
--- a/site-modules/profile/functions/security_headers.pp
+++ b/site-modules/profile/functions/security_headers.pp
@@ -27,9 +27,9 @@ function profile::security_headers(
     x_content_type_options    => 'nosniff',
     referrer_policy           => 'strict-origin-when-cross-origin',
     permissions_policy        => 'accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()',
-    nel                       => '{\"report_to\":\"default\",\"max_age\":31536000,\"include_subdomains\":true}',
-    report_to                 => '{\"group\":\"default\",\"max_age\":31536000,\"endpoints\":[{\"url\":\"https://example.com/\"}],\"include_subdomains\":true}',
-    expect_ct                 => 'report-uri=\"https://example.com/\", max-age=86400',
+    nel                       => '{"report_to":"default","max_age":31536000,"include_subdomains":true}',
+    report_to                 => '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://example.com"}],"include_subdomains":true}',
+    expect_ct                 => 'report-uri="https://example.com/", max-age=86400',
     x_xss_protection          => '0',
   } + $options.lest || { {} }
 

```

#### This Pull Request (PR) fixes the following issues

n/a