### PR TITLE
Allow to set log_format's "escape" parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class nginx (
   Enum['on', 'off'] $http_tcp_nopush                         = 'off',
   $keepalive_timeout                                         = '65s',
   $keepalive_requests                                        = '100',
-  $log_format                                                = {},
+  Hash[String[1], Nginx::LogFormat] $log_format              = {},
   Boolean $mail                                              = false,
   Variant[String, Boolean] $mime_types_path                  = 'mime.types',
   Boolean $stream                                            = false,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -544,11 +544,20 @@ describe 'nginx' do
                 attr: 'log_format',
                 value: {
                   'format1' => 'FORMAT1',
-                  'format2' => 'FORMAT2'
+                  'format2' => 'FORMAT2',
+                  'format3' => {
+                    'format' => 'FORMAT3',
+                  },
+                  'format4' => {
+                    'escape' => 'json',
+                    'format' => '{"response": $status, "verb": "$request_method"}',
+                  },
                 },
                 match: [
                   '  log_format format1 \'FORMAT1\';',
-                  '  log_format format2 \'FORMAT2\';'
+                  '  log_format format2 \'FORMAT2\';',
+                  '  log_format format3 \'FORMAT3\';',
+                  '  log_format format4 \'escape=json\' \'{"response": $status, "verb": "$request_method"}\';'
                 ]
               },
               {

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -554,10 +554,10 @@ describe 'nginx' do
                   },
                 },
                 match: [
-                  '  log_format format1 \'FORMAT1\';',
-                  '  log_format format2 \'FORMAT2\';',
-                  '  log_format format3 \'FORMAT3\';',
-                  '  log_format format4 \'escape=json\' \'{"response": $status, "verb": "$request_method"}\';'
+                  '  log_format format1 "FORMAT1";',
+                  '  log_format format2 "FORMAT2";',
+                  '  log_format format3 "FORMAT3";',
+                  '  log_format format4 escape=json "{\\"response\\": $status, \\"verb\\": \\"$request_method\\"}";'
                 ]
               },
               {

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -74,7 +74,11 @@ http {
   default_type  application/octet-stream;
 <% if @log_format -%>
 <% @log_format.sort_by{|k,v| k}.each do |key,value| -%>
-  log_format <%= key %> '<%= value %>';
+  <%- if value.is_a?(Hash) -%>
+  log_format <%= key %> <%= "escape=#{value['escape']} " if value['escape'] %><%= value['format'].inspect %>;
+  <%- else -%>
+  log_format <%= key %> <%= value.inspect %>;
+  <%- end -%>
 <% end -%>
 <% end -%>
 

--- a/types/logformat.pp
+++ b/types/logformat.pp
@@ -1,0 +1,7 @@
+type Nginx::LogFormat = Variant[
+  String[1],
+  Struct[{
+    Optional[escape] => Enum['default', 'json', 'none'],
+    format           => String[1],
+  }],
+]


### PR DESCRIPTION
#### Pull Request (PR) description

NGINX can output logs in JSONL format.  This requires to set the escape
parameter to NGINX log_format, which the module does not currently
support.

#### This change is backwards-incompatible

Most users will not be affected, but if you customized the `escape` parameter with a `log_format` containing closing and opening quotes in the form `"escape=foo' 'actual_format"`, an update is required. e.g.:

```diff
diff --git a/site-modules/profile/manifests/nginx.pp b/site-modules/profile/manifests/nginx.pp
index 1fa15f7..3d5192f 100644
--- a/site-modules/profile/manifests/nginx.pp
+++ b/site-modules/profile/manifests/nginx.pp
@@ -109,7 +108,10 @@ class profile::nginx (
     dynamic_modules           => $dynamic_modules,
     log_mode                  => '0755',
     log_format                => {
-      json_combined => "escape=json' '{${json_log.map |$key, $value| { "\"${key}\":${value}" }.join(',')}}",
+      json_combined => {
+        escape => 'json',
+        format => "{${json_log.map |$key, $value| { "\"${key}\":${value}" }.join(',')}}",
+      },
     },
     http_format_log           => 'json_combined buffer=10m flush=5m',
 

```

#### This Pull Request (PR) fixes the following issues

n/a