### PR TITLE
fix documentation about ipv6only always being added

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2644,9 +2644,7 @@ Default value: `$listen_port`
 
 Data type: `String`
 
-Extra options for listen directive like 'default' to catchall. Template
-will allways add ipv6only=on.  While issue jfryman/puppet-nginx#30 is
-discussed, default value is 'default'.
+Extra options for listen directive like 'default' to catchall.
 
 Default value: `'default ipv6only=on'`
 
@@ -3354,9 +3352,7 @@ Default value: `$listen_port`
 
 Data type: `String`
 
-Extra options for listen directive like 'default' to catchall. Template
-will allways add ipv6only=on.  While issue jfryman/puppet-nginx#30 is
-discussed, default value is 'default'.
+Extra options for listen directive like 'default' to catchall.
 
 Default value: `'default ipv6only=on'`
 
@@ -4479,9 +4475,7 @@ Default value: `$listen_port`
 
 Data type: `String`
 
-Extra options for listen directive like 'default' to catchall. Template
-will allways add ipv6only=on. While issue jfryman/puppet-nginx#30 is
-discussed, default value is 'default'.
+Extra options for listen directive like 'default' to catchall.
 
 Default value: `'default ipv6only=on'`
 

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -17,9 +17,7 @@
 # @param ipv6_listen_port
 #   Default IPv6 Port for NGINX to listen with this server on.
 # @param ipv6_listen_options
-#   Extra options for listen directive like 'default' to catchall. Template
-#   will allways add ipv6only=on.  While issue jfryman/puppet-nginx#30 is
-#   discussed, default value is 'default'.
+#   Extra options for listen directive like 'default' to catchall.
 # @param ssl
 #   Indicates whether to setup SSL bindings for this mailhost.
 # @param ssl_cert

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -30,9 +30,7 @@
 # @param ipv6_listen_port
 #   Default IPv6 Port for NGINX to listen with this server on. Defaults to TCP 80
 # @param ipv6_listen_options
-#   Extra options for listen directive like 'default' to catchall. Template
-#   will allways add ipv6only=on.  While issue jfryman/puppet-nginx#30 is
-#   discussed, default value is 'default'.
+#   Extra options for listen directive like 'default' to catchall.
 # @param add_header
 #   Adds headers to the HTTP response when response code is equal to 200, 204,
 #   301, 302 or 304.

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -18,9 +18,8 @@
 # @param ipv6_listen_port
 #   Default IPv6 Port for NGINX to listen with this streamhost on.
 # @param ipv6_listen_options
-#   Extra options for listen directive like 'default' to catchall. Template
-#   will allways add ipv6only=on. While issue jfryman/puppet-nginx#30 is
-#   discussed, default value is 'default'.
+#   Extra options for listen directive like 'default' to
+#   catchall.
 # @param proxy
 #   Proxy server(s) for the root location to connect to. Accepts a single
 #   value, can be used in conjunction with nginx::resource::upstream


### PR DESCRIPTION
This was refering to issue #30 which was closed by changing the
behavior for *not* adding the default in the template. Instead, the
default includes the setting. We do not mention the default here
because it's visible in the generated `REFERENCE.md` file and is not
mentioned in other parameter documentation anyways.
