### PR TITLE
apt::source: configure repo only for current architecture

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -29,10 +29,11 @@ class nginx::package::debian {
           default => $repo_source,
         }
         apt::source { 'nginx':
-          location => $stable_repo_source,
-          repos    => 'nginx',
-          key      => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
-          release  => $release,
+          location     => $stable_repo_source,
+          repos        => 'nginx',
+          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+          release      => $release,
+          architecture => $facts['os']['architecture'],
         }
       }
       'nginx-mainline': {
@@ -41,10 +42,11 @@ class nginx::package::debian {
           default => $repo_source,
         }
         apt::source { 'nginx':
-          location => $mainline_repo_source,
-          repos    => 'nginx',
-          key      => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
-          release  => $release,
+          location     => $mainline_repo_source,
+          repos        => 'nginx',
+          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+          release      => $release,
+          architecture => $facts['os']['architecture'],
         }
       }
       'passenger': {
@@ -53,9 +55,10 @@ class nginx::package::debian {
           default => $repo_source,
         }
         apt::source { 'nginx':
-          location => $passenger_repo_source,
-          repos    => 'main',
-          key      => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' },
+          location     => $passenger_repo_source,
+          repos        => 'main',
+          key          => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' },
+          architecture => $facts['os']['architecture'],
         }
 
         package { $passenger_package_name:


### PR DESCRIPTION
Without this setting, we tell apt to download release information for all architectures apt knows. This includes i386 on amd64 systems. nginx doesn't publish i386 packages. because of that, it results in a warning during apt update:

N: Skipping acquire of configured file 'nginx/binary-i386/Packages' as repository 'https://nginx.org/packages/ubuntu jammy InRelease' doesn't support architecture 'i386'

This is fixed with this change.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
