### PR TITLE
Enable subdirectory hierarchy for client_body and proxy temp paths

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -331,9 +331,9 @@ Default value: `{}`
 
 ##### <a name="-nginx--client_body_temp_path"></a>`client_body_temp_path`
 
-Data type: `Optional[Stdlib::Absolutepath]`
+Data type: `Optional[Variant[Stdlib::Absolutepath, Tuple[Stdlib::Absolutepath, Integer, 1, 4]]]`
 
-
+Can be used to define a directory for storing temporary files holding client request bodies, and up to a three-level subdirectory hierarchy can be used under the specified directory.
 
 Default value: `undef`
 
@@ -523,9 +523,9 @@ Default value: `$nginx::params::pid`
 
 ##### <a name="-nginx--proxy_temp_path"></a>`proxy_temp_path`
 
-Data type: `Optional[Stdlib::Absolutepath]`
+Data type: `Optional[Variant[Stdlib::Absolutepath, Tuple[Stdlib::Absolutepath, Integer, 1, 4]]]`
 
-
+Can be used to define a directory for storing temporary files with data received from proxied servers, and up to a three-level subdirectory hierarchy can be used under the specified directory.
 
 Default value: `undef`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -206,7 +206,13 @@ class nginx::config {
   }
 
   if $client_body_temp_path {
-    file { $client_body_temp_path:
+    if $client_body_temp_path.is_a(String) {
+      $_client_body_temp_path = [$client_body_temp_path]
+    } else {
+      $_client_body_temp_path = $client_body_temp_path
+    }
+
+    file { $_client_body_temp_path[0]:
       ensure => directory,
       owner  => $daemon_user,
       mode   => '0700',
@@ -214,7 +220,14 @@ class nginx::config {
   }
 
   if $proxy_temp_path {
-    file { $proxy_temp_path:
+    if $proxy_temp_path.is_a(String) {
+      $_proxy_temp_path = [$proxy_temp_path]
+    }
+    else {
+      $_proxy_temp_path = $proxy_temp_path
+    }
+
+    file { $_proxy_temp_path[0]:
       ensure => directory,
       owner  => $daemon_user,
       mode   => '0700',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@
 #
 class nginx (
   ### START Nginx Configuration ###
-  Optional[Stdlib::Absolutepath] $client_body_temp_path      = undef,
+  Optional[Variant[Stdlib::Absolutepath, Tuple[Stdlib::Absolutepath, Integer, 1, 4]]] $client_body_temp_path      = undef,
   Boolean $confd_only                                        = false,
   Boolean $confd_purge                                       = false,
   $conf_dir                                                  = $nginx::params::conf_dir,
@@ -70,7 +70,7 @@ class nginx (
   Variant[String, Array[String]] $nginx_error_log            = "${log_dir}/${nginx::params::nginx_error_log_file}",
   Nginx::ErrorLogSeverity $nginx_error_log_severity          = 'error',
   $pid                                                       = $nginx::params::pid,
-  Optional[Stdlib::Absolutepath] $proxy_temp_path            = undef,
+  Optional[Variant[Stdlib::Absolutepath, Tuple[Stdlib::Absolutepath, Integer, 1, 4]]] $proxy_temp_path            = undef,
   $root_group                                                = $nginx::params::root_group,
   $sites_available_owner                                     = $nginx::params::sites_available_owner,
   $sites_available_group                                     = $nginx::params::sites_available_group,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -918,10 +918,32 @@ describe 'nginx' do
                 match: '  client_body_temp_path   /path/to/body_temp;'
               },
               {
+                title: 'should set client_body_temp_path with subdirectory hierarchy',
+                attr: 'client_body_temp_path',
+                value: [
+                  '/path/to/body_temp',
+                  1,
+                  2,
+                  3
+                ],
+                match: '  client_body_temp_path   /path/to/body_temp 1 2 3;'
+              },
+              {
                 title: 'should set proxy_temp_path',
                 attr: 'proxy_temp_path',
                 value: '/path/to/proxy_temp',
                 match: '  proxy_temp_path         /path/to/proxy_temp;'
+              },
+              {
+                title: 'should set proxy_temp_path with subdirectory hierarchy',
+                attr: 'proxy_temp_path',
+                value: [
+                  '/path/to/proxy_temp',
+                  1,
+                  2,
+                  3
+                ],
+                match: '  proxy_temp_path         /path/to/proxy_temp 1 2 3;'
               },
               {
                 title: 'should set proxy_max_temp_file_size',
@@ -1124,7 +1146,9 @@ describe 'nginx' do
 
                   # if we have a _path attribute make sure we create the path
                   if param[:attr].end_with?('_path')
-                    if param[:value].is_a?(Hash)
+                    if %w[client_body_temp_path proxy_temp_path].include?(param[:attr]) && param[:value].is_a?(Array)
+                      is_expected.to contain_file(param[:value][0]).with_ensure('directory')
+                    elsif param[:value].is_a?(Hash)
                       param[:value].each_key do |path|
                         is_expected.to contain_file(path).with_ensure('directory')
                       end

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -167,8 +167,8 @@ http {
   gzip_vary         <%= @gzip_vary %>;
 <% end -%>
 
-<% if @client_body_temp_path -%>
-  client_body_temp_path   <%= @client_body_temp_path %>;
+<% if @_client_body_temp_path -%>
+  client_body_temp_path   <%= @_client_body_temp_path.join(' ') %>;
 <% end -%>
 <% if @client_max_body_size -%>
   client_max_body_size    <%= @client_max_body_size %>;
@@ -179,8 +179,8 @@ http {
 <% if @proxy_redirect -%>
   proxy_redirect          <%= @proxy_redirect %>;
 <% end -%>
-<% if @proxy_temp_path -%>
-  proxy_temp_path         <%= @proxy_temp_path %>;
+<% if @_proxy_temp_path -%>
+  proxy_temp_path         <%= @_proxy_temp_path.join(' ') %>;
 <% end -%>
 <% if @proxy_connect_timeout -%>
   proxy_connect_timeout   <%= @proxy_connect_timeout %>;


### PR DESCRIPTION
#### Pull Request (PR) description
Allow specification of up to three-level subdirectory hierarchy for both [client_body_temp_path](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_temp_path) and [proxy_temp_path](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_temp_path) options

This allows for the existing string option to specify just the path as it works now, and for an alternate type as an array with the first element as the path, and the up to 3 additional integers for each level

- Updated docs
- Updated tests
