### PR TITLE
Add support for proxy_cache_convert_head

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1909,6 +1909,7 @@ The following parameters are available in the `nginx::resource::location` define
 * [`proxy_cache_valid`](#-nginx--resource--location--proxy_cache_valid)
 * [`proxy_cache_lock`](#-nginx--resource--location--proxy_cache_lock)
 * [`proxy_cache_background_update`](#-nginx--resource--location--proxy_cache_background_update)
+* [`proxy_cache_convert_head`](#-nginx--resource--location--proxy_cache_convert_head)
 * [`proxy_cache_bypass`](#-nginx--resource--location--proxy_cache_bypass)
 * [`proxy_method`](#-nginx--resource--location--proxy_method)
 * [`proxy_http_version`](#-nginx--resource--location--proxy_http_version)
@@ -2377,6 +2378,14 @@ Default value: `undef`
 Data type: `Optional[Enum['on', 'off']]`
 
 Allows starting a background subrequest to update an expired cache item
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--location--proxy_cache_convert_head"></a>`proxy_cache_convert_head`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+Enables or disables the conversion of the “HEAD” method to “GET” for caching. When the conversion is disabled, the cache key should be configured to include the $request_method.
 
 Default value: `undef`
 
@@ -3027,7 +3036,7 @@ Create a new mapping entry for NGINX
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 nginx::resource::map { 'backend_pool':
@@ -3160,7 +3169,7 @@ Create a virtual host
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 nginx::resource::server { 'test2.local':
@@ -3250,6 +3259,7 @@ The following parameters are available in the `nginx::resource::server` defined 
 * [`proxy_cache_valid`](#-nginx--resource--server--proxy_cache_valid)
 * [`proxy_cache_lock`](#-nginx--resource--server--proxy_cache_lock)
 * [`proxy_cache_background_update`](#-nginx--resource--server--proxy_cache_background_update)
+* [`proxy_cache_convert_head`](#-nginx--resource--server--proxy_cache_convert_head)
 * [`proxy_cache_bypass`](#-nginx--resource--server--proxy_cache_bypass)
 * [`proxy_method`](#-nginx--resource--server--proxy_method)
 * [`proxy_http_version`](#-nginx--resource--server--proxy_http_version)
@@ -3933,6 +3943,14 @@ Allows starting a background subrequest to update an expired cache item
 
 Default value: `undef`
 
+##### <a name="-nginx--resource--server--proxy_cache_convert_head"></a>`proxy_cache_convert_head`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+Enables or disables the conversion of the “HEAD” method to “GET” for caching. When the conversion is disabled, the cache key should be configured to include the $request_method.
+
+Default value: `undef`
+
 ##### <a name="-nginx--resource--server--proxy_cache_bypass"></a>`proxy_cache_bypass`
 
 Data type: `Optional[Variant[Array[String], String]]`
@@ -4460,7 +4478,7 @@ Create a virtual steamhost
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 nginx::resource::streamhost { 'test2.local':
@@ -4642,7 +4660,7 @@ Create a new upstream proxy entry for NGINX
 
 #### Examples
 
-##### 
+#####
 
 ```puppet
 nginx::resource::upstream { 'proxypass':

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -129,6 +129,9 @@
 #   This directive sets the locking mechanism for pouplating cache.
 # @param proxy_cache_background_update
 #   Allows starting a background subrequest to update an expired cache item
+# @param proxy_cache_convert_head
+#    Enables or disables the conversion of the “HEAD” method to “GET” for caching.
+#    When the conversion is disabled, the cache key should be configured to include the $request_method.
 # @param proxy_cache_bypass
 #   Defines conditions which the response will not be cached
 # @param proxy_method
@@ -286,6 +289,7 @@ define nginx::resource::location (
   Optional[String] $proxy_cache_use_stale                          = undef,
   Optional[Enum['on', 'off']] $proxy_cache_lock                    = undef,
   Optional[Enum['on', 'off']] $proxy_cache_background_update       = undef,
+  Optional[Enum['on', 'off']] $proxy_cache_convert_head            = undef,
   Optional[Variant[Array, String]] $proxy_cache_valid              = undef,
   Optional[Variant[Array, String]] $proxy_cache_bypass             = undef,
   Optional[String] $proxy_method                                   = undef,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -174,6 +174,9 @@
 #   This directive sets the locking mechanism for pouplating cache.
 # @param proxy_cache_background_update
 #   Allows starting a background subrequest to update an expired cache item
+# @param proxy_cache_convert_head
+#    Enables or disables the conversion of the “HEAD” method to “GET” for caching.
+#    When the conversion is disabled, the cache key should be configured to include the $request_method.
 # @param proxy_cache_bypass
 #   Defines conditions which the response will not be cached
 # @param proxy_method
@@ -340,6 +343,7 @@ define nginx::resource::server (
   Optional[Variant[Array[String], String]] $proxy_cache_valid                    = undef,
   Optional[Enum['on', 'off']] $proxy_cache_lock                                  = undef,
   Optional[Enum['on', 'off']] $proxy_cache_background_update                     = undef,
+  Optional[Enum['on', 'off']] $proxy_cache_convert_head                          = undef,
   Optional[Variant[Array[String], String]] $proxy_cache_bypass                   = undef,
   Optional[String] $proxy_method                                                 = undef,
   Optional[String] $proxy_http_version                                           = undef,
@@ -526,6 +530,7 @@ define nginx::resource::server (
       proxy_pass_header             => $proxy_pass_header,
       proxy_cache_lock              => $proxy_cache_lock,
       proxy_cache_background_update => $proxy_cache_background_update,
+      proxy_cache_convert_head      => $proxy_cache_convert_head,
       proxy_set_body                => $proxy_set_body,
       proxy_cache_bypass            => $proxy_cache_bypass,
       proxy_buffering               => $proxy_buffering,

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -945,6 +945,18 @@ describe 'nginx::resource::location' do
               match: %r{^\s+proxy_cache_background_update\s+off;}
             },
             {
+              title: 'should set proxy_cache_convert_head with a string',
+              attr: 'proxy_cache_convert_head',
+              value: 'on',
+              match: %r{^\s+proxy_cache_convert_head\s+on;}
+            },
+            {
+              title: 'should set proxy_cache_convert_head with a string',
+              attr: 'proxy_cache_convert_head',
+              value: 'off',
+              match: %r{^\s+proxy_cache_convert_head\s+off;}
+            },
+            {
               title: 'should set proxy_pass',
               attr: 'proxy',
               value: 'value',

--- a/templates/server/locations/proxy.erb
+++ b/templates/server/locations/proxy.erb
@@ -72,6 +72,9 @@
 <% if @proxy_cache_background_update -%>
     proxy_cache_background_update <%= @proxy_cache_background_update %>;
 <% end -%>
+<% if @proxy_cache_convert_head -%>
+    proxy_cache_convert_head <%= @proxy_cache_convert_head %>;
+<% end -%>
 <% if @proxy_next_upstream -%>
     proxy_next_upstream      <%= @proxy_next_upstream %>;
 <% end -%>


### PR DESCRIPTION
This adds support for the proxy_cache_convert_head directive:

https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_convert_head
