### PR TITLE
Fix legacy facts usage

### DIFF
--- a/templates/server/fastcgi.conf.erb
+++ b/templates/server/fastcgi.conf.erb
@@ -1,4 +1,4 @@
-# This file managed by puppet on host <%= @fqdn %>
+# This file managed by puppet on host <%= @facts['networking']['fqdn'] %>
 
 fastcgi_param  SCRIPT_FILENAME    $document_root$fastcgi_script_name;
 fastcgi_param  QUERY_STRING       $query_string;

--- a/templates/server/uwsgi_params.erb
+++ b/templates/server/uwsgi_params.erb
@@ -1,4 +1,4 @@
-# This file managed by puppet on host <%= @fqdn %>
+# This file managed by puppet on host <%= @facts['networking']['fqdn'] %>
 
 uwsgi_param  QUERY_STRING       $query_string;
 uwsgi_param  REQUEST_METHOD     $request_method;


### PR DESCRIPTION
Puppet 8 will default to not sending legacy facts.  Start replacing those with the one that supersede them.

There might be more, but with this change i have no difference on my nodes when running with `--no-include_legacy_facts`.