### PR TITLE
Fix streamhost default logging

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,7 @@ class nginx (
   Stdlib::Filemode $log_mode                                 = $nginx::params::log_mode,
   Variant[String, Array[String]] $http_access_log            = "${log_dir}/${nginx::params::http_access_log_file}",
   Optional[String] $http_format_log                          = undef,
-  Variant[String, Array[String]] $stream_access_log          = "${log_dir}/stream-access.log",
+  Variant[String, Array[String]] $stream_access_log          = "off",
   Optional[String] $stream_custom_format_log                 = undef,
   Variant[String, Array[String]] $nginx_error_log            = "${log_dir}/${nginx::params::nginx_error_log_file}",
   Nginx::ErrorLogSeverity $nginx_error_log_severity          = 'error',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Current default value for stream_access_log will cause Nginx to fail to start if nginx::stream is true.

http://nginx.org/en/docs/stream/ngx_stream_log_module.html#access_log
Format must be defined, which current default configuration doesn't do (since stream_custom_format_log is undef as well).
 
Nginx default is "off", and therefore the Puppet-module default should be "off" as well.
-->

#### This Pull Request (PR) fixes the following issues
<!--
n/a
-->
