### PR TITLE
fix: stream block manager

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -332,11 +332,6 @@ mail {
 <% end -%>
 <% if @stream -%>
 stream {
-  <%-# conf.stream.d gets included either way if $stream is enabled -%>
-  include <%= @conf_dir %>/conf.stream.d/*.conf;
-<% unless @confd_only -%>
-  include <%= @conf_dir %>/streams-enabled/*;
-<% end -%>
 <% unless @stream_log_format.empty? -%>
 
 <% @stream_log_format.sort.each do |key,value| -%>
@@ -346,6 +341,12 @@ stream {
 
 <%- Array(@stream_access_log).each do |log_item| -%>
   access_log <%= log_item %><% if @stream_custom_format_log %> <%= @stream_custom_format_log%><% end %>;
+<% end -%>
+
+  <%-# conf.stream.d gets included either way if $stream is enabled -%>
+  include <%= @conf_dir %>/conf.stream.d/*.conf;
+<% unless @confd_only -%>
+  include <%= @conf_dir %>/streams-enabled/*;
 <% end -%>
 }
 <% end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Hello the goal of the pr is to fix the nginx order configuration for the block stream.
As the configuration sites included at the end of the the http block we will do the same for the stream, like that we can use declaration provided on the nginx.conf on stream configured.

#### This Pull Request (PR) fixes the following issues
Fixes #1551

