### PR TITLE
Mock out nginx in os-independent tests

### DIFF
--- a/spec/defines/resource_geo_spec.rb
+++ b/spec/defines/resource_geo_spec.rb
@@ -31,6 +31,24 @@ describe 'nginx::resource::geo' do
       end
 
       describe 'os-independent items' do
+        let(:pre_condition) do
+          <<~PUPPET
+          class nginx::service {}
+          class nginx {
+            $root_group = 'root'
+            $conf_dir = '/etc/nginx'
+            $global_mode = '0644'
+
+            include nginx::service
+
+            file { [$conf_dir, "${conf_dir}/conf.d"]:
+              ensure => directory,
+            }
+          }
+          include nginx
+          PUPPET
+        end
+
         describe 'basic assumptions' do
           let(:params) { default_params }
 


### PR DESCRIPTION
This defines a very minimal nginx class that is just enough to make the
os-independent tests pass:

Prior to this patch:

Finished in 15.21 seconds (files took 7.58 seconds to load)

After this patch:

Finished in 2.94 seconds (files took 7.66 seconds to load)