### PR TITLE
Remove legacy data types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -807,7 +807,7 @@ Default value: `20`
 
 ##### <a name="-nginx--gzip_http_version"></a>`gzip_http_version`
 
-Data type: `Variant[Enum['1.0','1.1'], Float]`
+Data type: `Enum['1.0','1.1']`
 
 
 
@@ -903,7 +903,7 @@ Default value: `'65s'`
 
 ##### <a name="-nginx--keepalive_requests"></a>`keepalive_requests`
 
-Data type: `Variant[Integer, String]`
+Data type: `Integer`
 
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,7 +111,7 @@ class nginx (
   Integer $gzip_comp_level                                   = 1,
   String $gzip_disable                                       = 'msie6',
   Integer $gzip_min_length                                   = 20,
-  Variant[Enum['1.0','1.1'], Float] $gzip_http_version       = '1.1',
+  Enum['1.0','1.1'] $gzip_http_version                       = '1.1',
   Variant[Nginx::GzipProxied, Array[Nginx::GzipProxied]] $gzip_proxied = 'off',
   Optional[Variant[String[1],Array[String[1]]]] $gzip_types  = undef,
   Enum['on', 'off'] $gzip_vary                               = 'off',
@@ -123,7 +123,7 @@ class nginx (
   Enum['on', 'off'] $http_tcp_nodelay                        = 'on',
   Enum['on', 'off'] $http_tcp_nopush                         = 'off',
   Nginx::Time $keepalive_timeout                             = '65s',
-  Variant[Integer, String] $keepalive_requests               = 100,
+  Integer $keepalive_requests                                = 100,
   Hash[String[1], Nginx::LogFormat] $log_format              = {},
   Hash[String[1], Nginx::LogFormat] $stream_log_format       = {},
   Boolean $mail                                              = false,
@@ -244,13 +244,6 @@ class nginx (
 
   ### END Hiera Lookups ###
 ) inherits nginx::params {
-  if $gzip_http_version =~ Float {
-    deprecation('gzip_http_version', 'Passing a Float is deprecated, please pass a String')
-  }
-  if $keepalive_requests =~ String {
-    deprecation('keepalive_requests', 'Passing a String is deprecated, please pass a Integer')
-  }
-
   contain 'nginx::package'
   contain 'nginx::config'
   contain 'nginx::service'


### PR DESCRIPTION
This PR remove backwards-compatible data types which where bogus.

It is intended to be rebased on top of master and merged when we want to cut a new major version and people had the time to update their code to not rely on these.
