### PR TITLE
Add support for multiple `limit_req` statements in `location` directives

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2281,10 +2281,11 @@ Default value: `undef`
 
 ##### <a name="-nginx--resource--location--limit_zone"></a>`limit_zone`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Variant[String[1],Array[String[1],1]]]`
 
-Apply a limit_req_zone to the location. Expects a string indicating a
-previously defined limit_req_zone in the main nginx configuration
+Apply a limit_req_zone to the location. Expects a string or array of
+strings indicating a previously defined limit_req_zone in the main nginx
+configuration
 
 Default value: `undef`
 

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -92,8 +92,9 @@
 #   (after custom_cfg directives). NOTE: YOU are responsible for a semicolon on
 #   each line that requires one.
 # @param limit_zone
-#   Apply a limit_req_zone to the location. Expects a string indicating a
-#   previously defined limit_req_zone in the main nginx configuration
+#   Apply a limit_req_zone to the location. Expects a string or array of
+#   strings indicating a previously defined limit_req_zone in the main nginx
+#   configuration
 # @param location_custom_cfg
 #   Expects a hash with custom directives, cannot be used with other location
 #   types (proxy, fastcgi, root, or stub_status)
@@ -270,7 +271,7 @@ define nginx::resource::location (
   Boolean $ssl                                                     = false,
   Boolean $ssl_only                                                = false,
   Optional[String] $location_alias                                 = undef,
-  Optional[String[1]] $limit_zone                                  = undef,
+  Optional[Variant[String[1],Array[String[1],1]]] $limit_zone      = undef,
   Optional[Enum['any', 'all']] $location_satisfy                   = undef,
   Optional[Array] $location_allow                                  = undef,
   Optional[Array] $location_deny                                   = undef,

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -110,6 +110,15 @@ describe 'nginx::resource::location' do
               match: '    limit_req zone=myzone1;'
             },
             {
+              title: 'should set multiple limit_zone',
+              attr: 'limit_zone',
+              value: %w[myzone1 myzone2],
+              match: [
+                '    limit_req zone=myzone1;',
+                '    limit_req zone=myzone1;'
+              ]
+            },
+            {
               title: 'should set expires',
               attr: 'expires',
               value: '33d',

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -115,7 +115,7 @@ describe 'nginx::resource::location' do
               value: %w[myzone1 myzone2],
               match: [
                 '    limit_req zone=myzone1;',
-                '    limit_req zone=myzone1;'
+                '    limit_req zone=myzone2;'
               ]
             },
             {

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -78,7 +78,9 @@
     <%- end -%>
 <% end -%>
 <% if @limit_zone -%>
-    limit_req zone=<%= @limit_zone %>;
+  <%- Array(@limit_zone).each do |lz| -%>
+    limit_req zone=<%= lz %>;
+  <%- end -%>
 <% end -%>
 <% if @reset_timedout_connection -%>
   reset_timedout_connection <%= @reset_timedout_connection %>;


### PR DESCRIPTION
#### Pull Request (PR) description
Adds support for multiple `limit_req` statements in a `location` by allowing `limit_zone` to be passed as an array OR a string.

#### This Pull Request (PR) fixes the following issues
Fixes #1569