### PR TITLE
metadata.json: drop EoL Ubuntu 18.04

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -95,7 +95,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04"
       ]


### PR DESCRIPTION
Drop EoL Ubuntu 18.04 from `metadata.json`.