### PR TITLE
Allow multiple values in `gzip_proxied` parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -815,7 +815,7 @@ Default value: `'1.1'`
 
 ##### <a name="-nginx--gzip_proxied"></a>`gzip_proxied`
 
-Data type: `Nginx::GzipProxied`
+Data type: `Variant[Nginx::GzipProxied, Array[Nginx::GzipProxied]]`
 
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,7 +112,7 @@ class nginx (
   String $gzip_disable                                       = 'msie6',
   Integer $gzip_min_length                                   = 20,
   Variant[Enum['1.0','1.1'], Float] $gzip_http_version       = '1.1',
-  Nginx::GzipProxied $gzip_proxied                           = 'off',
+  Variant[Nginx::GzipProxied, Array[Nginx::GzipProxied]] $gzip_proxied = 'off',
   Optional[Variant[String[1],Array[String[1]]]] $gzip_types  = undef,
   Enum['on', 'off'] $gzip_vary                               = 'off',
   Optional[Enum['on', 'off', 'always']] $gzip_static         = undef,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -1554,6 +1554,22 @@ describe 'nginx' do
             end
           end
 
+          context 'when gzip is non-default (on) set gzip_proxied' do
+            let(:params) { { gzip: 'on' } }
+
+            context 'set gzip_proxied to a single value' do
+              let(:params) { super().merge({ gzip_proxied: 'any' }) }
+
+              it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(%r{  gzip_proxied      any;}) }
+            end
+
+            context 'set gzip_proxied to multiple values' do
+              let(:params) { super().merge({ gzip_proxied: %w[no-cache expired] }) }
+
+              it { is_expected.to contain_file('/etc/nginx/nginx.conf').with_content(%r{  gzip_proxied      no-cache expired;}) }
+            end
+          end
+
           context 'when gzip_static is non-default set gzip_static' do
             let(:params) do
               {

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -166,7 +166,7 @@ http {
   gzip_min_length   <%= @gzip_min_length %>;
   gzip_http_version <%= @gzip_http_version %>;
 <% if @gzip_proxied -%>
-  gzip_proxied      <%= @gzip_proxied %>;
+  gzip_proxied      <%= Array(@gzip_proxied).uniq.join(' ') %>;
 <% end -%>
 <% if @gzip_types -%>
   gzip_types        <%= @gzip_types.kind_of?(Array) ? @gzip_types.join(' ') : @gzip_types %>;

--- a/templates/streamhost/streamhost.erb
+++ b/templates/streamhost/streamhost.erb
@@ -9,7 +9,7 @@ server {
 <%- end -%>
 <%# check to see if ipv6 support exists in the kernel before applying -%>
 <%# FIXME this logic is duplicated all over the place -%>
-<%- if @ipv6_enable && (defined? @ipaddress6) -%>
+<%- if @ipv6_enable && (defined? @facts.fetch('networking', {})['ip6']) -%>
   <%- if @ipv6_listen_ip.is_a?(Array) then -%>
     <%- @ipv6_listen_ip.each do |ipv6| -%>
   listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;


### PR DESCRIPTION
According to the official NGINX documentation the parameter gzip_proxied allows multiple parameters.

Closes #1567 