### PR TITLE
Add `http2` directive instead of `listen` option

### DIFF
--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -687,6 +687,26 @@ describe 'nginx::resource::server' do
               it { is_expected.to contain_concat__fragment("#{title}-ssl-header").without_content(%r{  ssl on;}) }
             end
 
+            context 'http2 on with fact nginx_version=1.25.1' do
+              let(:facts) { facts.merge(nginx_version: '1.25.1') }
+              let :params do
+                default_params.merge(
+                  http2: 'on',
+                  ssl: true,
+                  ssl_key: '/tmp/dummy.key',
+                  ssl_cert: '/tmp/dummy.crt'
+                )
+              end
+
+              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{^\s+http2\s+on;}) }
+            end
+
+            context 'with fact nginx_version=1.25.1' do
+              let(:facts) { facts.merge(nginx_version: '1.25.1') }
+
+              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{^\s+http2\s+off;}) }
+            end
+
             context 'with ssl cert and key definitions' do
               let(:pre_condition) do
                 <<-PUPPET
@@ -742,18 +762,6 @@ describe 'nginx::resource::server' do
             {
               title: 'should not set SPDY',
               attr: 'spdy',
-              value: 'off',
-              match: %r{\s+listen\s+\*:443 ssl;}
-            },
-            {
-              title: 'should set HTTP2',
-              attr: 'http2',
-              value: 'on',
-              match: %r{\s+listen\s+\*:443 ssl http2;}
-            },
-            {
-              title: 'should not set HTTP2',
-              attr: 'http2',
               value: 'off',
               match: %r{\s+listen\s+\*:443 ssl;}
             },

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -766,6 +766,18 @@ describe 'nginx::resource::server' do
               match: %r{\s+listen\s+\*:443 ssl;}
             },
             {
+              title: 'should set HTTP2',
+              attr: 'http2',
+              value: 'on',
+              match: %r{\s+listen\s+\*:443 ssl http2;}
+            },
+            {
+              title: 'should not set HTTP2',
+              attr: 'http2',
+              value: 'off',
+              match: %r{\s+listen\s+\*:443 ssl;}
+            },
+            {
               title: 'should set the IPv4 listen options',
               attr: 'listen_options',
               value: 'default',

--- a/templates/server/server_ssl_header.erb
+++ b/templates/server/server_ssl_header.erb
@@ -4,10 +4,10 @@
 server {
   <%- if @listen_ip.is_a?(Array) then -%>
     <%- @listen_ip.each do |ip| -%>
-  listen       <%= ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+  listen       <%= ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
     <%- end -%>
   <%- else -%>
-  listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+  listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
   <%- end -%>
 <%= scope.function_template(["nginx/server/server_ssl_ipv6_listen.erb"]) %>
 <%- if @rewrite_www_to_non_www -%>
@@ -48,10 +48,10 @@ server {
 server {
   <%- if @listen_ip.is_a?(Array) then -%>
     <%- @listen_ip.each do |ip| -%>
-  listen       <%= ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+  listen       <%= ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
     <%- end -%>
   <%- else -%>
-  listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
+  listen       <%= @listen_ip %>:<%= @ssl_port %> <% if @ssl_listen_option %>ssl<% end %><% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @listen_options %> <%= @listen_options %><% end %>;
   <%- end -%>
 <%= scope.function_template(["nginx/server/server_ssl_ipv6_listen.erb"]) %>
 <%- if @rewrite_www_to_non_www -%>

--- a/templates/server/server_ssl_ipv6_listen.erb
+++ b/templates/server/server_ssl_ipv6_listen.erb
@@ -2,9 +2,9 @@
   <%- if @ipv6_enable -%>
     <%- if @ipv6_listen_ip.is_a?(Array) then -%>
       <%- @ipv6_listen_ip.each do |ipv6| -%>
-  listen [<%= ipv6 %>]:<%= @ssl_port %> ssl<% if @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+  listen [<%= ipv6 %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
       <%- end -%>
     <%- else -%>
-  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- end -%>

--- a/templates/server/server_ssl_settings.erb
+++ b/templates/server/server_ssl_settings.erb
@@ -1,6 +1,9 @@
 <% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.15.0']) < 0 -%>
   ssl on;
 <% end -%>
+<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) >= 0 && @http2 -%>
+  http2 <%= @http2 %>;
+<% end -%>
 <% if @ssl_cert_real -%>
 <% @ssl_cert_real.each do | cert | -%>
   ssl_certificate           <%= cert %>;


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This PR is meant to create the http2 directive: http://nginx.org/en/docs/http/ngx_http_v2_module.html#http2


#### This Pull Request (PR) fixes the following issues

Fixes following warning in nginx:
nginx: [warn] the "listen ... http2" directive is deprecated, use the "http2" directive instead.

