### PR TITLE
raise default version to 1.16.0

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -281,7 +281,7 @@ already installed.  If the fact is unavailable, it defaults to '1.6.0'.
 You may need to set this manually to get a working and idempotent
 configuration.
 
-Default value: `pick(fact('nginx_version'), '1.6.0')`
+Default value: `pick(fact('nginx_version'), '1.16.0')`
 
 ##### <a name="-nginx--debug_connections"></a>`debug_connections`
 
@@ -2918,7 +2918,7 @@ Default value: `'on'`
 
 Data type: `Enum['on', 'off']`
 
-Wheter to use proxy_protocol
+Wheter to use proxy_protocol, only suppported with nginx >= 1.19.8
 
 Default value: `'off'`
 
@@ -2926,7 +2926,7 @@ Default value: `'off'`
 
 Data type: `Enum['on', 'off']`
 
-Wheter to use proxy_smtp_auth
+Wheter to use proxy_smtp_auth, only suppported with nginx >= 1.19.4
 
 Default value: `'off'`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -240,7 +240,7 @@ class nginx (
   Hash $nginx_upstreams                                   = {},
   Nginx::UpstreamDefaults $nginx_upstreams_defaults       = {},
   Boolean $purge_passenger_repo                           = true,
-  String[1] $nginx_version                                = pick(fact('nginx_version'), '1.6.0'),
+  String[1] $nginx_version                                = pick(fact('nginx_version'), '1.16.0'),
 
   ### END Hiera Lookups ###
 ) inherits nginx::params {

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -73,9 +73,9 @@
 # @param xclient
 #   Whether to use xclient for smtp
 # @param proxy_protocol
-#   Wheter to use proxy_protocol
+#   Wheter to use proxy_protocol, only suppported with nginx >= 1.19.8
 # @param proxy_smtp_auth
-#   Wheter to use proxy_smtp_auth
+#   Wheter to use proxy_smtp_auth, only suppported with nginx >= 1.19.4
 # @param imap_auth
 #   Sets permitted methods of authentication for IMAP clients.
 # @param imap_capabilities
@@ -257,6 +257,7 @@ define nginx::resource::mailhost (
       smtp_auth                => $smtp_auth,
       smtp_capabilities        => $smtp_capabilities,
       xclient                  => $xclient,
+      nginx_version            => $nginx::nginx_version,
   })
 
   concat { $config_file:

--- a/spec/acceptance/nginx_mail_spec.rb
+++ b/spec/acceptance/nginx_mail_spec.rb
@@ -80,7 +80,7 @@ describe 'nginx::resource::mailhost define:' do
       it { is_expected.to be_listening }
     end
 
-    context 'when configured for nginx 1.14' do
+    context 'when configured for nginx 1.14', if: !%w[Debian Archlinux].include?(fact('os.family')) do
       it 'runs successfully' do
         pp = "
       if fact('os.family') == 'RedHat' {

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -189,13 +189,8 @@ describe 'nginx' do
             let(:params) { { package_source: 'passenger' } }
 
             it { is_expected.to contain_package('nginx') }
+            it { is_expected.to contain_package('libnginx-mod-http-passenger') }
 
-            if (facts.dig(:os, 'name') == 'Debian' && %w[11].include?(facts.dig(:os, 'release', 'major'))) ||
-               (facts.dig(:os, 'name') == 'Ubuntu' && %w[bionic focal jammy].include?(facts.dig(:os, 'distro', 'codename')))
-              it { is_expected.to contain_package('libnginx-mod-http-passenger') }
-            else
-              it { is_expected.to contain_package('passenger') }
-            end
             it do
               is_expected.to contain_apt__source('nginx').with(
                 'location' => 'https://oss-binaries.phusionpassenger.com/apt/passenger',

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -111,18 +111,6 @@ describe 'nginx::resource::mailhost' do
               match: '  xclient               off;'
             },
             {
-              title: 'should set proxy_protocol',
-              attr: 'proxy_protocol',
-              value: 'off',
-              match: '  proxy_protocol        off;'
-            },
-            {
-              title: 'should set proxy_smtp_auth',
-              attr: 'proxy_smtp_auth',
-              value: 'off',
-              match: '  proxy_smtp_auth       off;'
-            },
-            {
               title: 'should set auth_http',
               attr: 'auth_http',
               value: 'test-auth_http',
@@ -252,6 +240,23 @@ describe 'nginx::resource::mailhost' do
                   expect(lines & Array(param[:match])).to eq(Array(param[:match]))
                 end
               end
+            end
+          end
+          context 'mail proxy parameters' do
+            let(:pre_condition) { ['class { "nginx": nginx_version => "1.20.0"}'] }
+            let(:params) do
+              {
+                listen_port: 25,
+                ipv6_enable: true,
+                ssl_cert: 'dummy.crt',
+                ssl_key: 'dummy.key'
+              }
+            end
+
+            it 'configures mail proxy settings' do
+              content = catalogue.resource('concat::fragment', "#{title}-header").send(:parameters)[:content]
+              expect(content).to include('proxy_protocol        off;')
+              expect(content).to include('proxy_smtp_auth       off;')
             end
           end
         end
@@ -548,7 +553,7 @@ describe 'nginx::resource::mailhost' do
               title: 'should set the IPv4 SSL listen port',
               attr: 'ssl_port',
               value: 45,
-              match: '  listen                *:45;'
+              match: '  listen                *:45 ssl;'
             },
             {
               title: 'should enable IPv6',
@@ -597,18 +602,6 @@ describe 'nginx::resource::mailhost' do
               attr: 'xclient',
               value: 'off',
               match: '  xclient               off;'
-            },
-            {
-              title: 'should set proxy_protocol',
-              attr: 'proxy_protocol',
-              value: 'off',
-              match: '  proxy_protocol        off;'
-            },
-            {
-              title: 'should set proxy_smtp_auth',
-              attr: 'proxy_smtp_auth',
-              value: 'off',
-              match: '  proxy_smtp_auth       off;'
             },
             {
               title: 'should set auth_http',
@@ -710,6 +703,16 @@ describe 'nginx::resource::mailhost' do
               it 'also has `ssl` at end of listen directive' do
                 content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
                 expect(content).to include('listen                *:587 ssl;')
+              end
+            end
+
+            context 'mail proxy parameters' do
+              let(:pre_condition) { ['class { "nginx": nginx_version => "1.20.0"}'] }
+
+              it 'configures mail proxy settings' do
+                content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
+                expect(content).to include('proxy_protocol        off;')
+                expect(content).to include('proxy_smtp_auth       off;')
               end
             end
           end

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -672,7 +672,7 @@ describe 'nginx::resource::server' do
                 facts[:nginx_version] ? facts.delete(:nginx_version) : facts
               end
 
-              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{  ssl on;}) }
+              it { is_expected.to contain_concat__fragment("#{title}-ssl-header").with_content(%r{listen       \*:443 ssl;}) }
             end
 
             context 'with fact nginx_version=1.14.1' do

--- a/templates/mailhost/mailhost_common.epp
+++ b/templates/mailhost/mailhost_common.epp
@@ -15,14 +15,19 @@
   Optional[String]  $smtp_auth,
   Optional[Array]   $smtp_capabilities,
   Enum['on', 'off'] $xclient,
+  String            $nginx_version,
 | -%>
   server_name           <%= $server_name.join(" ") %>;
 <%- if $protocol { -%>
   protocol              <%= $protocol %>;
 <%- } -%>
   xclient               <%= $xclient %>;
+<%- if versioncmp($nginx_version, '1.19.8') >= 0 { -%>
   proxy_protocol        <%= $proxy_protocol %>;
+<%- } -%>
+<%- if versioncmp($nginx_version, '1.19.4') >= 0 { -%>
   proxy_smtp_auth       <%= $proxy_smtp_auth %>;
+<%- } -%>
 <%- if $auth_http { -%>
   auth_http             <%= $auth_http %>;
 <%- } -%>


### PR DESCRIPTION
this fixes the acceptance tests. But there is a bigger issue here. The code in manifests/init.pp is not idempotent:

```puppet
 String[1] $nginx_version                                = pick(fact('nginx_version'), '1.6.0'),
```

Turns out on the first run the fact might not be set yet leading to a pre 1.15.0 compatible configuration on systems wich ship a newer version of nginx. Leading to

```
nginx: [emerg] unknown directive "ssl" in /etc/nginx/sites-enabled/www.puppetlabs.com.conf:25
```
