### PR TITLE
Fix http_raw_prepend/append indentation

### DIFF
--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -55,9 +55,9 @@ events {
 
 http {
 <% if @http_raw_prepend && Array(@http_raw_prepend).size > 0 -%>
-    <%- Array(@http_raw_prepend).each do |line| -%>
-    <%= line %>
-    <%- end -%>
+  <%- Array(@http_raw_prepend).each do |line| -%>
+  <%= line %>
+  <%- end -%>
 <% end -%>
 
 <% if @http_cfg_prepend -%>
@@ -315,9 +315,9 @@ http {
 <% end -%>
 
 <% if @http_raw_append && Array(@http_raw_append).size > 0 -%>
-    <%- Array(@http_raw_append).each do |line| -%>
-    <%= line %>
-    <%- end -%>
+  <%- Array(@http_raw_append).each do |line| -%>
+  <%= line %>
+  <%- end -%>
 <% end -%>
 
   include <%= @conf_dir %>/conf.d/*.conf;


### PR DESCRIPTION
#### Pull Request (PR) description

`http_raw_prepend` and `http_raw_append` have wrong indentation. Example with current template:
```
  ssl_stapling_verify       off;

    real_ip_header X-Forwarded-For;
    set_real_ip_from 1.2.3.4;

  include /etc/nginx/conf.d/*.conf;
```

This MR removes 2 extra spaces.