### PR TITLE
Use `keyring` for `apt::source`

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -32,6 +32,7 @@ class nginx::package::debian {
           location     => $stable_repo_source,
           repos        => 'nginx',
           key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+          keyring => '/usr/share/keyrings/deriv-archive-keyring.gpg',
           release      => $release,
           architecture => $facts['os']['architecture'],
         }
@@ -45,6 +46,7 @@ class nginx::package::debian {
           location     => $mainline_repo_source,
           repos        => 'nginx',
           key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+          keyring => '/usr/share/keyrings/deriv-archive-keyring.gpg',
           release      => $release,
           architecture => $facts['os']['architecture'],
         }

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -44,7 +44,7 @@ class nginx::package::debian {
         apt::source { 'nginx':
           location     => $mainline_repo_source,
           repos        => 'nginx',
-          keyring => '/usr/share/keyrings/nginx-archive-keyring.gpg',
+          keyring      => '/usr/share/keyrings/nginx-archive-keyring.gpg',
           release      => $release,
           architecture => $facts['os']['architecture'],
         }

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -31,7 +31,6 @@ class nginx::package::debian {
         apt::source { 'nginx':
           location     => $stable_repo_source,
           repos        => 'nginx',
-          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
           keyring => '/usr/share/keyrings/deriv-archive-keyring.gpg',
           release      => $release,
           architecture => $facts['os']['architecture'],
@@ -45,7 +44,6 @@ class nginx::package::debian {
         apt::source { 'nginx':
           location     => $mainline_repo_source,
           repos        => 'nginx',
-          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
           keyring => '/usr/share/keyrings/deriv-archive-keyring.gpg',
           release      => $release,
           architecture => $facts['os']['architecture'],

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -31,7 +31,7 @@ class nginx::package::debian {
         apt::source { 'nginx':
           location     => $stable_repo_source,
           repos        => 'nginx',
-          keyring => '/usr/share/keyrings/nginx-archive-keyring.gpg',
+          keyring      => '/usr/share/keyrings/nginx-archive-keyring.gpg',
           release      => $release,
           architecture => $facts['os']['architecture'],
         }

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -31,7 +31,7 @@ class nginx::package::debian {
         apt::source { 'nginx':
           location     => $stable_repo_source,
           repos        => 'nginx',
-          keyring => '/usr/share/keyrings/deriv-archive-keyring.gpg',
+          keyring => '/usr/share/keyrings/nginx-archive-keyring.gpg',
           release      => $release,
           architecture => $facts['os']['architecture'],
         }
@@ -44,7 +44,7 @@ class nginx::package::debian {
         apt::source { 'nginx':
           location     => $mainline_repo_source,
           repos        => 'nginx',
-          keyring => '/usr/share/keyrings/deriv-archive-keyring.gpg',
+          keyring => '/usr/share/keyrings/nginx-archive-keyring.gpg',
           release      => $release,
           architecture => $facts['os']['architecture'],
         }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adding the path to `keyring` to the `apt::source` fixes warnings happening on `apt update`

#### This Pull Request (PR) fixes the following issues
apt-key is deprecated and the nginx keys are stored in legacy trusted.gpg. This returns warnings:

```W: https://nginx.org/packages/debian/dists/bookworm/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: https://nginx.org/packages/debian bookworm InRelease: The following signatures were invalid: EXPKEYSIG ABF5BD827BD9BF62 nginx signing key <signing-key@nginx.com>
W: Failed to fetch https://nginx.org/packages/debian/dists/bookworm/InRelease  The following signatures were invalid: EXPKEYSIG ABF5BD827BD9BF62 nginx signing key <signing-key@nginx.com>
W: Some index files failed to download. They have been ignored, or old ones used instead.```
