### PR TITLE
Fix `apt-key` deprecated message

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This module manages NGINX configuration.
 
 * Puppet 4.6.1 or later.  Puppet 3 was supported up until release 0.6.0.
 * apt is now a soft dependency. If your system uses apt, you'll need to
-  configure an appropriate version of the apt module. Version 4.4.0 or higher is
-  recommended because of the proper handling of `apt-transport-https`.
+  configure an appropriate version of the apt module. Version 9.2.0 or higher is
+  recommended because of supporting "modern keyrings".
 
 ### Additional Documentation
 

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -31,7 +31,10 @@ class nginx::package::debian {
         apt::source { 'nginx':
           location     => $stable_repo_source,
           repos        => 'nginx',
-          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+          key          => {
+            'name'   => 'nginx.asc',
+            'source' => 'https://nginx.org/keys/nginx_signing.key',
+          },
           release      => $release,
           architecture => $facts['os']['architecture'],
         }
@@ -44,7 +47,10 @@ class nginx::package::debian {
         apt::source { 'nginx':
           location     => $mainline_repo_source,
           repos        => 'nginx',
-          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+          key          => {
+            'name'   => 'nginx.asc',
+            'source' => 'https://nginx.org/keys/nginx_signing.key',
+          },
           release      => $release,
           architecture => $facts['os']['architecture'],
         }
@@ -57,10 +63,12 @@ class nginx::package::debian {
         apt::source { 'nginx':
           location     => $passenger_repo_source,
           repos        => 'main',
-          key          => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' },
+          key          => {
+            'name'   => 'phusionpassenger.asc',
+            'source' => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt',
+          },
           architecture => $facts['os']['architecture'],
         }
-
         package { $passenger_package_name:
           ensure  => $passenger_package_ensure,
           require => Exec['apt_update'],

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -160,7 +160,10 @@ describe 'nginx' do
               is_expected.to contain_apt__source('nginx').with(
                 'location' => "https://nginx.org/packages/#{facts[:os]['name'].downcase}",
                 'repos'    => 'nginx',
-                'key'      => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' }
+                'key'      => {
+                  'source' => 'https://nginx.org/keys/nginx_signing.key',
+                  'name' => 'nginx.asc'
+                }
               )
             end
           end
@@ -195,7 +198,10 @@ describe 'nginx' do
               is_expected.to contain_apt__source('nginx').with(
                 'location' => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
                 'repos'    => 'main',
-                'key'      => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' }
+                'key'      => {
+                  'source' => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt',
+                  'name' => 'phusionpassenger.asc'
+                }
               )
             end
           end


### PR DESCRIPTION
#### Pull Request (PR) description
In the current implementation, apt::source stores GPG keys in the trusted.gpg file, which is no longer recommended. Additionally, with the deprecation of apt-key, running the apt update command triggers warnings on Debian-based distributions.
This PR modifies the handling of GPG keys so that they are stored in the keyrings directory, aligning with best practices and avoiding the deprecation warnings associated with apt-key
