### PR TITLE
Fix usage of `include_files` in `nginx::resource::map`

### DIFF
--- a/spec/defines/resource_map_spec.rb
+++ b/spec/defines/resource_map_spec.rb
@@ -15,12 +15,6 @@ describe 'nginx::resource::map' do
       let :default_params do
         {
           string: '$uri',
-          default: 'pool_a',
-          mappings: {
-            'foo' => 'pool_b',
-            'bar' => 'pool_c',
-            'baz' => 'pool_d'
-          }
         }
       end
 

--- a/templates/conf.d/map.epp
+++ b/templates/conf.d/map.epp
@@ -17,6 +17,7 @@ map <%= $string %> $<%= $name %> {
 <%- $include_files.each |$h| { -%>
   include <%= $h %>;
 <%- } -%>
+<%- unless $mappings.empty { -%>
 
 <%-
 $m = $mappings ? {
@@ -27,5 +28,6 @@ $field_width = $m.map |$x| { $x['key'].length }.max
 -%>
 <%- $m.each |$h| { -%>
   <%= sprintf("%-*s %s", $field_width, $h['key'], $h['value']) %>;
+<%- } -%>
 <%- } -%>
 }


### PR DESCRIPTION
When passing some `include_files` but no `mappings`, catalog compilation fail with the following error message:

```
Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Method call, max(): Wrong number of arguments need at least one (file: /etc/puppetlabs/code/environments/romain/modules/nginx/templates/conf.d/map.epp, line: 26, column: 48)
```

Refactoring done in #1575 has introduced this regression.
