### PR TITLE
fix handling for arm64 vs aarch64 on debian/ubuntu apt repositories

### DIFF
--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -28,12 +28,23 @@ class nginx::package::debian {
           undef => "https://nginx.org/packages/${distro}",
           default => $repo_source,
         }
-        apt::source { 'nginx':
-          location     => $stable_repo_source,
-          repos        => 'nginx',
-          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
-          release      => $release,
-          architecture => $facts['os']['architecture'],
+        if $facts['os']['architecture'] == 'aarch64' {
+          apt::source { 'nginx':
+            location     => $stable_repo_source,
+            repos        => 'nginx',
+            key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+            release      => $release,
+            architecture => 'arm64',
+          }
+        }
+        else {
+          apt::source { 'nginx':
+            location     => $stable_repo_source,
+            repos        => 'nginx',
+            key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+            release      => $release,
+            architecture => $facts['os']['architecture'],
+          }
         }
       }
       'nginx-mainline': {
@@ -41,12 +52,23 @@ class nginx::package::debian {
           undef => "https://nginx.org/packages/mainline/${distro}",
           default => $repo_source,
         }
-        apt::source { 'nginx':
-          location     => $mainline_repo_source,
-          repos        => 'nginx',
-          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
-          release      => $release,
-          architecture => $facts['os']['architecture'],
+        if $facts['os']['architecture'] == 'aarch64' {
+          apt::source { 'nginx':
+            location     => $mainline_repo_source,
+            repos        => 'nginx',
+            key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+            release      => $release,
+            architecture => 'arm64',
+          }
+        }
+        else {
+          apt::source { 'nginx':
+            location     => $mainline_repo_source,
+            repos        => 'nginx',
+            key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+            release      => $release,
+            architecture => $facts['os']['architecture'],
+          }
         }
       }
       'passenger': {
@@ -54,11 +76,21 @@ class nginx::package::debian {
           undef => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
           default => $repo_source,
         }
-        apt::source { 'nginx':
-          location     => $passenger_repo_source,
-          repos        => 'main',
-          key          => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' },
-          architecture => $facts['os']['architecture'],
+        if $facts['os']['architecture'] == 'aarch64' {
+          apt::source { 'nginx':
+            location     => $passenger_repo_source,
+            repos        => 'main',
+            key          => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' },
+            architecture => 'arm64',
+          }
+        }
+        else {
+          apt::source { 'nginx':
+            location     => $passenger_repo_source,
+            repos        => 'main',
+            key          => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' },
+            architecture => $facts['os']['architecture'],
+          }
         }
 
         package { $passenger_package_name:

--- a/manifests/package/debian.pp
+++ b/manifests/package/debian.pp
@@ -12,6 +12,10 @@ class nginx::package::debian {
   $repo_source              = $nginx::repo_source
 
   $distro = downcase($facts['os']['name'])
+  $arch = $facts['os']['architecture'] ? {
+    'aarch64' => 'arm64',
+    default   => $facts['os']['architecture'],
+  }
 
   package { 'nginx':
     ensure => $package_ensure,
@@ -28,23 +32,12 @@ class nginx::package::debian {
           undef => "https://nginx.org/packages/${distro}",
           default => $repo_source,
         }
-        if $facts['os']['architecture'] == 'aarch64' {
-          apt::source { 'nginx':
-            location     => $stable_repo_source,
-            repos        => 'nginx',
-            key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
-            release      => $release,
-            architecture => 'arm64',
-          }
-        }
-        else {
-          apt::source { 'nginx':
-            location     => $stable_repo_source,
-            repos        => 'nginx',
-            key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
-            release      => $release,
-            architecture => $facts['os']['architecture'],
-          }
+        apt::source { 'nginx':
+          location     => $stable_repo_source,
+          repos        => 'nginx',
+          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+          release      => $release,
+          architecture => $arch,
         }
       }
       'nginx-mainline': {
@@ -52,23 +45,12 @@ class nginx::package::debian {
           undef => "https://nginx.org/packages/mainline/${distro}",
           default => $repo_source,
         }
-        if $facts['os']['architecture'] == 'aarch64' {
-          apt::source { 'nginx':
-            location     => $mainline_repo_source,
-            repos        => 'nginx',
-            key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
-            release      => $release,
-            architecture => 'arm64',
-          }
-        }
-        else {
-          apt::source { 'nginx':
-            location     => $mainline_repo_source,
-            repos        => 'nginx',
-            key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
-            release      => $release,
-            architecture => $facts['os']['architecture'],
-          }
+        apt::source { 'nginx':
+          location     => $mainline_repo_source,
+          repos        => 'nginx',
+          key          => { 'id' => '573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62' },
+          release      => $release,
+          architecture => $arch,
         }
       }
       'passenger': {
@@ -76,21 +58,11 @@ class nginx::package::debian {
           undef => 'https://oss-binaries.phusionpassenger.com/apt/passenger',
           default => $repo_source,
         }
-        if $facts['os']['architecture'] == 'aarch64' {
-          apt::source { 'nginx':
-            location     => $passenger_repo_source,
-            repos        => 'main',
-            key          => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' },
-            architecture => 'arm64',
-          }
-        }
-        else {
-          apt::source { 'nginx':
-            location     => $passenger_repo_source,
-            repos        => 'main',
-            key          => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' },
-            architecture => $facts['os']['architecture'],
-          }
+        apt::source { 'nginx':
+          location     => $passenger_repo_source,
+          repos        => 'main',
+          key          => { 'id' => '16378A33A6EF16762922526E561F9B9CAC40B2F7' },
+          architecture => $arch,
         }
 
         package { $passenger_package_name:


### PR DESCRIPTION
#### Pull Request (PR) description
Add logic for using arm64 instead of aarch64 on ubuntu/debian systems.
The system fact reported by puppet is aarch64 but the repositories expecting arm64. 

#### This Pull Request (PR) fixes the following issues
Fixes #1625 