### PR TITLE
Add ssl parameter to IPv6 listen directive

### DIFF
--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -559,7 +559,7 @@ describe 'nginx::resource::mailhost' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: '  listen                [::]:587 default ipv6only=on;'
+              match: '  listen                [::]:587 ssl default ipv6only=on;'
             },
             {
               title: 'should not enable IPv6',
@@ -571,19 +571,19 @@ describe 'nginx::resource::mailhost' do
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: '  listen                [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:587 default ipv6only=on;'
+              match: '  listen                [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:587 ssl default ipv6only=on;'
             },
             {
               title: 'should set the IPv6 ssl port',
               attr: 'ssl_port',
               value: 45,
-              match: '  listen                [::]:45 default ipv6only=on;'
+              match: '  listen                [::]:45 ssl default ipv6only=on;'
             },
             {
               title: 'should set the IPv6 listen options',
               attr: 'ipv6_listen_options',
               value: 'spdy',
-              match: '  listen                [::]:587 spdy;'
+              match: '  listen                [::]:587 ssl spdy;'
             },
             {
               title: 'should set servername(s)',
@@ -695,6 +695,11 @@ describe 'nginx::resource::mailhost' do
                 content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
                 expect(content).to include('listen                *:587 ssl;')
               end
+
+              it 'contains `ssl` in the listen directive for ipv6' do
+                content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
+                expect(content).to include('listen                [::]:587 ssl default ipv6only=on;')
+              end
             end
 
             context 'when version comes from parameter' do
@@ -703,6 +708,11 @@ describe 'nginx::resource::mailhost' do
               it 'also has `ssl` at end of listen directive' do
                 content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
                 expect(content).to include('listen                *:587 ssl;')
+              end
+
+              it 'contains `ssl` in the listen directive for ipv6' do
+                content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
+                expect(content).to include('listen                [::]:587 ssl default ipv6only=on;')
               end
             end
 

--- a/templates/mailhost/mailhost_ssl.epp
+++ b/templates/mailhost/mailhost_ssl.epp
@@ -17,7 +17,7 @@ server {
   listen                <%= $ip %>:<%= $ssl_port %> ssl;
 <%- } -%>
 <%- $ipv6_listen_ip.each |$ipv6| { -%>
-  listen                [<%= $ipv6 %>]:<%= $ssl_port %> <% if $ipv6_listen_options { %><%= $ipv6_listen_options %><% } %>;
+  listen                [<%= $ipv6 %>]:<%= $ssl_port %><% if versioncmp($nginx_version, '1.15.0') >= 0 { %> ssl<% } %> <% if $ipv6_listen_options { %><%= $ipv6_listen_options %><% } %>;
 <%- } -%>
 <%= $mailhost_common -%>
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This change ensures that the `ssl` parameter is also applied to the IPv6 listen directive ([::]:993) when the Nginx version is ≥ 1.15.0. Previously, only the IPv4 directive (*:993 ssl) included the ssl parameter.