### PR TITLE
Disable mail relay in nginx 1.14

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -77,6 +77,7 @@ The following parameters are available in the `nginx` class:
 
 * [`include_modules_enabled`](#-nginx--include_modules_enabled)
 * [`passenger_package_name`](#-nginx--passenger_package_name)
+* [`mail_package_name`](#-nginx--mail_package_name)
 * [`nginx_version`](#-nginx--nginx_version)
 * [`debug_connections`](#-nginx--debug_connections)
 * [`service_config_check`](#-nginx--service_config_check)
@@ -266,9 +267,18 @@ Default value: `$nginx::params::include_modules_enabled`
 Data type: `String[1]`
 
 The name of the package to install in order for the passenger module of
-nginx being usable.
+nginx to be usable.
 
 Default value: `$nginx::params::passenger_package_name`
+
+##### <a name="-nginx--mail_package_name"></a>`mail_package_name`
+
+Data type: `Optional[String[1]]`
+
+The name of the package to install in order for the mail module of
+nginx to be usable.
+
+Default value: `$nginx::params::mail_package_name`
 
 ##### <a name="-nginx--nginx_version"></a>`nginx_version`
 
@@ -395,7 +405,7 @@ Data type: `Array[String]`
 
 
 
-Default value: `[]`
+Default value: `$nginx::params::dynamic_modules`
 
 ##### <a name="-nginx--global_owner"></a>`global_owner`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -258,7 +258,8 @@ The following parameters are available in the `nginx` class:
 Data type: `Boolean`
 
 When set, nginx will include module configurations files installed in the
-/etc/nginx/modules-enabled directory.
+/etc/nginx/modules-enabled directory. This is also enabled if mail is
+being configured (to allow the module to be loaded).
 
 Default value: `$nginx::params::include_modules_enabled`
 
@@ -405,7 +406,7 @@ Data type: `Array[String]`
 
 
 
-Default value: `$nginx::params::dynamic_modules`
+Default value: `[]`
 
 ##### <a name="-nginx--global_owner"></a>`global_owner`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -199,6 +199,12 @@ class nginx::config {
     }
   }
 
+  if ($include_modules_enabled or $nginx::mail) {
+    file { "${conf_dir}/modules-enabled":
+      ensure => directory,
+    }
+  }
+
   file { $log_dir:
     ensure  => directory,
     mode    => $log_mode,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,8 @@
 #
 # @param include_modules_enabled
 #   When set, nginx will include module configurations files installed in the
-#   /etc/nginx/modules-enabled directory.
+#   /etc/nginx/modules-enabled directory. This is also enabled if mail is
+#   being configured (to allow the module to be loaded).
 #
 # @param passenger_package_name
 #   The name of the package to install in order for the passenger module of
@@ -224,7 +225,7 @@ class nginx (
   Optional[Enum['on', 'off']] $daemon                        = undef,
   String[1] $daemon_user                                     = $nginx::params::daemon_user,
   Optional[String[1]] $daemon_group                          = undef,
-  Array[String] $dynamic_modules                             = $nginx::params::dynamic_modules,
+  Array[String] $dynamic_modules                             = [],
   String[1] $global_owner                                    = 'root',
   String[1] $global_group                                    = $nginx::params::global_group,
   Stdlib::Filemode $global_mode                              = '0644',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,11 @@
 #
 # @param passenger_package_name
 #   The name of the package to install in order for the passenger module of
-#   nginx being usable.
+#   nginx to be usable.
+#
+# @param mail_package_name
+#   The name of the package to install in order for the mail module of
+#   nginx to be usable.
 #
 # @param nginx_version
 #   The version of nginx installed (or being installed).
@@ -220,7 +224,7 @@ class nginx (
   Optional[Enum['on', 'off']] $daemon                        = undef,
   String[1] $daemon_user                                     = $nginx::params::daemon_user,
   Optional[String[1]] $daemon_group                          = undef,
-  Array[String] $dynamic_modules                             = [],
+  Array[String] $dynamic_modules                             = $nginx::params::dynamic_modules,
   String[1] $global_owner                                    = 'root',
   String[1] $global_group                                    = $nginx::params::global_group,
   Stdlib::Filemode $global_mode                              = '0644',
@@ -375,6 +379,8 @@ class nginx (
   Optional[String] $repo_release                             = undef,
   String $passenger_package_ensure                           = installed,
   String[1] $passenger_package_name                          = $nginx::params::passenger_package_name,
+  # This is optional, to allow it to be set to undef for systems that install it with nginx always
+  Optional[String[1]] $mail_package_name                     = $nginx::params::mail_package_name,
   Optional[Stdlib::HTTPUrl] $repo_source                     = undef,
   ### END Package Configuration ###
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,8 +14,10 @@ class nginx::params {
     'log_mode'                => '0750',
     'package_name'            => 'nginx',
     'passenger_package_name'  => 'passenger',
+    'mail_package_name'       => undef,
     'manage_repo'             => false,
     'include_modules_enabled' => false,
+    'dynamic_modules'         => [],
     'mime_types'              => {
       'text/html'                                                                 => 'html htm shtml',
       'text/css'                                                                  => 'css',
@@ -104,11 +106,12 @@ class nginx::params {
   case $facts['os']['family'] {
     'ArchLinux': {
       $_module_os_overrides = {
-        'pid'          => false,
-        'daemon_user'  => 'http',
-        'log_user'     => 'http',
-        'log_group'    => 'log',
-        'package_name' => 'nginx-mainline',
+        'pid'               => false,
+        'daemon_user'       => 'http',
+        'log_user'          => 'http',
+        'log_group'         => 'log',
+        'package_name'      => 'nginx-mainline',
+        'mail_package_name' => 'nginx-mod-mail',
       }
     }
     'Debian': {
@@ -144,7 +147,9 @@ class nginx::params {
         }
       } else {
         $_module_os_overrides = {
-          'log_group' => 'nginx',
+          'log_group'         => 'nginx',
+          'mail_package_name' => 'nginx-mod-mail',
+          'dynamic_modules'   => ['/usr/lib64/nginx/modules/ngx_mail_module.so'],
         }
       }
     }
@@ -204,6 +209,7 @@ class nginx::params {
   $log_mode                = $_module_parameters['log_mode']
   $pid                     = $_module_parameters['pid']
   $include_modules_enabled = $_module_parameters['include_modules_enabled']
+  $dynamic_modules         = $_module_parameters['dynamic_modules']
 
   $daemon_user             = $_module_parameters['daemon_user']
   $global_group            = $_module_parameters['root_group']
@@ -212,6 +218,7 @@ class nginx::params {
   $root_group              = $_module_parameters['root_group']
   $package_name            = $_module_parameters['package_name']
   $passenger_package_name  = $_module_parameters['passenger_package_name']
+  $mail_package_name       = $_module_parameters['mail_package_name']
   $sites_available_group   = $_module_parameters['root_group']
   ### END Referenced Variables
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -111,7 +111,7 @@ class nginx::params {
         'log_user'          => 'http',
         'log_group'         => 'log',
         'package_name'      => 'nginx-mainline',
-        'mail_package_name' => 'nginx-mod-mail',
+        'mail_package_name' => 'nginx-mainline-mod-mail',
       }
     }
     'Debian': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,6 @@ class nginx::params {
     'mail_package_name'       => undef,
     'manage_repo'             => false,
     'include_modules_enabled' => false,
-    'dynamic_modules'         => [],
     'mime_types'              => {
       'text/html'                                                                 => 'html htm shtml',
       'text/css'                                                                  => 'css',
@@ -149,7 +148,6 @@ class nginx::params {
         $_module_os_overrides = {
           'log_group'         => 'nginx',
           'mail_package_name' => 'nginx-mod-mail',
-          'dynamic_modules'   => ['/usr/lib64/nginx/modules/ngx_mail_module.so'],
         }
       }
     }
@@ -209,7 +207,6 @@ class nginx::params {
   $log_mode                = $_module_parameters['log_mode']
   $pid                     = $_module_parameters['pid']
   $include_modules_enabled = $_module_parameters['include_modules_enabled']
-  $dynamic_modules         = $_module_parameters['dynamic_modules']
 
   $daemon_user             = $_module_parameters['daemon_user']
   $global_group            = $_module_parameters['root_group']

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -194,6 +194,17 @@ define nginx::resource::mailhost (
     package { $nginx::mail_package_name:
       ensure => 'installed',
     }
+    $mail_load_content = $facts['os']['family'] ? {
+      'ArchLinux' => "load_module /usr/lib/nginx/modules/ngx_mail_module.so;\n",
+      'RedHat'    => "load_module /usr/lib64/nginx/modules/ngx_mail_module.so;\n",
+    }
+    file { '/etc/nginx/modules-enabled/mail.conf':
+      ensure  => 'file',
+      owner   => 'root',
+      mode    => '0644',
+      content => $mail_load_content,
+      require => File['/etc/nginx/modules-enabled'],
+    }
   }
 
   # Add IPv6 Logic Check - Nginx service will not start if ipv6 is enabled

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -189,7 +189,10 @@ define nginx::resource::mailhost (
     fail('You must include the nginx base class before using any defined resources')
   } elsif versioncmp($facts.get('nginx_version', $nginx::nginx_version), '1.15.0') < 0 {
     fail('This module does not support nginx 1.14')
+  } elsif ! $nginx::mail {
+    fail('nginx mail proxy requires the nginx::mail flag to be set true')
   }
+
   if $nginx::mail_package_name {
     package { $nginx::mail_package_name:
       ensure => 'installed',

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -188,6 +188,11 @@ define nginx::resource::mailhost (
   if ! defined(Class['nginx']) {
     fail('You must include the nginx base class before using any defined resources')
   }
+  if $nginx::mail_package_name {
+    package { $nginx::mail_package_name:
+      ensure => 'installed',
+    }
+  }
 
   # Add IPv6 Logic Check - Nginx service will not start if ipv6 is enabled
   # and support does not exist for it in the kernel.

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -187,6 +187,8 @@ define nginx::resource::mailhost (
 ) {
   if ! defined(Class['nginx']) {
     fail('You must include the nginx base class before using any defined resources')
+  } elsif versioncmp($facts.get('nginx_version', $nginx::nginx_version), '1.15.0') < 0 {
+    fail('This module does not support nginx 1.14')
   }
   if $nginx::mail_package_name {
     package { $nginx::mail_package_name:

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -188,7 +188,7 @@ define nginx::resource::mailhost (
   if ! defined(Class['nginx']) {
     fail('You must include the nginx base class before using any defined resources')
   } elsif versioncmp($facts.get('nginx_version', $nginx::nginx_version), '1.15.0') < 0 {
-    fail('This module does not support nginx 1.14')
+    fail('The mail module requires nginx 1.15 or newer')
   } elsif ! $nginx::mail {
     fail('nginx mail proxy requires the nginx::mail flag to be set true')
   }

--- a/spec/acceptance/nginx_mail_spec.rb
+++ b/spec/acceptance/nginx_mail_spec.rb
@@ -3,9 +3,7 @@
 require 'spec_helper_acceptance'
 
 describe 'nginx::resource::mailhost define:' do
-  has_recent_mail_module = true
-
-  has_recent_mail_module = false if fact('os.family') == 'RedHat' && fact('os.release.major') == '8'
+  has_recent_mail_module = fact('os.family') != 'RedHat' || fact('os.release.major') != '8'
 
   it 'remove leftovers from previous tests', if: fact('os.family') == 'RedHat' do
     # nginx-mod-mail is not available for all versions of nginx, the one

--- a/spec/acceptance/nginx_mail_spec.rb
+++ b/spec/acceptance/nginx_mail_spec.rb
@@ -65,37 +65,5 @@ describe 'nginx::resource::mailhost define:' do
     describe port(465) do
       it { is_expected.to be_listening }
     end
-
-    context 'when configured for nginx 1.14', if: !%w[Debian Archlinux].include?(fact('os.family')) do
-      shell('yum -y install nginx-1.14.1') if fact('os.family') == 'RedHat' && fact('os.release.major') == '8'
-      it 'runs successfully' do
-        pp = "
-      class { 'nginx':
-        mail            => true,
-        manage_repo     => false,
-        nginx_version   => '1.14.0',
-      }
-      nginx::resource::mailhost { 'domain1.example':
-        ensure      => present,
-        auth_http   => 'localhost/cgi-bin/auth',
-        protocol    => 'smtp',
-        listen_port => 587,
-        ssl         => true,
-        ssl_port    => 465,
-        ssl_cert    => '/etc/pki/tls/certs/blah.cert',
-        ssl_key     => '/etc/pki/tls/private/blah.key',
-        xclient     => 'off',
-      }
-        "
-
-        apply_manifest(pp, catch_failures: true)
-      end
-
-      describe file('/etc/nginx/conf.mail.d/domain1.example.conf') do
-        it 'does\'t contain `ssl` on `listen` line' do
-          is_expected.to contain 'listen                *:465;'
-        end
-      end
-    end
   end
 end

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -16,6 +16,7 @@ describe 'nginx' do
           nginx_servers_defaults: { 'listen_options' => 'default_server' },
           nginx_locations: { 'test2.local' => { 'server' => 'test2.local', 'www_root' => '/' } },
           nginx_locations_defaults: { 'expires' => '@12h34m' },
+          mail: true,
           nginx_mailhosts: { 'smtp.test2.local' => { 'auth_http' => 'server2.example/cgi-bin/auth', 'protocol' => 'smtp', 'listen_port' => 587 } },
           nginx_mailhosts_defaults: { 'listen_options' => 'default_server_smtp' },
           nginx_streamhosts: { 'streamhost1' => { 'proxy' => 'streamproxy' } }

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -243,7 +243,7 @@ describe 'nginx::resource::mailhost' do
             end
           end
           context 'mail proxy parameters' do
-            let(:pre_condition) { ['class { "nginx": nginx_version => "1.20.0"}'] }
+            let(:pre_condition) { ['class { "nginx": nginx_version => "1.20.0", mail => true,}'] }
             let(:params) do
               {
                 listen_port: 25,
@@ -689,7 +689,7 @@ describe 'nginx::resource::mailhost' do
                 facts.merge(nginx_version: '1.16.0')
               end
 
-              let(:pre_condition) { ['include nginx'] }
+              let(:pre_condition) { ['class { "nginx": mail => true,}'] }
 
               it 'has `ssl` at end of listen directive' do
                 content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
@@ -698,7 +698,7 @@ describe 'nginx::resource::mailhost' do
             end
 
             context 'when version comes from parameter' do
-              let(:pre_condition) { ['class { "nginx": nginx_version => "1.16.0"}'] }
+              let(:pre_condition) { ['class { "nginx": nginx_version => "1.16.0", mail => true,}'] }
 
               it 'also has `ssl` at end of listen directive' do
                 content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
@@ -707,7 +707,7 @@ describe 'nginx::resource::mailhost' do
             end
 
             context 'mail proxy parameters' do
-              let(:pre_condition) { ['class { "nginx": nginx_version => "1.20.0"}'] }
+              let(:pre_condition) { ['class { "nginx": nginx_version => "1.20.0", mail => true,}'] }
 
               it 'configures mail proxy settings' do
                 content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -16,7 +16,7 @@ describe 'nginx::resource::mailhost' do
           ipv6_enable: true
         }
       end
-      let(:pre_condition) { ['include nginx'] }
+      let(:pre_condition) { ['class { "nginx": mail => true }'] }
 
       describe 'os-independent items' do
         describe 'basic assumptions' do

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -6,6 +6,7 @@ load_module "<%= mod_item -%>";
 load_module "modules/<%= mod_item -%>.so";
   <%- end -%>
 <%- end -%>
+
 <% if @daemon -%>
 daemon <%= @daemon %>;
 <% end -%>
@@ -23,7 +24,7 @@ pcre_jit <%= @pcre_jit %>;
 <% if @pid -%>
 pid        <%= @pid %>;
 <% end -%>
-<% if @include_modules_enabled -%>
+<% if @include_modules_enabled or @mail -%>
 include /etc/nginx/modules-enabled/*.conf;
 <% end -%>
 <% if @nginx_cfg_prepend -%>

--- a/templates/mailhost/mailhost_ssl.epp
+++ b/templates/mailhost/mailhost_ssl.epp
@@ -14,16 +14,13 @@
 server {
 <%= $mailhost_prepend -%>
 <%- $listen_ip.each |$ip| { -%>
-  listen                <%= $ip %>:<%= $ssl_port %><% if versioncmp($nginx_version, '1.15.0') >= 0 { %> ssl<% } %>;
+  listen                <%= $ip %>:<%= $ssl_port %> ssl;
 <%- } -%>
 <%- $ipv6_listen_ip.each |$ipv6| { -%>
   listen                [<%= $ipv6 %>]:<%= $ssl_port %> <% if $ipv6_listen_options { %><%= $ipv6_listen_options %><% } %>;
 <%- } -%>
 <%= $mailhost_common -%>
 
-<%- if versioncmp($nginx_version, '1.15.0') < 0 { -%>
-  ssl                   on;
-<% } %>
   starttls              off;
 
 <%= $mailhost_ssl_settings -%>


### PR DESCRIPTION
While redhat installs the mail packages by default, arch doesn't and therefore you need to be able to define that package for installation.
