### PR TITLE
Fix logging statements in locations

### DIFF
--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -295,15 +295,15 @@ describe 'nginx::resource::location' do
               title: 'should set error_log',
               attr: 'error_log',
               value: '/path/to/error.log',
-              match: '  error_log             /path/to/error.log;'
+              match: '    error_log             /path/to/error.log;'
             },
             {
               title: 'should allow multiple error_log directives',
               attr: 'error_log',
               value: ['/path/to/error.log', 'syslog:server=localhost'],
               match: [
-                '  error_log             /path/to/error.log;',
-                '  error_log             syslog:server=localhost;'
+                '    error_log             /path/to/error.log;',
+                '    error_log             syslog:server=localhost;'
               ]
             },
             {

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -91,22 +91,20 @@
 <% if @access_log -%>
     <% if @access_log.is_a?(Array) -%>
         <%- @access_log.each do |log_item| -%>
-  access_log            <%= log_item %><% unless @format_log.nil? -%> <%= @format_log %><% end -%>;
+    access_log            <%= log_item %><% unless @format_log.nil? -%> <%= @format_log %><% end -%>;
         <%- end -%>
     <% elsif @access_log == 'absent' -%>
     <% elsif @access_log == 'off' -%>
-  access_log            off;
+    access_log            off;
     <% else -%>
     access_log <%= @access_log %><% unless @format_log.nil? -%> <%= @format_log %><% end -%>;
     <% end -%>
 <% end -%>
 <% if @error_log.is_a?(Array) -%>
   <%- @error_log.each do |log_item| -%>
-  error_log             <%= log_item %>;
+    error_log             <%= log_item %>;
   <%- end -%>
-<% elsif @error_log == 'absent' -%>
-<% elsif not @error_log -%>
-  error_log             <%= scope['::nginx::config::log_dir'] %>/<%= @name_sanitized %>.error.log;
+<% elsif @error_log == 'absent' || @error_log.nil? -%>
 <% else -%>
-  error_log             <%= @error_log %>;
+    error_log             <%= @error_log %>;
 <% end -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
In version 7.0.0 [log statements functionality added per location](https://github.com/voxpupuli/puppet-nginx/pull/1471/files).
But with it there are some problems:
1. Intendations. Log statements intendation is 2 space from the left (top level intendation)
2. Wrong default behavieour. When error_log is undef, statement still creates.
See screenshot
![2025-06-11_10-24](https://github.com/user-attachments/assets/df9b4992-238f-43de-ba53-8feb56842fdd)
