### PR TITLE
Allow `ssl_verify_client` when only `ssl_trusted_cert` is set

### DIFF
--- a/templates/server/server_ssl_settings.erb
+++ b/templates/server/server_ssl_settings.erb
@@ -14,11 +14,18 @@
   ssl_certificate_key       <%= key %>;
 <% end -%>
 <% end -%>
-<% if defined? @ssl_client_cert -%>
+<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.27.2']) >= 0 -%>
+<%   if defined? @ssl_client_cert -%>
   ssl_client_certificate    <%= @ssl_client_cert %>;
-<% end -%>
-<% if defined? ssl_verify_client && ( defined? @ssl_client_cert || defined? @ssl_trusted_cert ) -%>
+<%   end -%>
+<%   if ( defined? @ssl_verify_client ) && ( @ssl_client_cert.is_a?(String) || @ssl_trusted_cert.is_a?(String) ) -%>
   ssl_verify_client         <%= @ssl_verify_client %>;
+<%   end -%>
+<% else -%>
+<%   if defined? @ssl_client_cert -%>
+  ssl_client_certificate    <%= @ssl_client_cert %>;
+  ssl_verify_client         <%= @ssl_verify_client %>;
+<%   end -%>
 <% end -%>
 <% if defined? @ssl_dhparam -%>
   ssl_dhparam               <%= @ssl_dhparam %>;


### PR DESCRIPTION
Fixes #1644

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
