### PR TITLE
Fix ssl verify client compat

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3747,11 +3747,11 @@ Default value: `undef`
 
 ##### <a name="-nginx--resource--server--ssl_verify_client"></a>`ssl_verify_client`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 Enables verification of client certificates.
 
-Default value: `'on'`
+Default value: `undef`
 
 ##### <a name="-nginx--resource--server--ssl_crl"></a>`ssl_crl`
 

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -305,7 +305,7 @@ define nginx::resource::server (
   Boolean $ssl_listen_option                                                     = true,
   Optional[Variant[String, Boolean, Array[String]]] $ssl_cert                    = undef,
   Optional[String] $ssl_client_cert                                              = undef,
-  String $ssl_verify_client                                                      = 'on',
+  Optional[String] $ssl_verify_client                                            = undef,
   Optional[String] $ssl_dhparam                                                  = undef,
   Optional[String] $ssl_ecdh_curve                                               = undef,
   Boolean $ssl_redirect                                                          = false,

--- a/templates/server/server_ssl_settings.erb
+++ b/templates/server/server_ssl_settings.erb
@@ -20,12 +20,12 @@
 <%   end -%>
 <%   if ( defined? @ssl_verify_client ) && ( @ssl_client_cert.is_a?(String) || @ssl_trusted_cert.is_a?(String) ) -%>
   ssl_verify_client         <%= @ssl_verify_client %>;
+<%   elsif ( not defined? @ssl_verify_client ) && ( @ssl_client_cert.is_a?(String) ) -%>
+  ssl_verify_client         on;
 <%   end -%>
 <% else -%>
 <%   if defined? @ssl_client_cert -%>
   ssl_client_certificate    <%= @ssl_client_cert %>;
-<% end -%>
-<% if defined? ssl_verify_client && ( defined? @ssl_client_cert || defined? @ssl_trusted_cert ) -%>
   ssl_verify_client         <%= @ssl_verify_client %>;
 <%   end -%>
 <% end -%>

--- a/templates/server/server_ssl_settings.erb
+++ b/templates/server/server_ssl_settings.erb
@@ -24,6 +24,8 @@
 <% else -%>
 <%   if defined? @ssl_client_cert -%>
   ssl_client_certificate    <%= @ssl_client_cert %>;
+<% end -%>
+<% if defined? ssl_verify_client && ( defined? @ssl_client_cert || defined? @ssl_trusted_cert ) -%>
   ssl_verify_client         <%= @ssl_verify_client %>;
 <%   end -%>
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes a problem introduced with #1645. The global default for `ssl_verify_client` is `on`, which means that it will be switched on for anyone who uses `ssl_trusted_certificates` for OCSP purposes, for example.

This commit changes the global default to `unset`. This will require people to be explicit if they want `ssl_verify_client`.

The `server_ssl_settings.erb` template now sets `ssl_verify_client` explicitly to 'on' if `ssl_client_certificate` is set AND `ssl_verify_client` is unset. This keeps the current behaviour for what I think is the majority of cases.

Tested to the best of my ability, and I could not find any other cases that expect a value to be present for `ssl_verify_client`.

#### This Pull Request (PR) fixes the following issues
Fixes #1646 