### PR TITLE
Add parameter `uwsgi_param` for default vhost in server resource

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3345,6 +3345,7 @@ The following parameters are available in the `nginx::resource::server` defined 
 * [`fastcgi_params`](#-nginx--resource--server--fastcgi_params)
 * [`fastcgi_index`](#-nginx--resource--server--fastcgi_index)
 * [`fastcgi_script`](#-nginx--resource--server--fastcgi_script)
+* [`uwsgi_param`](#-nginx--resource--server--uwsgi_param)
 * [`uwsgi_read_timeout`](#-nginx--resource--server--uwsgi_read_timeout)
 * [`ssl`](#-nginx--resource--server--ssl)
 * [`ssl_cert`](#-nginx--resource--server--ssl_cert)
@@ -3737,6 +3738,14 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 optional SCRIPT_FILE parameter
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--server--uwsgi_param"></a>`uwsgi_param`
+
+Data type: `Optional[Hash]`
+
+Set additional custom uwsgi parameters (uwsgi_param in nginx) in the default vhost.
 
 Default value: `undef`
 

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -79,6 +79,8 @@
 #   optional FastCGI index page
 # @param fastcgi_script
 #   optional SCRIPT_FILE parameter
+# @param uwsgi_param
+#   Set additional custom uwsgi parameters (uwsgi_param in nginx) in the default vhost.
 # @param uwsgi_read_timeout
 #   optional value for uwsgi_read_timeout
 # @param ssl
@@ -360,6 +362,7 @@ define nginx::resource::server (
   String $fastcgi_params                                                         = "${nginx::conf_dir}/fastcgi.conf",
   Optional[String] $fastcgi_script                                               = undef,
   Optional[String] $uwsgi                                                        = undef,
+  Optional[Hash] $uwsgi_param                                                    = undef,
   String $uwsgi_params                                                           = "${nginx::config::conf_dir}/uwsgi_params",
   Optional[String] $uwsgi_read_timeout                                           = undef,
   Array $index_files                                                             = [
@@ -545,6 +548,7 @@ define nginx::resource::server (
       fastcgi_params                => $fastcgi_params,
       fastcgi_script                => $fastcgi_script,
       uwsgi                         => $uwsgi,
+      uwsgi_param                   => $uwsgi_param,
       uwsgi_params                  => $uwsgi_params,
       uwsgi_read_timeout            => $uwsgi_read_timeout,
       try_files                     => $try_files,

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -1463,6 +1463,18 @@ describe 'nginx::resource::server' do
             it { is_expected.not_to contain_file('/etc/nginx/bogusparams') }
           end
 
+          context 'when uwsgi_param has custom params' do
+            let :params do
+              default_params.merge(
+                uwsgi_param: {
+                  'X-Custom-Param': 'Someting',
+                }
+              )
+            end
+
+            it { is_expected.to contain_nginx__resource__location("#{title}-default").with_uwsgi_param('X-Custom-Param' => 'Someting') }
+          end
+
           context 'when listen_port == ssl_port but ssl = false' do
             let :params do
               default_params.merge(listen_port: 80,


### PR DESCRIPTION
It was not easy to add uwsgi_param parameters to the default location in a server resource.