### PR TITLE
Add GB size unit support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5313,7 +5313,7 @@ Alias of `Enum['nginx', 'nginx-stable', 'nginx-mainline', 'passenger']`
 
 Type Alias for Nginx::Size
 
-Alias of `Variant[Integer[0], Pattern[/\A\d+[k|K|m|M]?\z/]]`
+Alias of `Variant[Integer[0], Pattern[/\A\d+[kKmMgG]?\z/]]`
 
 ### <a name="Nginx--StringMappings"></a>`Nginx::StringMappings`
 

--- a/spec/type_aliases/size_spec.rb
+++ b/spec/type_aliases/size_spec.rb
@@ -7,6 +7,8 @@ describe 'Nginx::Size' do
   it { is_expected.to allow_value('1024K') }
   it { is_expected.to allow_value('1m') }
   it { is_expected.to allow_value('1M') }
+  it { is_expected.to allow_value('1g') }
+  it { is_expected.to allow_value('1G') }
   it { is_expected.to allow_value(1) }
   it { is_expected.to allow_value(1024) }
   it { is_expected.to allow_value('1') }
@@ -22,6 +24,6 @@ describe 'Nginx::Size' do
   it { is_expected.not_to allow_value('0.1K') }
   it { is_expected.not_to allow_value('0.1m') }
   it { is_expected.not_to allow_value('0.1M') }
-  it { is_expected.not_to allow_value('1g') }
-  it { is_expected.not_to allow_value('1G') }
+  it { is_expected.not_to allow_value('0.1g') }
+  it { is_expected.not_to allow_value('0.1G') }
 end

--- a/types/size.pp
+++ b/types/size.pp
@@ -1,5 +1,5 @@
 # @summary Type Alias for Nginx::Size
 type Nginx::Size = Variant[
   Integer[0],
-  Pattern[/\A\d+[k|K|m|M]?\z/],
+  Pattern[/\A\d+[kKmMgG]?\z/],
 ]


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds support for **GB** as a unit for Nginx::size (see issue #1656 ). Also, the regex of the Pattern parameter has been fixed to not use _or_ symbol. Corresponding tests have been added to verify the new functionality.

#### This Pull Request (PR) fixes the following issues
Fixes #1656 

