### PR TITLE
Allow `fastcgi_cache_path` to be a Hash

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -765,7 +765,7 @@ Default value: `'500m'`
 
 ##### <a name="-nginx--fastcgi_cache_path"></a>`fastcgi_cache_path`
 
-Data type: `Optional[String]`
+Data type: `Optional[Variant[Hash, String[1]]]`
 
 
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -245,7 +245,13 @@ class nginx::config {
     }
   }
 
-  if $fastcgi_cache_path {
+  if $fastcgi_cache_path =~ Hash {
+    file { $fastcgi_cache_path.keys():
+      ensure => directory,
+      owner  => $daemon_user,
+      mode   => '0700',
+    }
+  } elsif $fastcgi_cache_path =~ String {
     file { $fastcgi_cache_path:
       ensure => directory,
       owner  => $daemon_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -279,7 +279,7 @@ class nginx (
   String $fastcgi_cache_keys_zone                            = 'd3:100m',
   String $fastcgi_cache_levels                               = '1',
   Nginx::Size $fastcgi_cache_max_size                        = '500m',
-  Optional[String] $fastcgi_cache_path                       = undef,
+  Optional[Variant[Hash, String[1]]] $fastcgi_cache_path     = undef,
   Optional[String] $fastcgi_cache_use_stale                  = undef,
   Enum['on', 'off'] $gzip                                    = 'off',
   Optional[String] $gzip_buffers                             = undef,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -746,6 +746,12 @@ describe 'nginx' do
                 match: %r{\s*fastcgi_cache_path\s+/path/to/proxy.cache levels=1 keys_zone=d3:100m max_size=500m inactive=20m;}
               },
               {
+                title: 'should set fastcgi_cache_path from hash',
+                attr: 'fastcgi_cache_path',
+                value: { '/path/to/proxy.cache' => 'd3:100m' },
+                match: %r{\s*fastcgi_cache_path\s+/path/to/proxy.cache levels=1 keys_zone=d3:100m max_size=500m inactive=20m;}
+              },
+              {
                 title: 'should set fastcgi_cache_use_stale',
                 attr: 'fastcgi_cache_use_stale',
                 value: 'invalid_header',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -251,8 +251,12 @@ http {
   <%- if @proxy_cache_loader_sleep %> loader_sleep=<%= @proxy_cache_loader_sleep %><% end -%>
   <%- if @proxy_cache_loader_threshold %> loader_threshold=<%= @proxy_cache_loader_threshold %><% end -%>;
 <% end -%>
-<% if @fastcgi_cache_path -%>
-  fastcgi_cache_path    	<%= @fastcgi_cache_path %> levels=<%= @fastcgi_cache_levels %> keys_zone=<%= @fastcgi_cache_keys_zone %> max_size=<%= @fastcgi_cache_max_size %> inactive=<%= @fastcgi_cache_inactive %>;
+<% if @fastcgi_cache_path.is_a?(Hash) -%>
+<% @fastcgi_cache_path.sort_by{|k,v| k}.each do |key,value| -%>
+  fastcgi_cache_path      <%= key %> levels=<%= @fastcgi_cache_levels %> keys_zone=<%= value %> max_size=<%= @fastcgi_cache_max_size %> inactive=<%= @fastcgi_cache_inactive %>;
+<% end -%>
+<% elsif @fastcgi_cache_path -%>
+  fastcgi_cache_path      <%= @fastcgi_cache_path %> levels=<%= @fastcgi_cache_levels %> keys_zone=<%= @fastcgi_cache_keys_zone %> max_size=<%= @fastcgi_cache_max_size %> inactive=<%= @fastcgi_cache_inactive %>;
 <% end -%>
 <% if @fastcgi_cache_key -%>
   fastcgi_cache_key		    <%= @fastcgi_cache_key %>;


### PR DESCRIPTION
#### Pull Request (PR) description

Allow setting `fastcgi_cache_path` as a hash. similar to `proxy_cache_path`

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-nginx/issues/727

