### PR TITLE
Fix `class_spec` acceptance test

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -30,7 +30,7 @@ describe 'nginx class:' do
       pp = "class { 'nginx': }"
       # Run it twice and test for idempotency
       apply_manifest(pp, catch_failures: true)
-      expect(apply_manifest(pp, catch_failures: true).exit_code).to be_zero
+      apply_manifest(pp, catch_changes: true)
     end
 
     describe package('nginx') do


### PR DESCRIPTION
#### Pull Request (PR) description

Fix the `class_spec` acceptance test to use `catch_changes` instead of checking the exit code being zero (which does not work?). 

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-nginx/issues/1666
