### PR TITLE
Allow hash for `proxy_cache_valid`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2422,7 +2422,7 @@ Default value: `undef`
 
 ##### <a name="-nginx--resource--location--proxy_cache_valid"></a>`proxy_cache_valid`
 
-Data type: `Optional[Variant[Array, String]]`
+Data type: `Optional[Variant[Array, String, Hash[String[1], String[1]]]]`
 
 This directive sets the time for caching different replies.
 
@@ -4056,7 +4056,7 @@ Default value: `undef`
 
 ##### <a name="-nginx--resource--server--proxy_cache_valid"></a>`proxy_cache_valid`
 
-Data type: `Optional[Variant[Array[String], String]]`
+Data type: `Optional[Variant[Array[String], String, Hash[String[1], String[1]]]]`
 
 This directive sets the time for caching different replies.
 

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -306,7 +306,7 @@ define nginx::resource::location (
   Optional[Enum['on', 'off']] $proxy_cache_lock                    = undef,
   Optional[Enum['on', 'off']] $proxy_cache_background_update       = undef,
   Optional[Enum['on', 'off']] $proxy_cache_convert_head            = undef,
-  Optional[Variant[Array, String]] $proxy_cache_valid              = undef,
+  Optional[Variant[Array, String, Hash[String[1], String[1]]]] $proxy_cache_valid = undef,
   Optional[Variant[Array, String]] $proxy_cache_bypass             = undef,
   Optional[String] $proxy_method                                   = undef,
   Optional[String] $proxy_http_version                             = undef,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -343,7 +343,7 @@ define nginx::resource::server (
   Optional[String] $proxy_cache                                                  = undef,
   Optional[String] $proxy_cache_key                                              = undef,
   Optional[String] $proxy_cache_use_stale                                        = undef,
-  Optional[Variant[Array[String], String]] $proxy_cache_valid                    = undef,
+  Optional[Variant[Array[String], String, Hash[String[1], String[1]]]] $proxy_cache_valid = undef,
   Optional[Enum['on', 'off']] $proxy_cache_lock                                  = undef,
   Optional[Enum['on', 'off']] $proxy_cache_background_update                     = undef,
   Optional[Enum['on', 'off']] $proxy_cache_convert_head                          = undef,

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -972,6 +972,16 @@ describe 'nginx::resource::location' do
               ]
             },
             {
+              title: 'should set proxy_cache_valid when hash',
+              attr: 'proxy_cache_valid',
+              value: { '200' => '10m', '301 302' => '1m', '404' => '5s' },
+              match: [
+                %r{^\s+proxy_cache_valid\s+200 10m;},
+                %r{^\s+proxy_cache_valid\s+301 302 1m;},
+                %r{^\s+proxy_cache_valid\s+404 5s;}
+              ]
+            },
+            {
               title: 'should set proxy_cache_key',
               attr: 'proxy_cache_key',
               value: 'value',

--- a/templates/server/locations/proxy.erb
+++ b/templates/server/locations/proxy.erb
@@ -51,9 +51,15 @@
     proxy_cache           <%= @proxy_cache %>;
 <% end -%>
 <% if @proxy_cache_valid -%>
+<% if @proxy_cache_valid.is_a?(Hash) -%>
+    <%- @proxy_cache_valid.sort_by { |k, _v| k }.each do |key, value| -%>
+    proxy_cache_valid     <%= key %> <%= value %>;
+    <%- end -%>
+<% else -%>
     <%- Array(@proxy_cache_valid).each do |line| -%>
     proxy_cache_valid     <%= line %>;
     <%- end -%>
+<% end -%>
 <% end -%>
 <% if @proxy_cache_use_stale -%>
     proxy_cache_use_stale   <%= @proxy_cache_use_stale %>;


### PR DESCRIPTION
#### Pull Request (PR) description

Allow `proxy_cache_valid` to be a hash of response codes mapped to cache time.

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-nginx/issues/726
