### PR TITLE
Make `ipv6_listen_options` default to `listen_options` plus ipv6only

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2803,11 +2803,13 @@ Default value: `$listen_port`
 
 ##### <a name="-nginx--resource--mailhost--ipv6_listen_options"></a>`ipv6_listen_options`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
-Extra options for listen directive like 'default' to catchall.
+Extra options for listen directive like 'default' to catchall. Defaults to
+'ipv6only=on'. If listen_options is set, those options are inherited with
+'ipv6only=on' appended.
 
-Default value: `'default ipv6only=on'`
+Default value: `undef`
 
 ##### <a name="-nginx--resource--mailhost--ssl"></a>`ssl`
 
@@ -3553,11 +3555,13 @@ Default value: `$listen_port`
 
 ##### <a name="-nginx--resource--server--ipv6_listen_options"></a>`ipv6_listen_options`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
-Extra options for listen directive like 'default' to catchall.
+Extra options for listen directive like 'default' to catchall. Defaults to
+'ipv6only=on'. If listen_options is set, those options are inherited with
+'ipv6only=on' appended.
 
-Default value: `'default ipv6only=on'`
+Default value: `undef`
 
 ##### <a name="-nginx--resource--server--add_header"></a>`add_header`
 
@@ -4712,12 +4716,13 @@ Default value: `$listen_port`
 
 ##### <a name="-nginx--resource--streamhost--ipv6_listen_options"></a>`ipv6_listen_options`
 
-Data type: `String`
+Data type: `Optional[String[1]]`
 
-Extra options for listen directive like 'default' to
-catchall.
+Extra options for listen directive like 'default' to catchall. Defaults to
+'ipv6only=on'. If listen_options is set, those options are inherited with
+'ipv6only=on' appended.
 
-Default value: `'default ipv6only=on'`
+Default value: `undef`
 
 ##### <a name="-nginx--resource--streamhost--proxy"></a>`proxy`
 

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -131,25 +131,25 @@ describe 'nginx::resource::server' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: %r{\s+listen\s+\[::\]:80 default ipv6only=on;}
+              match: %r{\s+listen\s+\[::\]:80 ipv6only=on;}
             },
             {
               title: 'should not enable IPv6',
               attr: 'ipv6_enable',
               value: false,
-              notmatch: %r{\slisten \[::\]:80 default ipv6only=on;}
+              notmatch: %r{\slisten \[::\]:80 ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:80 default ipv6only=on;}
+              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:80 ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen port',
               attr: 'ipv6_listen_port',
               value: 45,
-              match: %r{\s+listen\s+\[::\]:45 default ipv6only=on;}
+              match: %r{\s+listen\s+\[::\]:45 ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen options',
@@ -501,6 +501,32 @@ describe 'nginx::resource::server' do
             end
           end
 
+          describe 'ipv6_listen_options inheritance from listen_options' do
+            context 'when listen_options is set but ipv6_listen_options is not' do
+              let(:params) { default_params.merge(listen_options: 'reuseport') }
+
+              it 'inherits listen_options with ipv6only=on appended' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 reuseport ipv6only=on;})
+              end
+            end
+
+            context 'when both listen_options and ipv6_listen_options are set' do
+              let(:params) { default_params.merge(listen_options: 'reuseport', ipv6_listen_options: 'default') }
+
+              it 'uses explicit ipv6_listen_options' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 default;})
+              end
+            end
+
+            context 'when neither listen_options nor ipv6_listen_options is set' do
+              let(:params) { default_params }
+
+              it 'uses ipv6only=on' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 ipv6only=on;})
+              end
+            end
+          end
+
           context 'with a naked domain title over https' do
             let(:title) { 'rspec.example.com' }
 
@@ -799,25 +825,25 @@ describe 'nginx::resource::server' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: %r{\s+listen\s+\[::\]:443 ssl default ipv6only=on;}
+              match: %r{\s+listen\s+\[::\]:443 ssl ipv6only=on;}
             },
             {
               title: 'should disable IPv6',
               attr: 'ipv6_enable',
               value: false,
-              notmatch: %r{  listen \[::\]:443 ssl default ipv6only=on;}
+              notmatch: %r{  listen \[::\]:443 ssl ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:443 ssl default ipv6only=on;}
+              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:443 ssl ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen port',
               attr: 'ssl_port',
               value: 45,
-              match: %r{\s+listen\s+\[::\]:45 ssl default ipv6only=on;}
+              match: %r{\s+listen\s+\[::\]:45 ssl ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen options',

--- a/spec/defines/resource_stream_spec.rb
+++ b/spec/defines/resource_stream_spec.rb
@@ -80,25 +80,25 @@ describe 'nginx::resource::streamhost' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: %r{\s+listen\s+\[::\]:80 default ipv6only=on;}
+              match: %r{\s+listen\s+\[::\]:80 ipv6only=on;}
             },
             {
               title: 'should not enable IPv6',
               attr: 'ipv6_enable',
               value: false,
-              notmatch: %r{\slisten \[::\]:80 default ipv6only=on;}
+              notmatch: %r{\slisten \[::\]:80 ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:80 default ipv6only=on;}
+              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:80 ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen port',
               attr: 'ipv6_listen_port',
               value: 45,
-              match: %r{\s+listen\s+\[::\]:45 default ipv6only=on;}
+              match: %r{\s+listen\s+\[::\]:45 ipv6only=on;}
             },
             {
               title: 'should set the IPv6 listen options',
@@ -150,6 +150,32 @@ describe 'nginx::resource::streamhost' do
                 Array(param[:notmatch]).each do |item|
                   is_expected.to contain_concat__fragment("#{title}-header").without_content(item)
                 end
+              end
+            end
+          end
+
+          describe 'ipv6_listen_options inheritance from listen_options' do
+            context 'when listen_options is set but ipv6_listen_options is not' do
+              let(:params) { default_params.merge(listen_options: 'reuseport') }
+
+              it 'inherits listen_options with ipv6only=on appended' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 reuseport ipv6only=on;})
+              end
+            end
+
+            context 'when both listen_options and ipv6_listen_options are set' do
+              let(:params) { default_params.merge(listen_options: 'reuseport', ipv6_listen_options: 'default') }
+
+              it 'uses explicit ipv6_listen_options' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 default;})
+              end
+            end
+
+            context 'when neither listen_options nor ipv6_listen_options is set' do
+              let(:params) { default_params }
+
+              it 'uses ipv6only=on' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 ipv6only=on;})
               end
             end
           end

--- a/templates/mailhost/mailhost.epp
+++ b/templates/mailhost/mailhost.epp
@@ -1,6 +1,6 @@
 <%- |
   Array[String]             $ipv6_listen_ip,
-  String                    $ipv6_listen_options,
+  Optional[String[1]]       $ipv6_listen_options,
   Stdlib::Port              $ipv6_listen_port,
   Array[String]             $listen_ip,
   Optional[String]          $listen_options,

--- a/templates/mailhost/mailhost_ssl.epp
+++ b/templates/mailhost/mailhost_ssl.epp
@@ -1,6 +1,6 @@
 <%- |
   Array[String]          $ipv6_listen_ip,
-  String                 $ipv6_listen_options,
+  Optional[String[1]]    $ipv6_listen_options,
   Stdlib::Port           $ipv6_listen_port,
   Array[String]          $listen_ip,
   String                 $mailhost_append,

--- a/templates/server/server_ipv6_listen.erb
+++ b/templates/server/server_ipv6_listen.erb
@@ -2,9 +2,9 @@
   <%- if @ipv6_enable -%>
     <%- if @ipv6_listen_ip.is_a?(Array) then -%>
       <%- @ipv6_listen_ip.each do |ipv6| -%>
-  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @_ipv6_listen_options %><%= @_ipv6_listen_options %><% end %>;
       <%- end -%>
     <%- else -%>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @_ipv6_listen_options %><%= @_ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- end -%>

--- a/templates/server/server_ssl_ipv6_listen.erb
+++ b/templates/server/server_ssl_ipv6_listen.erb
@@ -2,9 +2,9 @@
   <%- if @ipv6_enable -%>
     <%- if @ipv6_listen_ip.is_a?(Array) then -%>
       <%- @ipv6_listen_ip.each do |ipv6| -%>
-  listen [<%= ipv6 %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+  listen [<%= ipv6 %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @_ipv6_listen_options %> <%= @_ipv6_listen_options %><% end %>;
       <%- end -%>
     <%- else -%>
-  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
+  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @_ipv6_listen_options %> <%= @_ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- end -%>

--- a/templates/streamhost/streamhost.erb
+++ b/templates/streamhost/streamhost.erb
@@ -12,10 +12,10 @@ server {
 <%- if @ipv6_enable && (defined? @facts.fetch('networking', {})['ip6']) -%>
   <%- if @ipv6_listen_ip.is_a?(Array) then -%>
     <%- @ipv6_listen_ip.each do |ipv6| -%>
-  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @_ipv6_listen_options %><%= @_ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- else -%>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @ipv6_listen_options %><%= @ipv6_listen_options %><% end %>;
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @_ipv6_listen_options %><%= @_ipv6_listen_options %><% end %>;
   <%- end -%>
 <%- end -%>
 <%- unless @resolver.empty? -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Make `ipv6_listen_options` default to `listen_options` if set (plus `ipv6only=on`), or `ipv6only=on` otherwise, for these

* mailhost
* server
* streamhost

This is a breaking change since it changes the default for `ipv6_listen_options` 

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-nginx/issues/874
