### PR TITLE
Add `real_ip` module support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -192,6 +192,9 @@ The following parameters are available in the `nginx` class:
 * [`proxy_ignore_header`](#-nginx--proxy_ignore_header)
 * [`proxy_max_temp_file_size`](#-nginx--proxy_max_temp_file_size)
 * [`proxy_busy_buffers_size`](#-nginx--proxy_busy_buffers_size)
+* [`real_ip_header`](#-nginx--real_ip_header)
+* [`real_ip_recursive`](#-nginx--real_ip_recursive)
+* [`set_real_ip_from`](#-nginx--set_real_ip_from)
 * [`sendfile`](#-nginx--sendfile)
 * [`server_tokens`](#-nginx--server_tokens)
 * [`spdy`](#-nginx--spdy)
@@ -1214,6 +1217,36 @@ Data type: `Optional[Nginx::Size]`
 
 Default value: `undef`
 
+##### <a name="-nginx--real_ip_header"></a>`real_ip_header`
+
+Data type: `Optional[String[1]]`
+
+Defines the request header field whose value will be used to replace the
+client address. See http://nginx.org/en/docs/http/ngx_http_realip_module.html
+
+Default value: `undef`
+
+##### <a name="-nginx--real_ip_recursive"></a>`real_ip_recursive`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+If disabled, the original client address that matches one of the trusted
+addresses is replaced by the last address sent in the request header field.
+If enabled, the original client address that matches one of the trusted
+addresses is replaced by the last non-trusted address sent in the request
+header field.
+
+Default value: `undef`
+
+##### <a name="-nginx--set_real_ip_from"></a>`set_real_ip_from`
+
+Data type: `Optional[Variant[String[1], Array[String[1]]]]`
+
+Defines trusted addresses that are known to send correct replacement
+addresses.
+
+Default value: `undef`
+
 ##### <a name="-nginx--sendfile"></a>`sendfile`
 
 Data type: `Enum['on', 'off']`
@@ -1987,6 +2020,9 @@ The following parameters are available in the `nginx::resource::location` define
 * [`add_header`](#-nginx--resource--location--add_header)
 * [`gzip_static`](#-nginx--resource--location--gzip_static)
 * [`reset_timedout_connection`](#-nginx--resource--location--reset_timedout_connection)
+* [`real_ip_header`](#-nginx--resource--location--real_ip_header)
+* [`real_ip_recursive`](#-nginx--resource--location--real_ip_recursive)
+* [`set_real_ip_from`](#-nginx--resource--location--set_real_ip_from)
 * [`format_log`](#-nginx--resource--location--format_log)
 * [`access_log`](#-nginx--resource--location--access_log)
 * [`error_log`](#-nginx--resource--location--error_log)
@@ -2611,6 +2647,36 @@ Data type: `Optional[Enum['on', 'off']]`
 
 Enables or disables resetting timed out connections and connections closed
 with the non-standard code 444.
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--location--real_ip_header"></a>`real_ip_header`
+
+Data type: `Optional[String[1]]`
+
+Defines the request header field whose value will be used to replace the
+client address. See http://nginx.org/en/docs/http/ngx_http_realip_module.html
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--location--real_ip_recursive"></a>`real_ip_recursive`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+If disabled, the original client address that matches one of the trusted
+addresses is replaced by the last address sent in the request header field.
+If enabled, the original client address that matches one of the trusted
+addresses is replaced by the last non-trusted address sent in the request
+header field.
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--location--set_real_ip_from"></a>`set_real_ip_from`
+
+Data type: `Optional[Variant[String[1], Array[String[1]]]]`
+
+Defines trusted addresses that are known to send correct replacement
+addresses.
 
 Default value: `undef`
 
@@ -3331,6 +3397,9 @@ The following parameters are available in the `nginx::resource::server` defined 
 * [`autoindex_format`](#-nginx--resource--server--autoindex_format)
 * [`autoindex_localtime`](#-nginx--resource--server--autoindex_localtime)
 * [`reset_timedout_connection`](#-nginx--resource--server--reset_timedout_connection)
+* [`real_ip_header`](#-nginx--resource--server--real_ip_header)
+* [`real_ip_recursive`](#-nginx--resource--server--real_ip_recursive)
+* [`set_real_ip_from`](#-nginx--resource--server--set_real_ip_from)
 * [`proxy`](#-nginx--resource--server--proxy)
 * [`proxy_read_timeout`](#-nginx--resource--server--proxy_read_timeout)
 * [`proxy_send_timeout`](#-nginx--resource--server--proxy_send_timeout)
@@ -3624,6 +3693,36 @@ Data type: `Optional[Enum['on', 'off']]`
 
 Enables or disables resetting timed out connections and connections closed
 with the non-standard code 444.
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--server--real_ip_header"></a>`real_ip_header`
+
+Data type: `Optional[String[1]]`
+
+Defines the request header field whose value will be used to replace the
+client address. See http://nginx.org/en/docs/http/ngx_http_realip_module.html
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--server--real_ip_recursive"></a>`real_ip_recursive`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+If disabled, the original client address that matches one of the trusted
+addresses is replaced by the last address sent in the request header field.
+If enabled, the original client address that matches one of the trusted
+addresses is replaced by the last non-trusted address sent in the request
+header field.
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--server--set_real_ip_from"></a>`set_real_ip_from`
+
+Data type: `Optional[Variant[String[1], Array[String[1]]]]`
+
+Defines trusted addresses that are known to send correct replacement
+addresses.
 
 Default value: `undef`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -111,6 +111,9 @@ class nginx::config {
   $proxy_set_header               = $nginx::proxy_set_header
   $proxy_hide_header              = $nginx::proxy_hide_header
   $proxy_pass_header              = $nginx::proxy_pass_header
+  $real_ip_header                 = $nginx::real_ip_header
+  $real_ip_recursive              = $nginx::real_ip_recursive
+  $set_real_ip_from               = $nginx::set_real_ip_from
   $sendfile                       = $nginx::sendfile
   $server_tokens                  = $nginx::server_tokens
   $spdy                           = $nginx::spdy

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -156,6 +156,18 @@
 # @param proxy_ignore_header
 # @param proxy_max_temp_file_size
 # @param proxy_busy_buffers_size
+# @param real_ip_header
+#   Defines the request header field whose value will be used to replace the
+#   client address. See http://nginx.org/en/docs/http/ngx_http_realip_module.html
+# @param real_ip_recursive
+#   If disabled, the original client address that matches one of the trusted
+#   addresses is replaced by the last address sent in the request header field.
+#   If enabled, the original client address that matches one of the trusted
+#   addresses is replaced by the last non-trusted address sent in the request
+#   header field.
+# @param set_real_ip_from
+#   Defines trusted addresses that are known to send correct replacement
+#   addresses.
 # @param sendfile
 # @param server_tokens
 # @param spdy
@@ -341,6 +353,9 @@ class nginx (
   Array $proxy_ignore_header                                 = [],
   Optional[Nginx::Size] $proxy_max_temp_file_size            = undef,
   Optional[Nginx::Size] $proxy_busy_buffers_size             = undef,
+  Optional[String[1]] $real_ip_header                        = undef,
+  Optional[Enum['on', 'off']] $real_ip_recursive             = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $set_real_ip_from = undef,
   Enum['on', 'off'] $sendfile                                = 'on',
   Enum['on', 'off'] $server_tokens                           = 'on',
   Enum['on', 'off'] $spdy                                    = 'off',

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -180,6 +180,18 @@
 # @param reset_timedout_connection
 #   Enables or disables resetting timed out connections and connections closed
 #   with the non-standard code 444.
+# @param real_ip_header
+#   Defines the request header field whose value will be used to replace the
+#   client address. See http://nginx.org/en/docs/http/ngx_http_realip_module.html
+# @param real_ip_recursive
+#   If disabled, the original client address that matches one of the trusted
+#   addresses is replaced by the last address sent in the request header field.
+#   If enabled, the original client address that matches one of the trusted
+#   addresses is replaced by the last non-trusted address sent in the request
+#   header field.
+# @param set_real_ip_from
+#   Defines trusted addresses that are known to send correct replacement
+#   addresses.
 # @param format_log
 #   Log_format to use with the defined access_log
 # @param access_log
@@ -327,6 +339,9 @@ define nginx::resource::location (
   Hash $add_header                                                 = {},
   Optional[Enum['on', 'off', 'always']] $gzip_static               = undef,
   Optional[Enum['on', 'off']] $reset_timedout_connection           = undef,
+  Optional[String[1]] $real_ip_header                              = undef,
+  Optional[Enum['on', 'off']] $real_ip_recursive                   = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $set_real_ip_from = undef,
   Optional[Variant[Array[String[1], 1], String[1]]] $access_log    = undef,
   Optional[Variant[Array[String[1], 1], String[1]]] $error_log     = undef,
   Optional[String[1]] $format_log                                  = $nginx::http_format_log,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -49,6 +49,18 @@
 # @param reset_timedout_connection
 #   Enables or disables resetting timed out connections and connections closed
 #   with the non-standard code 444.
+# @param real_ip_header
+#   Defines the request header field whose value will be used to replace the
+#   client address. See http://nginx.org/en/docs/http/ngx_http_realip_module.html
+# @param real_ip_recursive
+#   If disabled, the original client address that matches one of the trusted
+#   addresses is replaced by the last address sent in the request header field.
+#   If enabled, the original client address that matches one of the trusted
+#   addresses is replaced by the last non-trusted address sent in the request
+#   header field.
+# @param set_real_ip_from
+#   Defines trusted addresses that are known to send correct replacement
+#   addresses.
 # @param proxy
 #   Proxy server(s) for the root location to connect to. Accepts a single
 #   value, can be used in conjunction with nginx::resource::upstream
@@ -375,6 +387,9 @@ define nginx::resource::server (
   Optional[Enum['html', 'xml', 'json', 'jsonp']] $autoindex_format               = undef,
   Optional[Enum['on', 'off']] $autoindex_localtime                               = undef,
   Optional[Enum['on', 'off']] $reset_timedout_connection                         = undef,
+  Optional[String[1]] $real_ip_header                                            = undef,
+  Optional[Enum['on', 'off']] $real_ip_recursive                                 = undef,
+  Optional[Variant[String[1], Array[String[1]]]] $set_real_ip_from               = undef,
   Array[String] $server_name                                                     = [$name],
   Optional[String] $www_root                                                     = undef,
   Boolean $rewrite_www_to_non_www                                                = false,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -972,6 +972,51 @@ describe 'nginx' do
                 match: '  proxy_busy_buffers_size 16k;'
               },
               {
+                title: 'should not set set_real_ip_from',
+                attr: 'set_real_ip_from',
+                value: :undef,
+                notmatch: 'set_real_ip_from'
+              },
+              {
+                title: 'should set set_real_ip_from with single value',
+                attr: 'set_real_ip_from',
+                value: '192.168.1.0/24',
+                match: '  set_real_ip_from        192.168.1.0/24;'
+              },
+              {
+                title: 'should set set_real_ip_from with multiple values',
+                attr: 'set_real_ip_from',
+                value: ['192.168.1.0/24', '10.0.0.0/8'],
+                match: [
+                  '  set_real_ip_from        192.168.1.0/24;',
+                  '  set_real_ip_from        10.0.0.0/8;'
+                ]
+              },
+              {
+                title: 'should not set real_ip_header',
+                attr: 'real_ip_header',
+                value: :undef,
+                notmatch: 'real_ip_header'
+              },
+              {
+                title: 'should set real_ip_header',
+                attr: 'real_ip_header',
+                value: 'X-Forwarded-For',
+                match: '  real_ip_header          X-Forwarded-For;'
+              },
+              {
+                title: 'should not set real_ip_recursive',
+                attr: 'real_ip_recursive',
+                value: :undef,
+                notmatch: 'real_ip_recursive'
+              },
+              {
+                title: 'should set real_ip_recursive',
+                attr: 'real_ip_recursive',
+                value: 'on',
+                match: '  real_ip_recursive       on;'
+              },
+              {
                 title: 'should set ssl_stapling_verify',
                 attr: 'ssl_stapling_verify',
                 value: 'on',

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -250,6 +250,51 @@ describe 'nginx::resource::location' do
               match: %r{^\s+reset_timedout_connection\s+on;}
             },
             {
+              title: 'should not set set_real_ip_from',
+              attr: 'set_real_ip_from',
+              value: :undef,
+              notmatch: %r{set_real_ip_from}
+            },
+            {
+              title: 'should set set_real_ip_from with single value',
+              attr: 'set_real_ip_from',
+              value: '192.168.1.0/24',
+              match: %r{^\s+set_real_ip_from\s+192\.168\.1\.0/24;}
+            },
+            {
+              title: 'should set set_real_ip_from with multiple values',
+              attr: 'set_real_ip_from',
+              value: ['192.168.1.0/24', '10.0.0.0/8'],
+              match: [
+                %r{^\s+set_real_ip_from\s+192\.168\.1\.0/24;},
+                %r{^\s+set_real_ip_from\s+10\.0\.0\.0/8;}
+              ]
+            },
+            {
+              title: 'should not set real_ip_header',
+              attr: 'real_ip_header',
+              value: :undef,
+              notmatch: %r{real_ip_header}
+            },
+            {
+              title: 'should set real_ip_header',
+              attr: 'real_ip_header',
+              value: 'X-Forwarded-For',
+              match: %r{^\s+real_ip_header\s+X-Forwarded-For;}
+            },
+            {
+              title: 'should not set real_ip_recursive',
+              attr: 'real_ip_recursive',
+              value: :undef,
+              notmatch: %r{real_ip_recursive}
+            },
+            {
+              title: 'should set real_ip_recursive',
+              attr: 'real_ip_recursive',
+              value: 'on',
+              match: %r{^\s+real_ip_recursive\s+on;}
+            },
+            {
               title: 'access_log undef',
               attr: 'access_log',
               value: :undef,

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -411,6 +411,51 @@ describe 'nginx::resource::server' do
               attr: 'reset_timedout_connection',
               value: 'on',
               match: %r{^\s+reset_timedout_connection\s+on;}
+            },
+            {
+              title: 'should not set set_real_ip_from',
+              attr: 'set_real_ip_from',
+              value: :undef,
+              notmatch: %r{set_real_ip_from}
+            },
+            {
+              title: 'should set set_real_ip_from with single value',
+              attr: 'set_real_ip_from',
+              value: '192.168.1.0/24',
+              match: %r{^\s+set_real_ip_from\s+192\.168\.1\.0/24;}
+            },
+            {
+              title: 'should set set_real_ip_from with multiple values',
+              attr: 'set_real_ip_from',
+              value: ['192.168.1.0/24', '10.0.0.0/8'],
+              match: [
+                %r{^\s+set_real_ip_from\s+192\.168\.1\.0/24;},
+                %r{^\s+set_real_ip_from\s+10\.0\.0\.0/8;}
+              ]
+            },
+            {
+              title: 'should not set real_ip_header',
+              attr: 'real_ip_header',
+              value: :undef,
+              notmatch: %r{real_ip_header}
+            },
+            {
+              title: 'should set real_ip_header',
+              attr: 'real_ip_header',
+              value: 'X-Forwarded-For',
+              match: %r{^\s+real_ip_header\s+X-Forwarded-For;}
+            },
+            {
+              title: 'should not set real_ip_recursive',
+              attr: 'real_ip_recursive',
+              value: :undef,
+              notmatch: %r{real_ip_recursive}
+            },
+            {
+              title: 'should set real_ip_recursive',
+              attr: 'real_ip_recursive',
+              value: 'on',
+              match: %r{^\s+real_ip_recursive\s+on;}
             }
           ].each do |param|
             context "when #{param[:attr]} is #{param[:value]}" do

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -261,6 +261,18 @@ http {
   fastcgi_cache_use_stale <%= @fastcgi_cache_use_stale %>;
 <% end -%>
 
+<% if @set_real_ip_from -%>
+  <%- Array(@set_real_ip_from).each do |addr| -%>
+  set_real_ip_from        <%= addr %>;
+  <%- end -%>
+<% end -%>
+<% if @real_ip_header -%>
+  real_ip_header          <%= @real_ip_header %>;
+<% end -%>
+<% if @real_ip_recursive -%>
+  real_ip_recursive       <%= @real_ip_recursive %>;
+<% end -%>
+
 <% if @ssl_dhparam -%>
   ssl_dhparam               <%= @ssl_dhparam %>;
 <% end -%>

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -85,6 +85,17 @@
 <% if @reset_timedout_connection -%>
   reset_timedout_connection <%= @reset_timedout_connection %>;
 <% end -%>
+<% if @set_real_ip_from -%>
+  <%- Array(@set_real_ip_from).each do |addr| -%>
+    set_real_ip_from      <%= addr %>;
+  <%- end -%>
+<% end -%>
+<% if @real_ip_header -%>
+    real_ip_header        <%= @real_ip_header %>;
+<% end -%>
+<% if @real_ip_recursive -%>
+    real_ip_recursive     <%= @real_ip_recursive %>;
+<% end -%>
 <% if @log_not_found -%>
     log_not_found <%= @log_not_found %>;
 <% end -%>

--- a/templates/server/server_header.erb
+++ b/templates/server/server_header.erb
@@ -177,6 +177,17 @@ server {
 <% if @reset_timedout_connection -%>
   reset_timedout_connection <%= @reset_timedout_connection %>;
 <% end -%>
+<% if @set_real_ip_from -%>
+  <%- Array(@set_real_ip_from).each do |addr| -%>
+  set_real_ip_from      <%= addr %>;
+  <%- end -%>
+<% end -%>
+<% if @real_ip_header -%>
+  real_ip_header        <%= @real_ip_header %>;
+<% end -%>
+<% if @real_ip_recursive -%>
+  real_ip_recursive     <%= @real_ip_recursive %>;
+<% end -%>
 <% if defined? @log_by_lua -%>
   log_by_lua '<%= @log_by_lua %>';
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Add support for using the `real_ip` module for global, per-server, and per-location via these params:

* `real_ip_header`
* `real_ip_recursive`
* `set_real_ip_from`

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-nginx/issues/796
