### PR TITLE
Add missing `location` params

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1980,6 +1980,10 @@ The following parameters are available in the `nginx::resource::location` define
 * [`auth_basic`](#-nginx--resource--location--auth_basic)
 * [`auth_basic_user_file`](#-nginx--resource--location--auth_basic_user_file)
 * [`auth_request`](#-nginx--resource--location--auth_request)
+* [`client_max_body_size`](#-nginx--resource--location--client_max_body_size)
+* [`client_body_timeout`](#-nginx--resource--location--client_body_timeout)
+* [`client_body_buffer_size`](#-nginx--resource--location--client_body_buffer_size)
+* [`send_timeout`](#-nginx--resource--location--send_timeout)
 * [`priority`](#-nginx--resource--location--priority)
 * [`mp4`](#-nginx--resource--location--mp4)
 * [`flv`](#-nginx--resource--location--flv)
@@ -2549,6 +2553,38 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 This allows you to specify a custom auth endpoint
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--location--client_max_body_size"></a>`client_max_body_size`
+
+Data type: `Optional[Nginx::Size]`
+
+Sets the maximum allowed size of the client request body.
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--location--client_body_timeout"></a>`client_body_timeout`
+
+Data type: `Optional[Nginx::Time]`
+
+Defines a timeout for reading client request body.
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--location--client_body_buffer_size"></a>`client_body_buffer_size`
+
+Data type: `Optional[Nginx::Size]`
+
+Sets buffer size for reading client request body.
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--location--send_timeout"></a>`send_timeout`
+
+Data type: `Optional[Nginx::Time]`
+
+Sets a timeout for transmitting a response to the client.
 
 Default value: `undef`
 

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -160,6 +160,14 @@
 #   This directive sets the htpasswd filename for the authentication realm.
 # @param auth_request
 #   This allows you to specify a custom auth endpoint
+# @param client_max_body_size
+#   Sets the maximum allowed size of the client request body.
+# @param client_body_timeout
+#   Defines a timeout for reading client request body.
+# @param client_body_buffer_size
+#   Sets buffer size for reading client request body.
+# @param send_timeout
+#   Sets a timeout for transmitting a response to the client.
 # @param priority
 #   Location priority. User priority 401-499, 501-599. If the priority is
 #   higher than the default priority (500), the location will be defined after
@@ -319,6 +327,10 @@ define nginx::resource::location (
   Optional[String] $auth_basic                                     = undef,
   Optional[String] $auth_basic_user_file                           = undef,
   Optional[String] $auth_request                                   = undef,
+  Optional[Nginx::Size] $client_max_body_size                      = undef,
+  Optional[Nginx::Time] $client_body_timeout                       = undef,
+  Optional[Nginx::Size] $client_body_buffer_size                   = undef,
+  Optional[Nginx::Time] $send_timeout                              = undef,
   Array $rewrite_rules                                             = [],
   Integer[401, 599] $priority                                      = 500,
   Boolean $mp4                                                     = false,

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -244,6 +244,78 @@ describe 'nginx::resource::location' do
               match: %r{\s+auth_request\s+value;}
             },
             {
+              title: 'should not set client_max_body_size by default',
+              attr: 'client_max_body_size',
+              value: :undef,
+              notmatch: %r{client_max_body_size}
+            },
+            {
+              title: 'should set client_max_body_size',
+              attr: 'client_max_body_size',
+              value: '100m',
+              match: %r{\s+client_max_body_size\s+100m;}
+            },
+            {
+              title: 'should set client_max_body_size with bytes',
+              attr: 'client_max_body_size',
+              value: '1048576',
+              match: %r{\s+client_max_body_size\s+1048576;}
+            },
+            {
+              title: 'should not set client_body_timeout by default',
+              attr: 'client_body_timeout',
+              value: :undef,
+              notmatch: %r{client_body_timeout}
+            },
+            {
+              title: 'should set client_body_timeout',
+              attr: 'client_body_timeout',
+              value: '120s',
+              match: %r{\s+client_body_timeout\s+120s;}
+            },
+            {
+              title: 'should set client_body_timeout with minutes',
+              attr: 'client_body_timeout',
+              value: '2m',
+              match: %r{\s+client_body_timeout\s+2m;}
+            },
+            {
+              title: 'should not set client_body_buffer_size by default',
+              attr: 'client_body_buffer_size',
+              value: :undef,
+              notmatch: %r{client_body_buffer_size}
+            },
+            {
+              title: 'should set client_body_buffer_size',
+              attr: 'client_body_buffer_size',
+              value: '256k',
+              match: %r{\s+client_body_buffer_size\s+256k;}
+            },
+            {
+              title: 'should set client_body_buffer_size with megabytes',
+              attr: 'client_body_buffer_size',
+              value: '1m',
+              match: %r{\s+client_body_buffer_size\s+1m;}
+            },
+            {
+              title: 'should not set send_timeout by default',
+              attr: 'send_timeout',
+              value: :undef,
+              notmatch: %r{\bsend_timeout\b}
+            },
+            {
+              title: 'should set send_timeout',
+              attr: 'send_timeout',
+              value: '90s',
+              match: %r{\s+send_timeout\s+90s;}
+            },
+            {
+              title: 'should set send_timeout with minutes',
+              attr: 'send_timeout',
+              value: '5m',
+              match: %r{\s+send_timeout\s+5m;}
+            },
+            {
               title: 'should set reset_timedout_connection',
               attr: 'reset_timedout_connection',
               value: 'on',

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -37,6 +37,18 @@
 <%- if defined? @auth_request -%>
   auth_request <%= @auth_request %>;
   <%- end -%>
+<% if @client_max_body_size -%>
+    client_max_body_size <%= @client_max_body_size %>;
+<% end -%>
+<% if @client_body_timeout -%>
+    client_body_timeout <%= @client_body_timeout %>;
+<% end -%>
+<% if @client_body_buffer_size -%>
+    client_body_buffer_size <%= @client_body_buffer_size %>;
+<% end -%>
+<% if @send_timeout -%>
+    send_timeout <%= @send_timeout %>;
+<% end -%>
 <% if @location_custom_cfg_prepend -%>
   <%- @location_custom_cfg_prepend.each do |key,value| -%>
     <%- if value.is_a?(Hash) -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Add a few missing `location` params

* `client_max_body_size`
* `client_body_timeout`
* `client_body_buffer_size`
* `send_timeout`

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-nginx/issues/1206

