### PR TITLE
Allow arrays for `location_custom_cfg_prepend` and `append`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2351,21 +2351,23 @@ Default value: `undef`
 
 ##### <a name="-nginx--resource--location--location_custom_cfg_prepend"></a>`location_custom_cfg_prepend`
 
-Data type: `Optional[Hash]`
+Data type: `Optional[Variant[Hash, Array]]`
 
-Expects a array with extra directives to put before anything else inside
-location (used with all other types except custom_cfg). Used for logical
-structures such as if.
+Expects a hash or array with extra directives to put before anything else
+inside location (used with all other types except custom_cfg). Used for
+directives that should not have a semicolon appended. When an array is
+provided, each element is output as a raw line.
 
 Default value: `undef`
 
 ##### <a name="-nginx--resource--location--location_custom_cfg_append"></a>`location_custom_cfg_append`
 
-Data type: `Optional[Hash]`
+Data type: `Optional[Variant[Hash, Array]]`
 
-Expects a array with extra directives to put after anything else inside
-location (used with all other types except custom_cfg). Used for logical
-structures such as if.
+Expects a hash or array with extra directives to put after anything else
+inside location (used with all other types except custom_cfg). Used for
+directives that should not have a semicolon appended. When an array is
+provided, each element is output as a raw line.
 
 Default value: `undef`
 

--- a/manifests/resource/location.pp
+++ b/manifests/resource/location.pp
@@ -102,13 +102,15 @@
 #   Expects a hash with extra directives to put before anything else inside
 #   location (used with all other types except custom_cfg)
 # @param location_custom_cfg_prepend
-#   Expects a array with extra directives to put before anything else inside
-#   location (used with all other types except custom_cfg). Used for logical
-#   structures such as if.
+#   Expects a hash or array with extra directives to put before anything else
+#   inside location (used with all other types except custom_cfg). Used for
+#   directives that should not have a semicolon appended. When an array is
+#   provided, each element is output as a raw line.
 # @param location_custom_cfg_append
-#   Expects a array with extra directives to put after anything else inside
-#   location (used with all other types except custom_cfg). Used for logical
-#   structures such as if.
+#   Expects a hash or array with extra directives to put after anything else
+#   inside location (used with all other types except custom_cfg). Used for
+#   directives that should not have a semicolon appended. When an array is
+#   provided, each element is output as a raw line.
 # @param location_cfg_append
 #   Expects a hash with extra directives to put
 #   after everything else inside location (used with all other types except
@@ -296,8 +298,8 @@ define nginx::resource::location (
   Optional[Hash] $location_custom_cfg                              = undef,
   Optional[Hash] $location_cfg_prepend                             = undef,
   Optional[Hash] $location_cfg_append                              = undef,
-  Optional[Hash] $location_custom_cfg_prepend                      = undef,
-  Optional[Hash] $location_custom_cfg_append                       = undef,
+  Optional[Variant[Hash, Array]] $location_custom_cfg_prepend      = undef,
+  Optional[Variant[Hash, Array]] $location_custom_cfg_append       = undef,
   Optional[Array] $include                                         = undef,
   Optional[Array] $try_files                                       = undef,
   Optional[String] $proxy_cache                                    = undef,

--- a/spec/defines/resource_location_spec.rb
+++ b/spec/defines/resource_location_spec.rb
@@ -184,6 +184,16 @@ describe 'nginx::resource::location' do
               ]
             },
             {
+              title: 'should contain custom prepended directives as array',
+              attr: 'location_custom_cfg_prepend',
+              value: [
+                'if ($request_method != POST) { return 405; }'
+              ],
+              match: [
+                %r{^ +if \(\$request_method != POST\) \{ return 405; \}}
+              ]
+            },
+            {
               title: 'should contain raw_prepend directives',
               attr: 'raw_prepend',
               value: [
@@ -377,6 +387,16 @@ describe 'nginx::resource::location' do
                 %r{^ +test3\s+subtest1 "sub test value1a"},
                 %r{^ +test3\s+subtest1 "sub test value1b"},
                 %r{^ +test3\s+subtest2 "sub test value2"}
+              ]
+            },
+            {
+              title: 'should contain custom appended directives as array',
+              attr: 'location_custom_cfg_append',
+              value: [
+                'if ($request_method != POST) { return 405; }'
+              ],
+              match: [
+                %r{^ +if \(\$request_method != POST\) \{ return 405; \}}
               ]
             },
             {

--- a/templates/server/location_footer.erb
+++ b/templates/server/location_footer.erb
@@ -14,16 +14,22 @@
   <%- end -%>
 <% end -%>
 <% if @location_custom_cfg_append -%>
-  <%- @location_custom_cfg_append.each do |key,value| -%>
-    <%- if value.is_a?(Hash) -%>
-      <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>
-        <%- Array(subvalue).each do |asubvalue| -%>
+  <%- if @location_custom_cfg_append.is_a?(Array) -%>
+    <%- @location_custom_cfg_append.each do |line| -%>
+    <%= line %>
+    <%- end -%>
+  <%- else -%>
+    <%- @location_custom_cfg_append.each do |key,value| -%>
+      <%- if value.is_a?(Hash) -%>
+        <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>
+          <%- Array(subvalue).each do |asubvalue| -%>
     <%= key %> <%= subkey %> <%= asubvalue %>
+          <%- end -%>
         <%- end -%>
-      <%- end -%>
-    <%- else -%>
-      <%- Array(value).each do |asubvalue| -%>
+      <%- else -%>
+        <%- Array(value).each do |asubvalue| -%>
     <%= key %> <%= asubvalue %>
+        <%- end -%>
       <%- end -%>
     <%- end -%>
   <%- end -%>

--- a/templates/server/location_header.erb
+++ b/templates/server/location_header.erb
@@ -38,16 +38,22 @@
   auth_request <%= @auth_request %>;
   <%- end -%>
 <% if @location_custom_cfg_prepend -%>
-  <%- @location_custom_cfg_prepend.each do |key,value| -%>
-    <%- if value.is_a?(Hash) -%>
-      <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>
-        <%- Array(subvalue).each do |asubvalue| -%>
+  <%- if @location_custom_cfg_prepend.is_a?(Array) -%>
+    <%- @location_custom_cfg_prepend.each do |line| -%>
+    <%= line %>
+    <%- end -%>
+  <%- else -%>
+    <%- @location_custom_cfg_prepend.each do |key,value| -%>
+      <%- if value.is_a?(Hash) -%>
+        <%- value.sort_by {|k,v| k}.each do |subkey,subvalue| -%>
+          <%- Array(subvalue).each do |asubvalue| -%>
     <%= key %> <%= subkey %> <%= asubvalue %>
+          <%- end -%>
         <%- end -%>
-      <%- end -%>
-    <%- else -%>
-      <%- Array(value).each do |asubvalue| -%>
+      <%- else -%>
+        <%- Array(value).each do |asubvalue| -%>
     <%= key %> <%= asubvalue %>
+        <%- end -%>
       <%- end -%>
     <%- end -%>
   <%- end -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Allow arrays for `location_custom_cfg_prepend` and `location_custom_cfg_append`

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-nginx/issues/1218

