### PR TITLE
Allow arrays for `http_cfg_append` and `prepend`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -864,17 +864,21 @@ Default value: `undef`
 
 ##### <a name="-nginx--http_cfg_prepend"></a>`http_cfg_prepend`
 
-Data type: `Optional[Variant[Hash, Array]]`
+Data type: `Optional[Variant[Hash[String, Variant[String, Array[String]]], Array[Variant[String, Tuple[String, String]]]]]`
 
-
+Adds custom directives to the beginning of the http block. Supports:
+- Hash: `{ 'key' => 'value' }` (sorted by key)
+- Hash with arrays: `{ 'key' => ['val1', 'val2'] }` (multiple values per key)
+- Array of pairs: `[['key', 'val1'], ['key', 'val2']]` (preserves order, allows duplicates)
+- Array of strings: `['directive value']` (semicolons added automatically)
 
 Default value: `undef`
 
 ##### <a name="-nginx--http_cfg_append"></a>`http_cfg_append`
 
-Data type: `Optional[Variant[Hash, Array]]`
+Data type: `Optional[Variant[Hash[String, Variant[String, Array[String]]], Array[Variant[String, Tuple[String, String]]]]]`
 
-
+Adds custom directives to the end of the http block. Supports same formats as http_cfg_prepend.
 
 Default value: `undef`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,7 +114,13 @@
 # @param gzip_vary
 # @param gzip_static
 # @param http_cfg_prepend
+#   Adds custom directives to the beginning of the http block. Supports:
+#   - Hash: `{ 'key' => 'value' }` (sorted by key)
+#   - Hash with arrays: `{ 'key' => ['val1', 'val2'] }` (multiple values per key)
+#   - Array of pairs: `[['key', 'val1'], ['key', 'val2']]` (preserves order, allows duplicates)
+#   - Array of strings: `['directive value']` (semicolons added automatically)
 # @param http_cfg_append
+#   Adds custom directives to the end of the http block. Supports same formats as http_cfg_prepend.
 # @param http_raw_prepend
 # @param http_raw_append
 # @param http_tcp_nodelay
@@ -303,8 +309,8 @@ class nginx (
   Optional[Variant[String[1],Array[String[1]]]] $gzip_types  = undef,
   Enum['on', 'off'] $gzip_vary                               = 'off',
   Optional[Enum['on', 'off', 'always']] $gzip_static         = undef,
-  Optional[Variant[Hash, Array]] $http_cfg_prepend           = undef,
-  Optional[Variant[Hash, Array]] $http_cfg_append            = undef,
+  Optional[Variant[Hash[String, Variant[String, Array[String]]], Array[Variant[String, Tuple[String, String]]]]] $http_cfg_prepend = undef,
+  Optional[Variant[Hash[String, Variant[String, Array[String]]], Array[Variant[String, Tuple[String, String]]]]] $http_cfg_append = undef,
   Optional[Variant[Array[String], String]] $http_raw_prepend = undef,
   Optional[Variant[Array[String], String]] $http_raw_append  = undef,
   Enum['on', 'off'] $http_tcp_nodelay                        = 'on',

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -796,6 +796,28 @@ describe 'nginx' do
                 ]
               },
               {
+                title: 'should preserve order of directives from array of pairs',
+                attr: 'http_cfg_prepend',
+                value: [['allow', 'value 3'], ['allow', 'value 1'], ['allow', 'value 2']],
+                match: %r{allow\s+value 3;.*allow\s+value 1;.*allow\s+value 2;}m
+              },
+              {
+                title: 'should contain directives from array of strings',
+                attr: 'http_cfg_prepend',
+                value: ['allow 192.168.1.0/24', 'allow 10.0.0.0/8', 'deny all'],
+                match: [
+                  '  allow 192.168.1.0/24;',
+                  '  allow 10.0.0.0/8;',
+                  '  deny all;'
+                ]
+              },
+              {
+                title: 'should preserve order of directives from array of strings',
+                attr: 'http_cfg_prepend',
+                value: ['allow 3', 'allow 1', 'allow 2'],
+                match: %r{allow 3;.*allow 1;.*allow 2;}m
+              },
+              {
                 title: 'should contain http_raw_append directives',
                 attr: 'http_raw_append',
                 value: [
@@ -825,6 +847,12 @@ describe 'nginx' do
                 ]
               },
               {
+                title: 'should preserve order of directives from array of pairs',
+                attr: 'http_cfg_append',
+                value: [['allow', 'value 3'], ['allow', 'value 1'], ['allow', 'value 2']],
+                match: %r{allow\s+value 3;.*allow\s+value 1;.*allow\s+value 2;}m
+              },
+              {
                 title: 'should contain duplicate appended directives from array values',
                 attr: 'http_cfg_append',
                 value: { 'test1' => ['test value 1', 'test value 2', 'test value 3'] },
@@ -832,6 +860,22 @@ describe 'nginx' do
                   '  test1 test value 1;',
                   '  test1 test value 2;'
                 ]
+              },
+              {
+                title: 'should contain directives from array of strings',
+                attr: 'http_cfg_append',
+                value: ['allow 192.168.1.0/24', 'allow 10.0.0.0/8', 'deny all'],
+                match: [
+                  '  allow 192.168.1.0/24;',
+                  '  allow 10.0.0.0/8;',
+                  '  deny all;'
+                ]
+              },
+              {
+                title: 'should preserve order of directives from array of strings',
+                attr: 'http_cfg_append',
+                value: ['allow 3', 'allow 1', 'allow 2'],
+                match: %r{allow 3;.*allow 1;.*allow 2;}m
               },
               {
                 title: 'should contain ordered appended directives from hash',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -62,12 +62,23 @@ http {
 <% end -%>
 
 <% if @http_cfg_prepend -%>
+<% if @http_cfg_prepend.is_a?(Hash) -%>
   <%- field_width = @http_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
   <%- @http_cfg_prepend.sort_by{|k,v| k}.each do |key,value| -%>
   <%- Array(value).each do |asubvalue| -%>
   <%= sprintf("%-*s", field_width, key) %> <%= asubvalue %>;
   <%- end -%>
   <%- end -%>
+<% elsif @http_cfg_prepend.first.is_a?(Array) -%>
+  <%- field_width = @http_cfg_prepend.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
+  <%- @http_cfg_prepend.each do |key,value| -%>
+  <%= sprintf("%-*s", field_width, key) %> <%= value %>;
+  <%- end -%>
+<% else -%>
+  <%- @http_cfg_prepend.each do |line| -%>
+  <%= line %>;
+  <%- end -%>
+<% end -%>
 <% end -%>
 <% if @mime_types_path.is_a? String and @mime_types_path.empty? == false -%>
   include       <%= @mime_types_path %>;
@@ -332,6 +343,7 @@ http {
   ssl_password_file         <%= @ssl_password_file %>;
 <% end -%>
 <% if @http_cfg_append -%>
+<% if @http_cfg_append.is_a?(Hash) -%>
 
   <%- field_width = @http_cfg_append.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
   <%- @http_cfg_append.sort_by{|k,v| k}.each do |key,value| -%>
@@ -339,6 +351,16 @@ http {
   <%= sprintf("%-*s", field_width, key) %> <%= asubvalue %>;
   <%- end -%>
   <%- end -%>
+<% elsif @http_cfg_append.first.is_a?(Array) -%>
+  <%- field_width = @http_cfg_append.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>
+  <%- @http_cfg_append.each do |key,value| -%>
+  <%= sprintf("%-*s", field_width, key) %> <%= value %>;
+  <%- end -%>
+<% else -%>
+  <%- @http_cfg_append.each do |line| -%>
+  <%= line %>;
+  <%- end -%>
+<% end -%>
 <% end -%>
 
 <% if @http_raw_append && Array(@http_raw_append).size > 0 -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Allow arrays in `http_cfg_append` and `http_cfg_prepend`

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-nginx/issues/1173
