### PR TITLE
Remove string length requirement for `ipv6_listen_options`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2965,7 +2965,7 @@ Default value: `$listen_port`
 
 ##### <a name="-nginx--resource--mailhost--ipv6_listen_options"></a>`ipv6_listen_options`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[String]`
 
 Extra options for listen directive like 'default' to catchall. Defaults to
 'ipv6only=on'. If listen_options is set, those options are inherited with
@@ -3726,7 +3726,7 @@ Default value: `$listen_port`
 
 ##### <a name="-nginx--resource--server--ipv6_listen_options"></a>`ipv6_listen_options`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[String]`
 
 Extra options for listen directive like 'default' to catchall. Defaults to
 'ipv6only=on'. If listen_options is set, those options are inherited with
@@ -4972,7 +4972,7 @@ Default value: `$listen_port`
 
 ##### <a name="-nginx--resource--streamhost--ipv6_listen_options"></a>`ipv6_listen_options`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[String]`
 
 Extra options for listen directive like 'default' to catchall. Defaults to
 'ipv6only=on'. If listen_options is set, those options are inherited with

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -139,7 +139,7 @@ define nginx::resource::mailhost (
   Boolean $ipv6_enable = false,
   Variant[Array[String], String] $ipv6_listen_ip = '::',
   Stdlib::Port $ipv6_listen_port = $listen_port,
-  Optional[String[1]] $ipv6_listen_options = undef,
+  Optional[String] $ipv6_listen_options = undef,
   Boolean $ssl = false,
   Optional[String] $ssl_cert = undef,
   Optional[String] $ssl_ciphers = $nginx::ssl_ciphers,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -336,7 +336,7 @@ define nginx::resource::server (
   Boolean $ipv6_enable = false,
   Variant[Array, String] $ipv6_listen_ip = '::',
   Stdlib::Port $ipv6_listen_port = $listen_port,
-  Optional[String[1]] $ipv6_listen_options = undef,
+  Optional[String] $ipv6_listen_options = undef,
   Hash $add_header = {},
   Boolean $ssl = false,
   Boolean $ssl_listen_option = true,

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -57,7 +57,7 @@ define nginx::resource::streamhost (
   Boolean $ipv6_enable = false,
   Variant[Array, String] $ipv6_listen_ip = '::',
   Integer $ipv6_listen_port = $listen_port,
-  Optional[String[1]] $ipv6_listen_options = undef,
+  Optional[String] $ipv6_listen_options = undef,
   $proxy = undef,
   Optional[Nginx::Time] $proxy_read_timeout = $nginx::proxy_read_timeout,
   Optional[Nginx::Time] $proxy_connect_timeout = $nginx::proxy_connect_timeout,


### PR DESCRIPTION
#### Pull Request (PR) description
Removes the String length requirement on `ipv6_listen_options`. Which allows multiple IPv6 servers to exist without stopping nginx from starting.
This is because adding ipv6only=on can only be set once on a listen (according to the nginx docs)

#### This Pull Request (PR) fixes the following issues
Fixes #1700
