### PR TITLE
Manage `www_root` if specified for `Nginx::Resource::Server`

### DIFF
--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -635,6 +635,15 @@ define nginx::resource::server (
     $root = $www_root
   }
 
+  if $www_root {
+    ensure_resource('file', $www_root, {
+      'ensure' => 'directory',
+      'owner'  => 'root',
+      'group'  => 'root',
+      'mode'   => '0755',
+    })
+  }
+
   # Only try to manage these files if they're the default one (as you presumably
   # usually don't want the default template if you're using a custom file.
 

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -9,6 +9,7 @@ describe 'nginx class' do
       pp = "
       include nginx
 
+      file { ['/var/www']: ensure => directory }
       nginx::resource::server { 'example.com':
         ensure   => present,
         www_root => '/var/www/html',
@@ -49,6 +50,7 @@ describe 'nginx class' do
         service_config_check => true,
       }
 
+      file { ['/var/www']: ensure => directory }
       nginx::resource::server { 'example.com':
         ensure   => present,
         www_root => '/var/www/html',

--- a/spec/acceptance/nginx_location_spec.rb
+++ b/spec/acceptance/nginx_location_spec.rb
@@ -6,6 +6,7 @@ describe 'nginx::resource::location define:' do
   it 'runs successfully' do
     pp = "
     class { 'nginx': }
+    file { ['/var/www']: ensure => directory }
     nginx::resource::server { 'www.puppetlabs.com':
       ensure   => present,
       www_root => '/var/www/www.puppetlabs.com',

--- a/spec/acceptance/nginx_server_spec.rb
+++ b/spec/acceptance/nginx_server_spec.rb
@@ -15,7 +15,7 @@ describe 'nginx::resource::server define:' do
         path => '/etc/hosts',
         line => '127.0.0.1 www.puppetlabs.com'
       }
-      file { ['/var/www','/var/www/www.puppetlabs.com']: ensure => directory }
+      file { ['/var/www']: ensure => directory }
       file { '/var/www/www.puppetlabs.com/index.html': ensure  => file, content => 'Hello from www\n', }
       "
 
@@ -72,7 +72,7 @@ describe 'nginx::resource::server define:' do
         path => '/etc/hosts',
         line => '127.0.0.1 www.puppetlabs.com'
       }
-      file { ['/var/www','/var/www/www.puppetlabs.com']: ensure => directory }
+      file { ['/var/www']: ensure => directory }
       file { '/var/www/www.puppetlabs.com/index.html': ensure  => file, content => 'Hello from www\n', }
       "
 
@@ -141,7 +141,7 @@ describe 'nginx::resource::server define:' do
         path => '/etc/hosts',
         line => '127.0.0.1 www.puppetlabs.com'
       }
-      file { ['/var/www','/var/www/www.puppetlabs.com']: ensure => directory }
+      file { ['/var/www']: ensure => directory }
       file { '/var/www/www.puppetlabs.com/index.html': ensure  => file, content => 'Hello from www\n', }
       "
 
@@ -200,7 +200,7 @@ describe 'nginx::resource::server define:' do
         path => '/etc/hosts',
         line => '127.0.0.1 www.puppetlabs.com'
       }
-      file { ['/var/www','/var/www/www.puppetlabs.com','/var/www/letsencrypt','/var/www/letsencrypt/.well-known','/var/www/letsencrypt/.well-known/acme-challenge']: ensure => directory }
+      file { ['/var/www','/var/www/letsencrypt','/var/www/letsencrypt/.well-known','/var/www/letsencrypt/.well-known/acme-challenge']: ensure => directory }
       file { '/var/www/www.puppetlabs.com/index.html': ensure  => file, content => 'Hello from www\n', }
       file { '/var/www/letsencrypt/.well-known/acme-challenge/fb9bd98604be3d0c7d589fcc7561cb41': ensure  => file, content => 'LetsEncrypt\n', }
       "

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -52,6 +52,48 @@ describe 'nginx::resource::server' do
           end
         end
 
+        describe 'www_root directory management' do
+          context 'when www_root is set' do
+            let(:params) { default_params.merge(www_root: '/var/www/example') }
+
+            it 'ensures the www_root directory exists' do
+              is_expected.to contain_file('/var/www/example').with(
+                'ensure' => 'directory',
+                'owner'  => 'root',
+                'group'  => 'root',
+                'mode'   => '0755',
+              )
+            end
+          end
+
+          context 'when www_root is undef (proxy server)' do
+            let(:params) do
+              {
+                proxy: 'http://backend',
+              }
+            end
+
+            it 'does not declare a File resource for any www_root' do
+              is_expected.not_to contain_file('/var/www/example')
+            end
+          end
+
+          context 'when multiple servers share the same www_root' do
+            let(:params) { default_params.merge(www_root: '/var/www/shared') }
+            let(:pre_condition) do
+              [
+                'include nginx',
+                "nginx::resource::server { 'other.example.com': www_root => '/var/www/shared' }",
+              ]
+            end
+
+            it 'compiles without duplicate resource errors' do
+              is_expected.to compile
+              is_expected.to contain_file('/var/www/shared').with_ensure('directory')
+            end
+          end
+        end
+
         describe 'with $confd_only enabled' do
           let(:pre_condition) { 'class { "nginx": confd_only => true }' }
           let(:params) { default_params }


### PR DESCRIPTION
#### Pull Request (PR) description

Manage `www_root` if specified for `Nginx::Resource::Server`

#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-nginx/issues/1060