### PR TITLE
Fix default IPv6 listen_options clash

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2965,13 +2965,11 @@ Default value: `$listen_port`
 
 ##### <a name="-nginx--resource--mailhost--ipv6_listen_options"></a>`ipv6_listen_options`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[String[0]]`
 
-Extra options for listen directive like 'default' to catchall. Defaults to
-'ipv6only=on'. If listen_options is set, those options are inherited with
-'ipv6only=on' appended.
+Extra options for listen directive like 'default' to catchall.
 
-Default value: `undef`
+Default value: `$listen_options`
 
 ##### <a name="-nginx--resource--mailhost--ssl"></a>`ssl`
 
@@ -3726,13 +3724,11 @@ Default value: `$listen_port`
 
 ##### <a name="-nginx--resource--server--ipv6_listen_options"></a>`ipv6_listen_options`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[String[0]]`
 
-Extra options for listen directive like 'default' to catchall. Defaults to
-'ipv6only=on'. If listen_options is set, those options are inherited with
-'ipv6only=on' appended.
+Extra options for listen directive like 'default' to catchall.
 
-Default value: `undef`
+Default value: `$listen_options`
 
 ##### <a name="-nginx--resource--server--add_header"></a>`add_header`
 
@@ -4972,13 +4968,11 @@ Default value: `$listen_port`
 
 ##### <a name="-nginx--resource--streamhost--ipv6_listen_options"></a>`ipv6_listen_options`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[String[0]]`
 
-Extra options for listen directive like 'default' to catchall. Defaults to
-'ipv6only=on'. If listen_options is set, those options are inherited with
-'ipv6only=on' appended.
+Extra options for listen directive like 'default' to catchall.
 
-Default value: `undef`
+Default value: `$listen_options`
 
 ##### <a name="-nginx--resource--streamhost--proxy"></a>`proxy`
 

--- a/manifests/resource/mailhost.pp
+++ b/manifests/resource/mailhost.pp
@@ -17,9 +17,7 @@
 # @param ipv6_listen_port
 #   Default IPv6 Port for NGINX to listen with this server on.
 # @param ipv6_listen_options
-#   Extra options for listen directive like 'default' to catchall. Defaults to
-#   'ipv6only=on'. If listen_options is set, those options are inherited with
-#   'ipv6only=on' appended.
+#   Extra options for listen directive like 'default' to catchall.
 # @param ssl
 #   Indicates whether to setup SSL bindings for this mailhost.
 # @param ssl_cert
@@ -139,7 +137,7 @@ define nginx::resource::mailhost (
   Boolean $ipv6_enable = false,
   Variant[Array[String], String] $ipv6_listen_ip = '::',
   Stdlib::Port $ipv6_listen_port = $listen_port,
-  Optional[String[1]] $ipv6_listen_options = undef,
+  Optional[String[0]] $ipv6_listen_options = $listen_options,
   Boolean $ssl = false,
   Optional[String] $ssl_cert = undef,
   Optional[String] $ssl_ciphers = $nginx::ssl_ciphers,
@@ -221,18 +219,6 @@ define nginx::resource::mailhost (
   $has_ipaddress6 = ($facts.get('networking.ip6') =~ Stdlib::IP::Address::V6)
   if ($ipv6_enable and !$has_ipaddress6) {
     warning('nginx: IPv6 support is not enabled or configured properly')
-  }
-
-  # Compute effective ipv6_listen_options:
-  # - Use ipv6_listen_options if set
-  # - Otherwise use listen_options with ipv6only=on appended
-  # - Otherwise use 'ipv6only=on'
-  $_ipv6_listen_options = $ipv6_listen_options ? {
-    undef   => $listen_options ? {
-      undef   => 'ipv6only=on',
-      default => "${listen_options} ipv6only=on",
-    },
-    default => $ipv6_listen_options,
   }
 
   if $ipv6_enable and $has_ipaddress6 {
@@ -324,7 +310,7 @@ define nginx::resource::mailhost (
       content => epp('nginx/mailhost/mailhost.epp',
         {
           ipv6_listen_ip        => $_ipv6_listen_ip,
-          ipv6_listen_options   => $_ipv6_listen_options,
+          ipv6_listen_options   => $ipv6_listen_options,
           ipv6_listen_port      => $ipv6_listen_port,
           listen_ip             => Array($listen_ip, true),
           listen_options        => $listen_options,
@@ -348,7 +334,7 @@ define nginx::resource::mailhost (
       content => epp('nginx/mailhost/mailhost_ssl.epp',
         {
           ipv6_listen_ip        => $_ipv6_listen_ip,
-          ipv6_listen_options   => $_ipv6_listen_options,
+          ipv6_listen_options   => $ipv6_listen_options,
           ipv6_listen_port      => $ipv6_listen_port,
           listen_ip             => Array($listen_ip, true),
           listen_options        => $listen_options,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -30,9 +30,7 @@
 # @param ipv6_listen_port
 #   Default IPv6 Port for NGINX to listen with this server on. Defaults to TCP 80
 # @param ipv6_listen_options
-#   Extra options for listen directive like 'default' to catchall. Defaults to
-#   'ipv6only=on'. If listen_options is set, those options are inherited with
-#   'ipv6only=on' appended.
+#   Extra options for listen directive like 'default' to catchall.
 # @param add_header
 #   Adds headers to the HTTP response when response code is equal to 200, 204,
 #   301, 302 or 304.
@@ -93,7 +91,7 @@
 # @param proxy_busy_buffers_size
 #   Sets the total size of buffers that can be busy sending a response to the
 #   client while the response is not yet fully read.
-# @param proxy_next_upstream 
+# @param proxy_next_upstream
 #   Specify cases a request should be passed to the next server in the upstream.
 # @param grpc
 #   Sets the gRPC server address (`grpc_pass`)
@@ -336,7 +334,7 @@ define nginx::resource::server (
   Boolean $ipv6_enable = false,
   Variant[Array, String] $ipv6_listen_ip = '::',
   Stdlib::Port $ipv6_listen_port = $listen_port,
-  Optional[String[1]] $ipv6_listen_options = undef,
+  Optional[String[0]] $ipv6_listen_options = $listen_options,
   Hash $add_header = {},
   Boolean $ssl = false,
   Boolean $ssl_listen_option = true,
@@ -476,18 +474,6 @@ define nginx::resource::server (
 
   if $rewrite_www_to_non_www == true and $rewrite_non_www_to_www == true {
     fail('You must not set both $rewrite_www_to_non_www and $rewrite_non_www_to_www to true')
-  }
-
-  # Compute effective ipv6_listen_options:
-  # - Use ipv6_listen_options if set
-  # - Otherwise use listen_options with ipv6only=on appended
-  # - Otherwise use 'ipv6only=on'
-  $_ipv6_listen_options = $ipv6_listen_options ? {
-    undef   => $listen_options ? {
-      undef   => 'ipv6only=on',
-      default => "${listen_options} ipv6only=on",
-    },
-    default => $ipv6_listen_options,
   }
 
   # Variables

--- a/manifests/resource/streamhost.pp
+++ b/manifests/resource/streamhost.pp
@@ -18,9 +18,7 @@
 # @param ipv6_listen_port
 #   Default IPv6 Port for NGINX to listen with this streamhost on.
 # @param ipv6_listen_options
-#   Extra options for listen directive like 'default' to catchall. Defaults to
-#   'ipv6only=on'. If listen_options is set, those options are inherited with
-#   'ipv6only=on' appended.
+#   Extra options for listen directive like 'default' to catchall.
 # @param proxy
 #   Proxy server(s) for the root location to connect to. Accepts a single
 #   value, can be used in conjunction with nginx::resource::upstream
@@ -57,7 +55,7 @@ define nginx::resource::streamhost (
   Boolean $ipv6_enable = false,
   Variant[Array, String] $ipv6_listen_ip = '::',
   Integer $ipv6_listen_port = $listen_port,
-  Optional[String[1]] $ipv6_listen_options = undef,
+  Optional[String[0]] $ipv6_listen_options = $listen_options,
   $proxy = undef,
   Optional[Nginx::Time] $proxy_read_timeout = $nginx::proxy_read_timeout,
   Optional[Nginx::Time] $proxy_connect_timeout = $nginx::proxy_connect_timeout,
@@ -70,18 +68,6 @@ define nginx::resource::streamhost (
 ) {
   if !defined(Class['nginx']) {
     fail('You must include the nginx base class before using any defined resources')
-  }
-
-  # Compute effective ipv6_listen_options:
-  # - Use ipv6_listen_options if set
-  # - Otherwise use listen_options with ipv6only=on appended
-  # - Otherwise use 'ipv6only=on'
-  $_ipv6_listen_options = $ipv6_listen_options ? {
-    undef   => $listen_options ? {
-      undef   => 'ipv6only=on',
-      default => "${listen_options} ipv6only=on",
-    },
-    default => $ipv6_listen_options,
   }
 
   # Variables

--- a/spec/defines/resource_mailhost_spec.rb
+++ b/spec/defines/resource_mailhost_spec.rb
@@ -66,25 +66,25 @@ describe 'nginx::resource::mailhost' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: '  listen                [::]:25 ipv6only=on;',
+              match: '  listen                [::]:25;',
             },
             {
               title: 'should not enable IPv6',
               attr: 'ipv6_enable',
               value: false,
-              notmatch: %r{  listen                \[::\]:25 ipv6only=on;},
+              notmatch: %r{  listen                \[::\]:25;},
             },
             {
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: '  listen                [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:25 ipv6only=on;',
+              match: '  listen                [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:25;',
             },
             {
               title: 'should set the IPv6 listen port',
               attr: 'ipv6_listen_port',
               value: 45,
-              match: '  listen                [::]:45 ipv6only=on;',
+              match: '  listen                [::]:45;',
             },
             {
               title: 'should set the IPv6 listen options',
@@ -254,8 +254,8 @@ describe 'nginx::resource::mailhost' do
             context 'when listen_options is set but ipv6_listen_options is not' do
               let(:params) { default_params.merge(listen_options: 'reuseport') }
 
-              it 'inherits listen_options with ipv6only=on appended' do
-                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:25 reuseport ipv6only=on;})
+              it 'inherits listen_options' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:25 reuseport;})
               end
             end
 
@@ -270,8 +270,8 @@ describe 'nginx::resource::mailhost' do
             context 'when neither listen_options nor ipv6_listen_options is set' do
               let(:params) { default_params }
 
-              it 'uses ipv6only=on' do
-                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:25 ipv6only=on;})
+              it 'adds nothing' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:25;})
               end
             end
           end
@@ -593,25 +593,25 @@ describe 'nginx::resource::mailhost' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: '  listen                [::]:587 ssl ipv6only=on;',
+              match: '  listen                [::]:587 ssl;',
             },
             {
               title: 'should not enable IPv6',
               attr: 'ipv6_enable',
               value: false,
-              notmatch: %r{  listen\s+\[::\]:587 ;},
+              notmatch: %r{  listen\s+\[::\]:587;},
             },
             {
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: '  listen                [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:587 ssl ipv6only=on;',
+              match: '  listen                [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:587 ssl;',
             },
             {
               title: 'should set the IPv6 ssl port',
               attr: 'ssl_port',
               value: 45,
-              match: '  listen                [::]:45 ssl ipv6only=on;',
+              match: '  listen                [::]:45 ssl;',
             },
             {
               title: 'should set the IPv6 listen options',
@@ -732,7 +732,7 @@ describe 'nginx::resource::mailhost' do
 
               it 'contains `ssl` in the listen directive for ipv6' do
                 content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
-                expect(content).to include('listen                [::]:587 ssl ipv6only=on;')
+                expect(content).to include('listen                [::]:587 ssl;')
               end
             end
 
@@ -746,7 +746,7 @@ describe 'nginx::resource::mailhost' do
 
               it 'contains `ssl` in the listen directive for ipv6' do
                 content = catalogue.resource('concat::fragment', "#{title}-ssl").send(:parameters)[:content]
-                expect(content).to include('listen                [::]:587 ssl ipv6only=on;')
+                expect(content).to include('listen                [::]:587 ssl;')
               end
             end
 
@@ -879,12 +879,12 @@ describe 'nginx::resource::mailhost' do
 
           it do
             is_expected.to contain_concat__fragment("#{title}-header")
-              .without_content(%r{^  listen                \[::\]:25 ipv6only=on;})
+              .without_content(%r{^  listen                \[::\]:25;})
           end
 
           it do
             is_expected.to contain_concat__fragment("#{title}-ssl")
-              .without_content(%r{^  listen                \[::\]:587 ipv6only=on;})
+              .without_content(%r{^  listen                \[::\]:587;})
           end
         end
       end

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -131,25 +131,25 @@ describe 'nginx::resource::server' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: %r{\s+listen\s+\[::\]:80 ipv6only=on;},
+              match: %r{\s+listen\s+\[::\]:80;},
             },
             {
               title: 'should not enable IPv6',
               attr: 'ipv6_enable',
               value: false,
-              notmatch: %r{\slisten \[::\]:80 ipv6only=on;},
+              notmatch: %r{\slisten \[::\]:80;},
             },
             {
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:80 ipv6only=on;},
+              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:80;},
             },
             {
               title: 'should set the IPv6 listen port',
               attr: 'ipv6_listen_port',
               value: 45,
-              match: %r{\s+listen\s+\[::\]:45 ipv6only=on;},
+              match: %r{\s+listen\s+\[::\]:45;},
             },
             {
               title: 'should set the IPv6 listen options',
@@ -601,8 +601,8 @@ describe 'nginx::resource::server' do
             context 'when listen_options is set but ipv6_listen_options is not' do
               let(:params) { default_params.merge(listen_options: 'reuseport') }
 
-              it 'inherits listen_options with ipv6only=on appended' do
-                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 reuseport ipv6only=on;})
+              it 'inherits listen_options' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 reuseport;})
               end
             end
 
@@ -617,8 +617,8 @@ describe 'nginx::resource::server' do
             context 'when neither listen_options nor ipv6_listen_options is set' do
               let(:params) { default_params }
 
-              it 'uses ipv6only=on' do
-                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 ipv6only=on;})
+              it 'adds nothing' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80;})
               end
             end
           end
@@ -921,25 +921,25 @@ describe 'nginx::resource::server' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: %r{\s+listen\s+\[::\]:443 ssl ipv6only=on;},
+              match: %r{\s+listen\s+\[::\]:443 ssl;},
             },
             {
               title: 'should disable IPv6',
               attr: 'ipv6_enable',
               value: false,
-              notmatch: %r{  listen \[::\]:443 ssl ipv6only=on;},
+              notmatch: %r{  listen \[::\]:443 ssl;},
             },
             {
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:443 ssl ipv6only=on;},
+              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:443 ssl;},
             },
             {
               title: 'should set the IPv6 listen port',
               attr: 'ssl_port',
               value: 45,
-              match: %r{\s+listen\s+\[::\]:45 ssl ipv6only=on;},
+              match: %r{\s+listen\s+\[::\]:45 ssl;},
             },
             {
               title: 'should set the IPv6 listen options',

--- a/spec/defines/resource_stream_spec.rb
+++ b/spec/defines/resource_stream_spec.rb
@@ -80,25 +80,25 @@ describe 'nginx::resource::streamhost' do
               title: 'should enable IPv6',
               attr: 'ipv6_enable',
               value: true,
-              match: %r{\s+listen\s+\[::\]:80 ipv6only=on;},
+              match: %r{\s+listen\s+\[::\]:80;},
             },
             {
               title: 'should not enable IPv6',
               attr: 'ipv6_enable',
               value: false,
-              notmatch: %r{\slisten \[::\]:80 ipv6only=on;},
+              notmatch: %r{\slisten \[::\]:80;},
             },
             {
               title: 'should set the IPv6 listen IP',
               attr: 'ipv6_listen_ip',
               value: '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
-              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:80 ipv6only=on;},
+              match: %r{\s+listen\s+\[2001:0db8:85a3:0000:0000:8a2e:0370:7334\]:80;},
             },
             {
               title: 'should set the IPv6 listen port',
               attr: 'ipv6_listen_port',
               value: 45,
-              match: %r{\s+listen\s+\[::\]:45 ipv6only=on;},
+              match: %r{\s+listen\s+\[::\]:45;},
             },
             {
               title: 'should set the IPv6 listen options',
@@ -158,8 +158,8 @@ describe 'nginx::resource::streamhost' do
             context 'when listen_options is set but ipv6_listen_options is not' do
               let(:params) { default_params.merge(listen_options: 'reuseport') }
 
-              it 'inherits listen_options with ipv6only=on appended' do
-                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 reuseport ipv6only=on;})
+              it 'inherits listen_options' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 reuseport;})
               end
             end
 
@@ -174,8 +174,8 @@ describe 'nginx::resource::streamhost' do
             context 'when neither listen_options nor ipv6_listen_options is set' do
               let(:params) { default_params }
 
-              it 'uses ipv6only=on' do
-                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80 ipv6only=on;})
+              it 'adds nothing' do
+                is_expected.to contain_concat__fragment("#{title}-header").with_content(%r{\s+listen\s+\[::\]:80;})
               end
             end
           end

--- a/templates/mailhost/mailhost.epp
+++ b/templates/mailhost/mailhost.epp
@@ -19,7 +19,7 @@ server {
   listen                <%= $ip %>:<%= $listen_port %><% if $listen_options { %> <%= $listen_options %><% } %>;
 <%- } -%>
 <%- $ipv6_listen_ip.each |$ipv6| { -%>
-  listen                [<%= $ipv6 %>]:<%= $ipv6_listen_port %> <% if $ipv6_listen_options { %><%= $ipv6_listen_options %><% } %>;
+  listen                [<%= $ipv6 %>]:<%= $ipv6_listen_port %><% if $ipv6_listen_options { %> <%= $ipv6_listen_options %><% } %>;
 <%- } -%>
 <%= $mailhost_common -%>
 

--- a/templates/mailhost/mailhost_ssl.epp
+++ b/templates/mailhost/mailhost_ssl.epp
@@ -17,7 +17,7 @@ server {
   listen                <%= $ip %>:<%= $ssl_port %> ssl;
 <%- } -%>
 <%- $ipv6_listen_ip.each |$ipv6| { -%>
-  listen                [<%= $ipv6 %>]:<%= $ssl_port %><% if versioncmp($nginx_version, '1.15.0') >= 0 { %> ssl<% } %> <% if $ipv6_listen_options { %><%= $ipv6_listen_options %><% } %>;
+  listen                [<%= $ipv6 %>]:<%= $ssl_port %><% if versioncmp($nginx_version, '1.15.0') >= 0 { %> ssl<% } %><% if $ipv6_listen_options { %> <%= $ipv6_listen_options %><% } %>;
 <%- } -%>
 <%= $mailhost_common -%>
 

--- a/templates/server/server_ipv6_listen.erb
+++ b/templates/server/server_ipv6_listen.erb
@@ -2,9 +2,9 @@
   <%- if @ipv6_enable -%>
     <%- if @ipv6_listen_ip.is_a?(Array) then -%>
       <%- @ipv6_listen_ip.each do |ipv6| -%>
-  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @_ipv6_listen_options %><%= @_ipv6_listen_options %><% end %>;
+  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
       <%- end -%>
     <%- else -%>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @_ipv6_listen_options %><%= @_ipv6_listen_options %><% end %>;
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- end -%>

--- a/templates/server/server_ssl_ipv6_listen.erb
+++ b/templates/server/server_ssl_ipv6_listen.erb
@@ -2,9 +2,9 @@
   <%- if @ipv6_enable -%>
     <%- if @ipv6_listen_ip.is_a?(Array) then -%>
       <%- @ipv6_listen_ip.each do |ipv6| -%>
-  listen [<%= ipv6 %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @_ipv6_listen_options %> <%= @_ipv6_listen_options %><% end %>;
+  listen [<%= ipv6 %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
       <%- end -%>
     <%- else -%>
-  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @_ipv6_listen_options %> <%= @_ipv6_listen_options %><% end %>;
+  listen       [<%= @ipv6_listen_ip %>]:<%= @ssl_port %> ssl<% if scope.call_function('versioncmp', [scope['nginx::nginx_version'], '1.25.1']) < 0 && @http2 == 'on' %> http2<% end %><% if @spdy == 'on' %> spdy<% end %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- end -%>

--- a/templates/streamhost/streamhost.erb
+++ b/templates/streamhost/streamhost.erb
@@ -12,10 +12,10 @@ server {
 <%- if @ipv6_enable && (defined? @facts.fetch('networking', {})['ip6']) -%>
   <%- if @ipv6_listen_ip.is_a?(Array) then -%>
     <%- @ipv6_listen_ip.each do |ipv6| -%>
-  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %> <% if @_ipv6_listen_options %><%= @_ipv6_listen_options %><% end %>;
+  listen [<%= ipv6 %>]:<%= @ipv6_listen_port %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
     <%- end -%>
   <%- else -%>
-  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %> <% if @_ipv6_listen_options %><%= @_ipv6_listen_options %><% end %>;
+  listen [<%= @ipv6_listen_ip %>]:<%= @ipv6_listen_port %><% if @ipv6_listen_options %> <%= @ipv6_listen_options %><% end %>;
   <%- end -%>
 <%- end -%>
 <%- unless @resolver.empty? -%>


### PR DESCRIPTION
When not explicicly set, `$ipv6_listen_options` defaults to `$listen_options` with `"ipv6only=on"` appended to it.

The nginx documentation gives two important pieces of information regarding the `ipv6only` parameter:

1. "This parameter is turned on by default";
2. "It can only be set once on start".

Source: https://nginx.org/en/docs/http/ngx_http_core_module.html#listen

Because we explicitly set this parameter on each Virtual Host, this leads to broken configuration if multiple virtual hosts are configured.

While one could previously explicitly set `ipv6_listen_options => ''` to avoid this, the data type was changed in 4ad7bc0e4508368f667460be3220d558bec850c7 an empty String is not allowed anymore, making the module unusable in such a situation.

This commit adjust the module to not add `ipv6only=on` by default anymore, relying on the default behavior of nginx to achieve the same result.

It also allows to pass an explicit empty String as `$ipv6_listen_options` to avoid the default value which match `$listen_options`.

Last, it adjust the templates to avoid unexpeted spaces in the generated config.

Fixes: #1293
Fixes: #1700
Overcomes: #1701
