### PR TITLE
Add missing params `ssl_early_data`, `ssl_reject_handshake`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -226,6 +226,8 @@ The following parameters are available in the `nginx` class:
 * [`ssl_trusted_certificate`](#-nginx--ssl_trusted_certificate)
 * [`ssl_verify_depth`](#-nginx--ssl_verify_depth)
 * [`ssl_password_file`](#-nginx--ssl_password_file)
+* [`ssl_reject_handshake`](#-nginx--ssl_reject_handshake)
+* [`ssl_early_data`](#-nginx--ssl_early_data)
 * [`package_ensure`](#-nginx--package_ensure)
 * [`package_name`](#-nginx--package_name)
 * [`package_source`](#-nginx--package_source)
@@ -1491,6 +1493,22 @@ Default value: `undef`
 ##### <a name="-nginx--ssl_password_file"></a>`ssl_password_file`
 
 Data type: `Optional[Stdlib::Absolutepath]`
+
+
+
+Default value: `undef`
+
+##### <a name="-nginx--ssl_reject_handshake"></a>`ssl_reject_handshake`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+
+
+Default value: `undef`
+
+##### <a name="-nginx--ssl_early_data"></a>`ssl_early_data`
+
+Data type: `Optional[Enum['on', 'off']]`
 
 
 
@@ -3563,6 +3581,8 @@ The following parameters are available in the `nginx::resource::server` defined 
 * [`ssl_trusted_cert`](#-nginx--resource--server--ssl_trusted_cert)
 * [`ssl_verify_depth`](#-nginx--resource--server--ssl_verify_depth)
 * [`ssl_password_file`](#-nginx--resource--server--ssl_password_file)
+* [`ssl_reject_handshake`](#-nginx--resource--server--ssl_reject_handshake)
+* [`ssl_early_data`](#-nginx--resource--server--ssl_early_data)
 * [`spdy`](#-nginx--resource--server--spdy)
 * [`http2`](#-nginx--resource--server--http2)
 * [`server_name`](#-nginx--resource--server--server_name)
@@ -4258,6 +4278,22 @@ Default value: `undef`
 Data type: `Optional[Stdlib::Absolutepath]`
 
 File containing the password for the SSL Key file.
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--server--ssl_reject_handshake"></a>`ssl_reject_handshake`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+If enabled, SSL handshakes in the server block will be rejected.
+
+Default value: `undef`
+
+##### <a name="-nginx--resource--server--ssl_early_data"></a>`ssl_early_data`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+Enables or disables TLS 1.3 early data.
 
 Default value: `undef`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -136,6 +136,8 @@ class nginx::config {
   $ssl_prefer_server_ciphers = $nginx::ssl_prefer_server_ciphers
   $ssl_protocols = $nginx::ssl_protocols
   $ssl_verify_depth = $nginx::ssl_verify_depth
+  $ssl_reject_handshake = $nginx::ssl_reject_handshake
+  $ssl_early_data = $nginx::ssl_early_data
   $types_hash_bucket_size = $nginx::types_hash_bucket_size
   $types_hash_max_size = $nginx::types_hash_max_size
   $worker_connections = $nginx::worker_connections

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,6 +200,8 @@
 # @param ssl_trusted_certificate
 # @param ssl_verify_depth
 # @param ssl_password_file
+# @param ssl_reject_handshake
+# @param ssl_early_data
 # @param package_ensure
 # @param package_name
 # @param package_source
@@ -389,6 +391,8 @@ class nginx (
   Optional[Stdlib::Absolutepath] $ssl_trusted_certificate = undef,
   Optional[Integer] $ssl_verify_depth = undef,
   Optional[Stdlib::Absolutepath] $ssl_password_file = undef,
+  Optional[Enum['on', 'off']] $ssl_reject_handshake = undef,
+  Optional[Enum['on', 'off']] $ssl_early_data = undef,
   Optional[Enum['on', 'off']] $reset_timedout_connection = undef,
   Optional[Integer] $variables_hash_bucket_size = undef,
   Optional[Integer] $variables_hash_max_size = undef,

--- a/manifests/resource/server.pp
+++ b/manifests/resource/server.pp
@@ -180,6 +180,10 @@
 #   Sets the verification depth in the client certificates chain.
 # @param ssl_password_file
 #   File containing the password for the SSL Key file.
+# @param ssl_reject_handshake
+#   If enabled, SSL handshakes in the server block will be rejected.
+# @param ssl_early_data
+#   Enables or disables TLS 1.3 early data.
 # @param spdy
 #   Toggles SPDY protocol.
 # @param http2
@@ -367,6 +371,8 @@ define nginx::resource::server (
   Optional[String] $ssl_trusted_cert = undef,
   Optional[Integer] $ssl_verify_depth = undef,
   Optional[Stdlib::Absolutepath] $ssl_password_file = undef,
+  Optional[Enum['on', 'off']] $ssl_reject_handshake = undef,
+  Optional[Enum['on', 'off']] $ssl_early_data = undef,
   Enum['on', 'off'] $spdy = $nginx::spdy,
   Enum['on', 'off'] $http2 = $nginx::http2,
   Optional[String] $proxy = undef,

--- a/spec/classes/nginx_spec.rb
+++ b/spec/classes/nginx_spec.rb
@@ -1161,6 +1161,30 @@ describe 'nginx' do
                 notmatch: 'ssl_verify_depth',
               },
               {
+                title: 'should set ssl_reject_handshake on',
+                attr: 'ssl_reject_handshake',
+                value: 'on',
+                match: %r{\s+ssl_reject_handshake\s+on;},
+              },
+              {
+                title: 'should set ssl_reject_handshake off',
+                attr: 'ssl_reject_handshake',
+                value: 'off',
+                match: %r{\s+ssl_reject_handshake\s+off;},
+              },
+              {
+                title: 'should set ssl_early_data on',
+                attr: 'ssl_early_data',
+                value: 'on',
+                match: %r{\s+ssl_early_data\s+on;},
+              },
+              {
+                title: 'should set ssl_early_data off',
+                attr: 'ssl_early_data',
+                value: 'off',
+                match: %r{\s+ssl_early_data\s+off;},
+              },
+              {
                 title: 'should set ssl_verify_depth',
                 attr: 'ssl_verify_depth',
                 value: 5,

--- a/spec/defines/resource_server_spec.rb
+++ b/spec/defines/resource_server_spec.rb
@@ -1014,6 +1014,30 @@ describe 'nginx::resource::server' do
               match: %r{^\s+ssl_verify_depth\s+2;},
             },
             {
+              title: 'should set ssl_reject_handshake on',
+              attr: 'ssl_reject_handshake',
+              value: 'on',
+              match: %r{\s+ssl_reject_handshake\s+on;},
+            },
+            {
+              title: 'should set ssl_reject_handshake off',
+              attr: 'ssl_reject_handshake',
+              value: 'off',
+              match: %r{\s+ssl_reject_handshake\s+off;},
+            },
+            {
+              title: 'should set ssl_early_data on',
+              attr: 'ssl_early_data',
+              value: 'on',
+              match: %r{\s+ssl_early_data\s+on;},
+            },
+            {
+              title: 'should set ssl_early_data off',
+              attr: 'ssl_early_data',
+              value: 'off',
+              match: %r{\s+ssl_early_data\s+off;},
+            },
+            {
               title: 'should set the SSL cache',
               attr: 'ssl_cache',
               value: 'shared:SSL:1m',

--- a/templates/conf.d/nginx.conf.erb
+++ b/templates/conf.d/nginx.conf.erb
@@ -367,6 +367,12 @@ http {
 <% if @ssl_password_file -%>
   ssl_password_file         <%= @ssl_password_file %>;
 <% end -%>
+<% if @ssl_reject_handshake -%>
+  ssl_reject_handshake      <%= @ssl_reject_handshake %>;
+<% end -%>
+<% if @ssl_early_data -%>
+  ssl_early_data            <%= @ssl_early_data %>;
+<% end -%>
 <% if @http_cfg_append -%>
 
   <%- field_width = @http_cfg_append.inject(0) { |l,(k,v)| k.size > l ? k.size : l } -%>

--- a/templates/server/server_ssl_settings.erb
+++ b/templates/server/server_ssl_settings.erb
@@ -84,4 +84,10 @@
   <%- if @ssl_password_file -%>
   ssl_password_file         <%= @ssl_password_file %>;
   <%- end -%>
+  <%- if @ssl_reject_handshake -%>
+  ssl_reject_handshake      <%= @ssl_reject_handshake %>;
+  <%- end -%>
+  <%- if @ssl_early_data -%>
+  ssl_early_data            <%= @ssl_early_data %>;
+  <%- end -%>
 <% end -%>


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds following missing ssl parameters (see issue https://github.com/voxpupuli/puppet-nginx/issues/1583):
- `ssl_reject_handshake`
- `ssl_early_data`

Corresponding tests have been added to verify the new functionality.

#### This Pull Request (PR) fixes the following issues
Fixes https://github.com/voxpupuli/puppet-nginx/issues/1583
